### PR TITLE
Fixed build error on demo app

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/SplashScreen.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/SplashScreen.swift
@@ -127,7 +127,7 @@ struct SplashScreen: View {
         .task {
             await authenticate()
         }
-        .onReceive(CrossmintSDK.shared.isOTPRequred) {
+        .onReceive(CrossmintSDK.shared.isOTPRequired) {
             showOTPView = $0
         }
     }


### PR DESCRIPTION
After the merge of #7, one of the demo apps were still using the old property name, which lead to the SmartWalletsDemo app to fail to build, resulting in our build CI workflow to fail as well. This update fixes this issue by using the correct property name on the demo app