### PR TITLE
Update release workflow to use PR-based approach

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,68 @@
+name: Auto Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  auto-release:
+    name: Create Release
+    # Only run if PR was merged and has the "release" label
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: macos-15
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: main
+
+    - name: Extract version from PR title
+      id: extract_version
+      run: |
+        PR_TITLE="${{ github.event.pull_request.title }}"
+        # Extract version from title like "Release 0.0.8" or "Release 0.0.8-beta"
+        VERSION=$(echo "$PR_TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?')
+
+        if [ -z "$VERSION" ]; then
+          echo "Error: Could not extract version from PR title: $PR_TITLE"
+          exit 1
+        fi
+
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "✅ Extracted version: $VERSION"
+
+    - name: Verify version in SDKVersion.swift matches
+      run: |
+        VERSION="${{ steps.extract_version.outputs.version }}"
+        if ! grep -q "public static let version = \"$VERSION\"" Sources/Utils/SDKVersion.swift; then
+          echo "Error: Version in SDKVersion.swift does not match PR version"
+          echo "Expected: $VERSION"
+          echo "Current content:"
+          cat Sources/Utils/SDKVersion.swift
+          exit 1
+        fi
+        echo "✅ Version verified in SDKVersion.swift"
+
+    - name: Create and push tag
+      run: |
+        VERSION="${{ steps.extract_version.outputs.version }}"
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+        git tag "$VERSION"
+        git push origin "$VERSION"
+        echo "✅ Created and pushed tag: $VERSION"
+
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION="${{ steps.extract_version.outputs.version }}"
+        gh release create "$VERSION" \
+          --title "Release $VERSION" \
+          --generate-notes
+        echo "✅ Created GitHub release: $VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ env:
 jobs:
   create-version-pr:
     name: Create Version Bump PR
-    # Only run if version input is provided (prevents validation failures on push)
-    if: github.event.inputs.version != ''
+    # Only run if manually triggered with version input
+    if: github.event_name == 'workflow_dispatch'
     runs-on: macos-15
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Create Version Bump PR
 
 on:
   workflow_dispatch:
@@ -12,11 +12,12 @@ env:
   DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
 
 jobs:
-  release:
-    name: Create Release
+  create-version-pr:
+    name: Create Version Bump PR
     runs-on: macos-15
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
     - uses: actions/checkout@v4
@@ -76,17 +77,29 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
-    - name: Commit version bump and create tag
+    - name: Create branch and commit
       run: |
+        BRANCH_NAME="release-${{ inputs.version }}"
+        git checkout -b "$BRANCH_NAME"
         git add Sources/Utils/SDKVersion.swift
         git commit -m "chore: bump version to ${{ inputs.version }}"
-        git tag "${{ inputs.version }}"
-        git push origin main --tags
+        git push origin "$BRANCH_NAME"
 
-    - name: Create GitHub Release
+    - name: Create Pull Request
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create "${{ inputs.version }}" \
+        gh pr create \
           --title "Release ${{ inputs.version }}" \
-          --generate-notes
+          --body "$(cat <<'EOF'
+This PR bumps the SDK version to ${{ inputs.version }}.
+
+Once this PR is merged, a release will be automatically created.
+
+**Changes:**
+- Updated \`SDKVersion.swift\` to version ${{ inputs.version }}
+EOF
+)" \
+          --base main \
+          --head "release-${{ inputs.version }}" \
+          --label "release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ on:
         description: 'Version number (e.g., 0.0.8)'
         required: true
         type: string
-  push:
-    paths:
-      - '.github/workflows/this-file-does-not-exist.yml'
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
@@ -17,8 +14,6 @@ env:
 jobs:
   create-version-pr:
     name: Create Version Bump PR
-    # Only run if manually triggered with version input
-    if: github.event_name == 'workflow_dispatch'
     runs-on: macos-15
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ env:
 jobs:
   create-version-pr:
     name: Create Version Bump PR
+    # Only run if version input is provided (prevents validation failures on push)
+    if: github.event.inputs.version != ''
     runs-on: macos-15
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,19 +85,53 @@ jobs:
         git commit -m "chore: bump version to ${{ inputs.version }}"
         git push origin "$BRANCH_NAME"
 
+    - name: Generate changelog preview
+      id: changelog
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Get the latest tag
+        LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+        if [ -z "$LATEST_TAG" ]; then
+          echo "No previous tags found, showing all commits"
+          CHANGELOG="## All Changes\n\n$(git log --pretty=format:'- %s (%h)' --reverse)"
+        else
+          echo "Generating changelog from $LATEST_TAG to HEAD"
+          # Use GitHub API to generate release notes
+          CHANGELOG=$(gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name="${{ inputs.version }}" \
+            -f target_commitish="release-${{ inputs.version }}" \
+            -f previous_tag_name="$LATEST_TAG" \
+            --jq '.body')
+        fi
+
+        # Save to file for PR body
+        echo "$CHANGELOG" > /tmp/changelog.md
+        echo "✅ Generated changelog preview"
+
     - name: Create Pull Request
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        CHANGELOG=$(cat /tmp/changelog.md)
+
         gh pr create \
           --title "Release ${{ inputs.version }}" \
-          --body "$(cat <<'EOF'
+          --body "$(cat <<EOF
 This PR bumps the SDK version to ${{ inputs.version }}.
 
 Once this PR is merged, a release will be automatically created.
 
-**Changes:**
+## Changes
 - Updated \`SDKVersion.swift\` to version ${{ inputs.version }}
+
+## Changelog Preview
+
+$CHANGELOG
 EOF
 )" \
           --base main \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
         description: 'Version number (e.g., 0.0.8)'
         required: true
         type: string
+  push:
+    paths:
+      - '.github/workflows/this-file-does-not-exist.yml'
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer


### PR DESCRIPTION
This pull request updates the release workflow to use a PR-based approach, ensuring compliance with branch protection rules without requiring bypass permissions

## Two-Step Release Process

The release workflow has been split into two automated workflows:

**Step 1: Create Version Bump PR (release.yml)**

Manually triggered workflow that validates the version format, runs tests and linting, updates `SDKVersion.swift`, and creates a PR to main with the `release` label. The PR includes a changelog preview generated from GitHub's release notes API, showing all merged PRs since the last tag

**Step 2: Auto Release (auto-release.yml)**

Triggers automatically when a PR with the "release" label is merged to main. Extracts the version from the PR title, verifies it matches `SDKVersion.swift`, creates and pushes the git tag, and generates the GitHub release with auto-generated notes

## Usage

Trigger the workflow from the terminal:

```bash
gh workflow run release.yml -f version=0.0.9
```

Once the PR is created and merged, the release is automatically generated
