### PR TITLE
Avoid using invalid SDK instance for the SmartWalletsDemo app.

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/SplashScreen.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/SplashScreen.swift
@@ -34,15 +34,13 @@ struct SplashScreen: View {
         }
     }
 
-    private let sdk: CrossmintSDK = .shared
-
     @State private var isLoading: Bool = false
     @State private var authenticationStatus: AuthenticationStatus?
     @State private var transitionOpacity: Double = 0
     @State private var error: Error?
 
     private var authManager: AuthManager {
-        sdk.authManager
+        CrossmintSDK.shared.authManager
     }
 
     @ViewBuilder


### PR DESCRIPTION
The SmartWalletsDemo was using an invalid SDK instance, which caused an infinite loop.