### PR TITLE
Add Explicit Remote Logging Permission to SDK

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/SmartWalletsDemoApp.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/SmartWalletsDemoApp.swift
@@ -7,7 +7,11 @@ struct SmartWalletsDemoApp: App {
         WindowGroup {
             SplashScreen()
                 .crossmintNonCustodialSigner(
-                    CrossmintSDK.shared(apiKey: crossmintApiKey, authManager: crossmintAuthManager)
+                    CrossmintSDK.shared(
+                        apiKey: crossmintApiKey,
+                        authManager: crossmintAuthManager,
+                        trackingConsent: .granted
+                    )
                 )
         }
     }

--- a/Examples/SolanaDemo/SolanaDemo/SolanaDemoApp.swift
+++ b/Examples/SolanaDemo/SolanaDemo/SolanaDemoApp.swift
@@ -7,7 +7,12 @@ struct SolanaDemoApp: App {
         WindowGroup {
             SplashScreen()
                 .crossmintNonCustodialSigner(
-                    CrossmintSDK.shared(apiKey: crossmintApiKey, authManager: crossmintAuthManager, logLevel: .debug)
+                    CrossmintSDK.shared(
+                        apiKey: crossmintApiKey,
+                        authManager: crossmintAuthManager,
+                        logLevel: .debug,
+                        trackingConsent: .granted
+                    )
                 )
         }
     }

--- a/Sources/Logger/DataDogConfig.swift
+++ b/Sources/Logger/DataDogConfig.swift
@@ -6,13 +6,45 @@
 //
 
 import Foundation
+import DatadogCore
 
 public enum DataDogConfig {
     static let clientToken = "pub946d87ea0c2cc02431c15e9446f776fc"
 
     private(set) nonisolated(unsafe) static var environment: String = "production"
+    private(set) nonisolated(unsafe) static var trackingConsent: TrackingConsent = .notGranted
+    private(set) nonisolated(unsafe) static var isDataDogInitialized: Bool = false
 
     public static func configure(environment: String) {
         self.environment = environment
+    }
+
+    /// Sets or updates the tracking consent for remote logging
+    /// - Parameter consent: The new tracking consent state
+    /// - Note: When changing from pending to granted, all batched data will be sent.
+    ///         When changing from pending to notGranted, all batched data will be wiped.
+    ///         Safe to call before or after DataDog initialization.
+    public static func setTrackingConsent(_ consent: TrackingConsent) {
+        self.trackingConsent = consent
+
+        // Only update DataDog if it's already initialized
+        if isDataDogInitialized {
+            Datadog.set(trackingConsent: datadogConsent(for: consent))
+        }
+    }
+
+    static func markDataDogInitialized() {
+        isDataDogInitialized = true
+    }
+
+    static func datadogConsent(for consent: TrackingConsent) -> DatadogCore.TrackingConsent {
+        switch consent {
+        case .pending:
+            return .pending
+        case .granted:
+            return .granted
+        case .notGranted:
+            return .notGranted
+        }
     }
 }

--- a/Sources/Logger/DataDogLoggerProvider.swift
+++ b/Sources/Logger/DataDogLoggerProvider.swift
@@ -10,8 +10,6 @@ import DatadogCore
 import DatadogLogs
 
 final class DataDogLoggerProvider: LoggerProvider {
-    private nonisolated(unsafe) static var isDataDogInitialized: Bool = false
-
     private let logger: LoggerProtocol
     private let service: String
 
@@ -60,7 +58,7 @@ final class DataDogLoggerProvider: LoggerProvider {
     }
 
     private static func setupDataDogIfNeeded(clientToken: String, environment: String) {
-        guard !isDataDogInitialized else { return }
+        guard !DataDogConfig.isDataDogInitialized else { return }
 
         Datadog.initialize(
             with: Datadog.Configuration(
@@ -68,11 +66,11 @@ final class DataDogLoggerProvider: LoggerProvider {
                 env: environment,
                 service: "crossmint-ios-sdk"
             ),
-            trackingConsent: .granted
+            trackingConsent: DataDogConfig.datadogConsent(for: DataDogConfig.trackingConsent)
         )
 
         Logs.enable()
 
-        isDataDogInitialized = true
+        DataDogConfig.markDataDogInitialized()
     }
 }

--- a/Sources/Logger/TrackingConsent.swift
+++ b/Sources/Logger/TrackingConsent.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import DatadogCore
 
 /// Tracking consent states for remote logging (GDPR compliance)
 public enum TrackingConsent: Sendable {

--- a/Sources/Logger/TrackingConsent.swift
+++ b/Sources/Logger/TrackingConsent.swift
@@ -1,0 +1,19 @@
+//
+//  TrackingConsent.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 11/12/25.
+//
+
+import Foundation
+import DatadogCore
+
+/// Tracking consent states for remote logging (GDPR compliance)
+public enum TrackingConsent: Sendable {
+    /// The SDK starts collecting and batching the data but does not send it to the remote logging endpoint.
+    case pending
+    /// The SDK starts collecting the data and sends it to the remote logging endpoint.
+    case granted
+    /// The SDK does not collect any data for remote logging.
+    case notGranted
+}


### PR DESCRIPTION
This pull request implements a new setting to our SDK, which allows users to explicitly set if they want to allow our SDK to send diagnostics logs to DataDog. This has been implemented to comply with GDPR regulations, ensuring that we only send information to DataDog when the user has consented

## Breaking Change

A new **required** `trackingConsent` parameter has been added to SDK initialization. All existing integrations must be updated to pass a consent status when initializing the SDK instance:

```swift
let sdk = CrossmintSDK.shared(
    apiKey: apiKey,
    trackingConsent: .granted
)
```

### Consent Levels

There are three levels of consent that users can set:

- `.pending` - SDK collects and batches data but doesn't send it to remote endpoints
- `.granted` - SDK collects and sends data to remote logging endpoints
- `.notGranted` - SDK doesn't collect any data for remote logging

**Note:** This only affects remote DataDog logging. Local logs sent through Swift's os.log continue to work regardless of the tracking consent setting, so messages are still displayed on Xcode's console

### Updating Consent

It's also possible to update the consent status after initializing the SDK:

```swift
sdk.setTrackingConsent(.granted)
```

When updating consent:
- `.pending` → `.granted` sends all batched data to DataDog
- `.pending` → `.notGranted` wipes all batched data
