### PR TITLE
Fix Lint Warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,8 +5,10 @@ disabled_rules: # rule identifiers turned on by default to exclude from running
   - identifier_name
   - multiple_closures_with_trailing_closure
   - for_where
+  - todo
 excluded: # case-sensitive paths to ignore during linting. Takes precedence over `included`
   - .build
+  - DerivedData
 
 opt_in_rules:
   - force_cast
@@ -32,3 +34,6 @@ nesting:
 type_body_length:
   warning: 400
   error: 500
+
+type_name:
+  max_length: 60

--- a/Examples/Crossmint-Demo/Crossmint-Demo/EmbeddedCheckout/EmbeddedCompletedView.swift
+++ b/Examples/Crossmint-Demo/Crossmint-Demo/EmbeddedCheckout/EmbeddedCompletedView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable line_length
 import CrossmintClient
 import Payments
 import PaymentsUI
@@ -255,3 +256,4 @@ public struct EmbeddedCompletedView: View {
         EmbeddedCheckoutCompletedView().environmentObject(orderManager)
     }
 }
+// swiftlint:enable line_length

--- a/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
+++ b/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
@@ -69,7 +69,10 @@ final public class CrossmintSDK: ObservableObject {
             }
         #endif
         Logger.client.error("Crossmint SDK requires an API key")
-        fatalError("Crossmint SDK requires an API key. Please call CrossmintSDK.shared(apiKey:) before accessing CrossmintSDK.shared")
+        fatalError(
+            "Crossmint SDK requires an API key. " +
+            "Please call CrossmintSDK.shared(apiKey:) before accessing CrossmintSDK.shared"
+        )
     }
 
     private init(apiKey: String, authManager: AuthManager? = nil) {

--- a/Sources/CrossmintCommonTypes/Blockchain/Models/Chain/EVMChain.swift
+++ b/Sources/CrossmintCommonTypes/Blockchain/Models/Chain/EVMChain.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable:next type_body_length
 public enum EVMChain: SpecificChain, CaseIterable, Equatable {
     public init?(_ from: String) {
         guard let knownChain = Known(rawValue: from) else { return nil }

--- a/Sources/CrossmintCommonTypes/Blockchain/Models/Wallet/AdminSignerData.swift
+++ b/Sources/CrossmintCommonTypes/Blockchain/Models/Wallet/AdminSignerData.swift
@@ -50,7 +50,8 @@ public struct ExternalWalletSignerData: AdminSignerData {
             throw DecodingError.dataCorruptedError(
                 forKey: .type,
                 in: container,
-                debugDescription: "Expected signer type to be \(AdminSignerDataType.externalWallet.rawValue) but found \(type)"
+                debugDescription:
+                    "Expected signer type to be \(AdminSignerDataType.externalWallet.rawValue) but found \(type)"
             )
         }
         self.address = try container.decode(String.self, forKey: .address)

--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -311,10 +311,12 @@ public enum LogEvents {
     public static let walletAddDelegatedSignerPreparedSignature = "wallet.addDelegatedSigner.prepared (signature)"
 
     /// Delegated signer signature pending
-    public static let walletAddDelegatedSignerSuccessSignaturePending = "wallet.addDelegatedSigner.success (signature pending)"
+    public static let walletAddDelegatedSignerSuccessSignaturePending =
+        "wallet.addDelegatedSigner.success (signature pending)"
 
     /// Delegated signer signature complete
-    public static let walletAddDelegatedSignerSuccessSignatureComplete = "wallet.addDelegatedSigner.success (signature complete)"
+    public static let walletAddDelegatedSignerSuccessSignatureComplete =
+        "wallet.addDelegatedSigner.success (signature complete)"
 
     /// Delegated signer added successfully
     public static let walletAddDelegatedSignerSuccess = "wallet.addDelegatedSigner.success"

--- a/Sources/Logger/Remote/DataDogLoggerProvider.swift
+++ b/Sources/Logger/Remote/DataDogLoggerProvider.swift
@@ -170,6 +170,7 @@ actor DataDogLoggerProvider: LoggerProvider {
         return "\(message) \(attributeStrings)"
     }
 
+    // swiftlint:disable:next function_body_length
     private func formatLogForDataDog(_ entry: LogEntry) -> [String: Any] {
         let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
 

--- a/Sources/Logger/Utils/DeviceInfoCache.swift
+++ b/Sources/Logger/Utils/DeviceInfoCache.swift
@@ -62,6 +62,7 @@ struct DeviceInfoCache: @unchecked Sendable {
         sysctlbyname("kern.osversion", nil, &size, nil, 0)
         var build = [UInt8](repeating: 0, count: size)
         sysctlbyname("kern.osversion", &build, &size, nil, 0)
+        // swiftlint:disable:next optional_data_string_conversion
         return String(decoding: build.prefix(while: { $0 != 0 }), as: UTF8.self)
     }
 

--- a/Sources/Payments/EmbeddedCheckout/ViewModels/PaymentProviders/CheckoutcomPaymentFormManager+CallbacksProvider.swift
+++ b/Sources/Payments/EmbeddedCheckout/ViewModels/PaymentProviders/CheckoutcomPaymentFormManager+CallbacksProvider.swift
@@ -9,6 +9,7 @@ import Logger
 // MARK: - Callback Handlers
 
 extension CheckoutComPaymentFormManager {
+    // swiftlint:disable:next function_body_length
     func initialiseCallbacks() -> CheckoutComponents.Callbacks {
         .init(
             onReady: { paymentMethod in
@@ -44,7 +45,8 @@ extension CheckoutComPaymentFormManager {
                     let showingPayButton = await MainActor.run { self.showPayButton }
                     guard !showingPayButton else {
                         Logger.payments.info(
-                            "[CheckoutComPaymentFormManager.CallbacksProvider.onTokenized] Showing checkout.com Flow element payment button. Skipping payment submission"
+                            "[CheckoutComPaymentFormManager.CallbacksProvider.onTokenized] " +
+                            "Showing checkout.com Flow element payment button. Skipping payment submission"
                         )
                         return
                     }
@@ -54,7 +56,8 @@ extension CheckoutComPaymentFormManager {
 
                     guard let order = orderToProcess else {
                         Logger.payments.error(
-                            "[CheckoutComPaymentFormManager.CallbacksProvider.onTokenized] Tokenized event received but no order to process"
+                            "[CheckoutComPaymentFormManager.CallbacksProvider.onTokenized] " +
+                            "Tokenized event received but no order to process"
                         )
                         return
                     }
@@ -64,12 +67,14 @@ extension CheckoutComPaymentFormManager {
                             withToken: tokenDetails, forOrder: order)
 
                         Logger.payments.debug(
-                            "[CheckoutComPaymentFormManager.CallbacksProvider.onTokenized] Payment response: \(paymentResponse.json(prettyPrinted: true))"
+                            "[CheckoutComPaymentFormManager.CallbacksProvider.onTokenized] " +
+                            "Payment response: \(paymentResponse.json(prettyPrinted: true))"
                         )
                     } catch {
                         // TODO update global message state
                         Logger.payments.error(
-                            "[CheckoutComPaymentFormManager.CallbacksProvider.onTokenized] Failed to submit payment: \(error.localizedDescription)"
+                            "[CheckoutComPaymentFormManager.CallbacksProvider.onTokenized] " +
+                            "Failed to submit payment: \(error.localizedDescription)"
                         )
                     }
                 }
@@ -95,7 +100,8 @@ extension CheckoutComPaymentFormManager {
 
     func handleOnSuccess(_ paymentMethod: CheckoutComponents.Describable, _ paymentId: String) {
         Logger.payments.info(
-            "[CheckoutComPaymentFormManager.CallbacksProvider.handleOnSuccess] Payment method: \(paymentMethod.name) ....> Payment Id: \(paymentId)"
+            "[CheckoutComPaymentFormManager.CallbacksProvider.handleOnSuccess] " +
+            "Payment method: \(paymentMethod.name) ....> Payment Id: \(paymentId)"
         )
         paymentSucceeded = true
         paymentID = paymentId

--- a/Sources/Payments/EmbeddedCheckout/ViewModels/PaymentProviders/CheckoutcomPaymentFormManager.swift
+++ b/Sources/Payments/EmbeddedCheckout/ViewModels/PaymentProviders/CheckoutcomPaymentFormManager.swift
@@ -47,7 +47,8 @@ extension CheckoutComPaymentFormManager {
             else {
                 // TODO either throw or show global message
                 errorMessage =
-                    "[CheckoutComPaymentFormManager.makeComponent] Cannot retrieve payment session and payment session secret"
+                    "[CheckoutComPaymentFormManager.makeComponent] " +
+                    "Cannot retrieve payment session and payment session secret"
                 Logger.payments.error(errorMessage)
                 return
             }

--- a/Sources/Payments/HeadlessCheckout/Manager/Models/CreateOrder/LineItem/Locators/CollectionLocators/blockchain/EvmContractCollectionLocator.swift
+++ b/Sources/Payments/HeadlessCheckout/Manager/Models/CreateOrder/LineItem/Locators/CollectionLocators/blockchain/EvmContractCollectionLocator.swift
@@ -4,7 +4,8 @@ import Utils
 // MARK: - Constants
 
 private let invalidBlockchainCollectionLocatorErrorMessage =
-    "Invalid blockchain collection locator. Expected: '<chain>:<contractAddress>' where chain is an EVM chain and contractAddress is a valid EVM address."
+    "Invalid blockchain collection locator. " +
+    "Expected: '<chain>:<contractAddress>' where chain is an EVM chain and contractAddress is a valid EVM address."
 
 // MARK: - EvmContractCollectionLocator
 

--- a/Sources/Payments/HeadlessCheckout/Manager/Models/CreateOrder/LineItem/Locators/TokenLocators/TokenLocator.swift
+++ b/Sources/Payments/HeadlessCheckout/Manager/Models/CreateOrder/LineItem/Locators/TokenLocators/TokenLocator.swift
@@ -18,8 +18,7 @@ public enum TokenLocator: Codable, Sendable, CustomStringConvertible {
     ]
 
     public init(string value: String) throws(TokenLocatorError) {
-        let tokenLocator: TokenLocator? = TokenLocator.initializers.reduce(nil) {
-            result, initializer in
+        let tokenLocator: TokenLocator? = TokenLocator.initializers.reduce(nil) { result, initializer in
             guard result == nil else { return result }
             return initializer(value)
         }

--- a/Sources/Payments/HeadlessCheckout/Order/Models/LineItem/Delivery/Quote/LineItemQuote.swift
+++ b/Sources/Payments/HeadlessCheckout/Order/Models/LineItem/Delivery/Quote/LineItemQuote.swift
@@ -68,7 +68,8 @@ public enum LineItemQuote: Codable, Sendable {
                 throw DecodingError.dataCorruptedError(
                     in: container,
                     debugDescription:
-                        "Cannot decode LineItemQuote: neither ExactOutLineItemQuote nor ExactInLineItemQuote could be decoded"
+                        "Cannot decode LineItemQuote: " +
+                        "neither ExactOutLineItemQuote nor ExactInLineItemQuote could be decoded"
                 )
             }
         }

--- a/Sources/Payments/HeadlessCheckout/PaymentProviders/Adapters/CheckoutCom/Models/CheckoutComAdapter.swift
+++ b/Sources/Payments/HeadlessCheckout/PaymentProviders/Adapters/CheckoutCom/Models/CheckoutComAdapter.swift
@@ -81,7 +81,8 @@ final class CheckoutComAdapter: Sendable {
         )
 
         Logger.payments.debug(
-            "[CheckoutComAdapter.submitPayment] CheckoutComPaymentInput: \(checkoutComPaymentInput.json(prettyPrinted: true))"
+            "[CheckoutComAdapter.submitPayment] " +
+            "CheckoutComPaymentInput: \(checkoutComPaymentInput.json(prettyPrinted: true))"
         )
 
         let endpoint = CheckoutComEndpoint.submitPayment(

--- a/Sources/Payments/HeadlessCheckout/ViewModels/HeadlessCheckoutOrderManager.swift
+++ b/Sources/Payments/HeadlessCheckout/ViewModels/HeadlessCheckoutOrderManager.swift
@@ -227,7 +227,8 @@ public final class HeadlessCheckoutOrderManager: @unchecked Sendable, Authentica
         _ error: OrderError, message: String, checkoutOrderMethod: HeadlessCheckoutOrderMethod
     ) {
         Logger.payments.error(
-            "[HeadlessOrderManager.handleNetworkError] \(checkoutOrderMethod): message: \(message) failed with error: \(error)"
+            "[HeadlessOrderManager.handleNetworkError] \(checkoutOrderMethod): " +
+            "message: \(message) failed with error: \(error)"
         )
         checkoutStateManager.globalMessage = EmbeddedCheckoutGlobalMessage(
             message: error.errorMessage,
@@ -271,6 +272,7 @@ public final class HeadlessCheckoutOrderManager: @unchecked Sendable, Authentica
         pollingTimer = nil
     }
 
+    // swiftlint:disable:next function_body_length
     private func scheduleQuoteRefreshIfNeeded() {
         // Cancel any existing timer first
         cancelQuoteRefreshTimer()
@@ -320,7 +322,8 @@ public final class HeadlessCheckoutOrderManager: @unchecked Sendable, Authentica
                 // Check if a submission is in progress
                 if self.checkoutStateManager.submitInProgress {
                     Logger.payments.info(
-                        "[HeadlessOrderManager.scheduleQuoteRefreshIfNeeded] Order payment is being submitted, skipping refresh"
+                        "[HeadlessOrderManager.scheduleQuoteRefreshIfNeeded] " +
+                        "Order payment is being submitted, skipping refresh"
                     )
                     return
                 }
@@ -328,14 +331,15 @@ public final class HeadlessCheckoutOrderManager: @unchecked Sendable, Authentica
                 // Get the current order again to ensure it's still refreshable
                 guard let currentOrder = self.order, self.isRefreshableOrder(currentOrder) else {
                     Logger.payments.info(
-                        "[HeadlessOrderManager.scheduleQuoteRefreshIfNeeded] Order is no longer refreshable, skipping refresh"
+                        "[HeadlessOrderManager.scheduleQuoteRefreshIfNeeded] " +
+                        "Order is no longer refreshable, skipping refresh"
                     )
                     return
                 }
 
                 Logger.payments.info(
-                    // swiftlint:disable:next line_length
-                    "[HeadlessOrderManager.scheduleQuoteRefreshIfNeeded] Quote about to expire for order \(currentOrder.orderId), refreshing quote..."
+                    "[HeadlessOrderManager.scheduleQuoteRefreshIfNeeded] " +
+                    "Quote about to expire for order \(currentOrder.orderId), refreshing quote..."
                 )
 
                 // Perform the refresh

--- a/Sources/Payments/Models/Common/Payments/Solana/SolanaPaymentInput.swift
+++ b/Sources/Payments/Models/Common/Payments/Solana/SolanaPaymentInput.swift
@@ -1,7 +1,7 @@
 import CrossmintCommonTypes
 
 public enum SolanaPaymentMethod: String, Codable, Sendable {
-    case solana = "solana"
+    case solana
 }
 
 public struct SolanaPaymentInput: CommonPaymentInput {

--- a/Sources/PaymentsUI/Common/Views/ProgressBar.swift
+++ b/Sources/PaymentsUI/Common/Views/ProgressBar.swift
@@ -15,8 +15,7 @@ struct ProgressBar: View {
                 startTime = Date()
                 progress = startingProgress
             }
-            .onReceive(Timer.publish(every: updateInterval, on: .main, in: .common).autoconnect()) {
-                currentTime in
+            .onReceive(Timer.publish(every: updateInterval, on: .main, in: .common).autoconnect()) { currentTime in
                 guard let startTime = startTime else { return }
 
                 let elapsedTime = currentTime.timeIntervalSince(startTime)

--- a/Sources/PaymentsUI/EmbeddedCheckout/Views/Components/DestinationContent/EmbeddedCheckoutDestinationEmailOrWalletInput.swift
+++ b/Sources/PaymentsUI/EmbeddedCheckout/Views/Components/DestinationContent/EmbeddedCheckoutDestinationEmailOrWalletInput.swift
@@ -33,7 +33,8 @@ struct EmbeddedCheckoutDestinationEmailOrWalletInput: View {
             )
         } catch {
             Logger.paymentsUI.error(
-                "[EmbeddedCheckoutDestinationEmailOrWalletInput.updateOrderRecipient] Error updating recipient: \(error)"
+                "[EmbeddedCheckoutDestinationEmailOrWalletInput.updateOrderRecipient] " +
+                "Error updating recipient: \(error)"
             )
         }
 
@@ -44,7 +45,8 @@ struct EmbeddedCheckoutDestinationEmailOrWalletInput: View {
 
     private func handleLiveEmailOrWalletChange(_ newValue: String) {
         Logger.paymentsUI.debug(
-            "[EmbeddedCheckoutDestinationEmailOrWalletInput.handleLiveEmailOrWalletChange] email or wallet text changed to: \(newValue)"
+            "[EmbeddedCheckoutDestinationEmailOrWalletInput.handleLiveEmailOrWalletChange] " +
+            "email or wallet text changed to: \(newValue)"
         )
 
         // Debouncing and updating the state
@@ -60,7 +62,8 @@ struct EmbeddedCheckoutDestinationEmailOrWalletInput: View {
         let value = destinationState.value
 
         Logger.paymentsUI.info(
-            "[EmbeddedCheckoutDestinationEmailOrWalletInput.validateNewEmailOrWalletAndUpdateRecipient] Validating and updating recipient with value: \(value)"
+            "[EmbeddedCheckoutDestinationEmailOrWalletInput.validateNewEmailOrWalletAndUpdateRecipient] " +
+            "Validating and updating recipient with value: \(value)"
         )
 
         // If it's empty, don't modify the state
@@ -72,7 +75,8 @@ struct EmbeddedCheckoutDestinationEmailOrWalletInput: View {
             Address.validateAddressAndReturnAddress(
                 value, chain: deliveryChain) {
             Logger.paymentsUI.debug(
-                "[EmbeddedCheckoutDestinationEmailOrWalletInput.validateNewEmailOrWalletAndUpdateRecipient] valid wallet address: \(value)"
+                "[EmbeddedCheckoutDestinationEmailOrWalletInput.validateNewEmailOrWalletAndUpdateRecipient] " +
+                "valid wallet address: \(value)"
             )
             await updateOrderRecipient(
                 newRecipient: RecipientInput.walletAddressWithOptionalPhysicalAddress(
@@ -83,7 +87,8 @@ struct EmbeddedCheckoutDestinationEmailOrWalletInput: View {
                 ))
         } else if isValidEmail(value) {
             Logger.paymentsUI.debug(
-                "[EmbeddedCheckoutDestinationEmailOrWalletInput.validateNewEmailOrWalletAndUpdateRecipient] valid email: \(value)"
+                "[EmbeddedCheckoutDestinationEmailOrWalletInput.validateNewEmailOrWalletAndUpdateRecipient] " +
+                "valid email: \(value)"
             )
             // TODO validate email
             await updateOrderRecipient(
@@ -99,7 +104,8 @@ struct EmbeddedCheckoutDestinationEmailOrWalletInput: View {
 
     private func validateEmailOrWalletAndShowErrors() {
         Logger.paymentsUI.debug(
-            "[EmbeddedCheckoutDestinationEmailOrWalletInput.validateEmailOrWalletAndShowErrors] Validating email or wallet: \(inputText)"
+            "[EmbeddedCheckoutDestinationEmailOrWalletInput.validateEmailOrWalletAndShowErrors] " +
+            "Validating email or wallet: \(inputText)"
         )
 
         let emailOrWallet = inputText
@@ -143,7 +149,8 @@ struct EmbeddedCheckoutDestinationEmailOrWalletInput: View {
         }
         .onReceive(checkoutStateManager.$debouncedDestinationState) { debouncedState in
             Logger.paymentsUI.debug(
-                "[EmbeddedCheckoutDestinationEmailOrWalletInput.onReceive] Debounced state changed to: \(debouncedState.value)"
+                "[EmbeddedCheckoutDestinationEmailOrWalletInput.onReceive] " +
+                "Debounced state changed to: \(debouncedState.value)"
             )
 
             // Validate that the debounced state is the same as the current state so we don't update the recipient twice

--- a/Sources/PaymentsUI/EmbeddedCheckout/Views/Components/DestinationContent/PhysicalAddressSection/EmbeddedCheckoutPhysicalAddressAutocomplete.swift
+++ b/Sources/PaymentsUI/EmbeddedCheckout/Views/Components/DestinationContent/PhysicalAddressSection/EmbeddedCheckoutPhysicalAddressAutocomplete.swift
@@ -6,7 +6,10 @@ struct EmbeddedCheckoutPhysicalAddressAutocomplete: View {
     let physicalAddressWithoutName: PhysicalAddressWithoutName
     let onAddressSelected: (PhysicalAddressWithoutName) -> Void
 
-    init(physicalAddressWithoutName: PhysicalAddressWithoutName, onAddressSelected: @escaping (PhysicalAddressWithoutName) -> Void) {
+    init(
+        physicalAddressWithoutName: PhysicalAddressWithoutName,
+        onAddressSelected: @escaping (PhysicalAddressWithoutName) -> Void
+    ) {
         self.physicalAddressWithoutName = physicalAddressWithoutName
         self.onAddressSelected = onAddressSelected
     }

--- a/Sources/PaymentsUI/EmbeddedCheckout/Views/Components/DestinationContent/PhysicalAddressSection/EmbeddedCheckoutPhysicalAddressForm.swift
+++ b/Sources/PaymentsUI/EmbeddedCheckout/Views/Components/DestinationContent/PhysicalAddressSection/EmbeddedCheckoutPhysicalAddressForm.swift
@@ -16,8 +16,14 @@ struct EmbeddedCheckoutPhysicalAddressForm: View {
         let name = defaultAddress?.name
         let physicalAddressWithoutName = defaultAddress?.withoutName()
 
-        self._nameDebouncer = StateObject(wrappedValue: DebouncerViewModel<String>(initialValue: name ?? "", delay: 1))
-        self._addressWithoutNameDebouncer = StateObject(wrappedValue: DebouncerViewModel<PhysicalAddressWithoutName?>(initialValue: physicalAddressWithoutName, delay: 1))
+        self._nameDebouncer = StateObject(
+            wrappedValue: DebouncerViewModel<String>(initialValue: name ?? "", delay: 1)
+        )
+        self._addressWithoutNameDebouncer = StateObject(
+            wrappedValue: DebouncerViewModel<PhysicalAddressWithoutName?>(
+                initialValue: physicalAddressWithoutName, delay: 1
+            )
+        )
     }
 
     var body: some View {

--- a/Sources/PaymentsUI/EmbeddedCheckout/Views/Components/EmbeddedCheckoutGlobalMessageView.swift
+++ b/Sources/PaymentsUI/EmbeddedCheckout/Views/Components/EmbeddedCheckoutGlobalMessageView.swift
@@ -88,8 +88,9 @@ struct EmbeddedCheckoutGlobalMessageView: View {
         // Set up a new timer if timeout is specified
         if let timeout = message.timeout {
             let weakStateManager = checkoutStateManager
-            autoDismissTimer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) {
-                [weak weakStateManager] _ in
+            autoDismissTimer = Timer.scheduledTimer(
+                withTimeInterval: timeout, repeats: false
+            ) { [weak weakStateManager] _ in
                 DispatchQueue.main.async {
                     weakStateManager?.globalMessage = nil
                 }

--- a/Sources/PaymentsUI/EmbeddedCheckout/Views/Components/PaymentMethodContent/Card/CardPaymentMethodContentView.swift
+++ b/Sources/PaymentsUI/EmbeddedCheckout/Views/Components/PaymentMethodContent/Card/CardPaymentMethodContentView.swift
@@ -25,7 +25,8 @@ struct CardPaymentMethodContentView: View {
 
     func validateDestination() -> Bool {
         Logger.paymentsUI.debug(
-            "[CardPaymentMethodContentView.validateDestination] Validating destination: \(checkoutStateManager.destinationState.value)"
+            "[CardPaymentMethodContentView.validateDestination] " +
+            "Validating destination: \(checkoutStateManager.destinationState.value)"
         )
 
         if !checkoutStateManager.isEditingDestination {

--- a/Sources/PaymentsUI/EmbeddedCheckout/Views/Phases/Completed/CompletedHeader/StatusHeaders/EmbeddedCheckoutExactInOrderFailedHeaderView.swift
+++ b/Sources/PaymentsUI/EmbeddedCheckout/Views/Phases/Completed/CompletedHeader/StatusHeaders/EmbeddedCheckoutExactInOrderFailedHeaderView.swift
@@ -14,7 +14,8 @@ struct EmbeddedCheckoutExactInOrderFailedHeaderView: View {
             EmbeddedCheckoutOrderWarningContainerView(
                 title: "Order slippage exceeded",
                 description:
-                    "Your slippage limit was exceeded and we were unable to fulfill your order at the quoted amount. You have not been charged."
+                    "Your slippage limit was exceeded and we were unable to fulfill your order " +
+                    "at the quoted amount. You have not been charged."
             )
         }
     }

--- a/Sources/PaymentsUI/EmbeddedCheckout/Views/Phases/EmbeddedCheckoutCompletedView.swift
+++ b/Sources/PaymentsUI/EmbeddedCheckout/Views/Phases/EmbeddedCheckoutCompletedView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable line_length
 import CrossmintService
 import Payments
 import SwiftUI
@@ -59,6 +60,7 @@ public struct EmbeddedCheckoutCompletedView: View {
                 "executionMode" : "exact-out",
                 "metadata" : {
                     "name" : "My nft",
+                    // swiftlint:disable:next line_length
                     "imageUrl" : "https://lh3.googleusercontent.com/K3jRCmDa1i11JfzUAegOk_LYwNFfbShz5ljBV8Prs4qSubHx437tO5M8KUaQ7A5JotzzNxW5N-PAp_H_8IuoCkWpmysGh31fFeEn=s1000",
                     "description" : "badd descre"
                 },
@@ -134,3 +136,4 @@ public struct EmbeddedCheckoutCompletedView: View {
         }
     }
 }
+// swiftlint:enable line_length

--- a/Sources/Utils/NonEmptyString.swift
+++ b/Sources/Utils/NonEmptyString.swift
@@ -16,6 +16,7 @@ public struct NonEmptyString: Equatable, Hashable, Codable, CustomStringConverti
     }
 
     public init(stringInterpolation: DefaultStringInterpolation) {
+        // swiftlint:disable:next compiler_protocol_init
         let string = String(stringInterpolation: stringInterpolation)
         precondition(!string.isEmpty, "NonEmptyString cannot be initialized with an empty string interpolation")
         self.value = string
@@ -245,7 +246,9 @@ extension NonEmptyString {
         return String(value.suffix(maxLength))
     }
 
-    public func split(separator: Character, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true) -> [String] {
+    public func split(
+        separator: Character, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true
+    ) -> [String] {
         return value.split(
             separator: separator,
             maxSplits: maxSplits,

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -17,6 +17,7 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
         Logger.smartWallet.info(LogEvents.sdkInitialized)
     }
 
+    // swiftlint:disable:next function_body_length
     public func getOrCreateWallet(
         chain: Chain,
         signer: any Signer,

--- a/Sources/Wallet/Model/EIP712/EIP712.swift
+++ b/Sources/Wallet/Model/EIP712/EIP712.swift
@@ -270,6 +270,7 @@ public enum EIP712 {
     }
 
     public enum CommonPatterns {
+        // swiftlint:disable:next function_parameter_count
         public static func permit(
             tokenName: String,
             tokenVersion: String = "1",
@@ -320,6 +321,7 @@ public enum EIP712 {
             )
         }
 
+        // swiftlint:disable:next function_parameter_count
         public static func metaTransaction(
             dappName: String,
             dappVersion: String = "1",

--- a/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
+++ b/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
@@ -37,7 +37,10 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
         }
     }
 
-    @available(*, deprecated, renamed: "sendTransaction(to:value:data:)", message: "Use the new sendTransaction method. This one will be removed.")
+    @available(
+        *, deprecated, renamed: "sendTransaction(to:value:data:)",
+        message: "Use the new sendTransaction method. This one will be removed."
+    )
     public func sendTransaction(
         to address: EVMAddress,
         data: String?,
@@ -202,7 +205,9 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
         }
     }
 
-    private func createAndApproveSignature(request: CreateSignatureRequest) async throws(SignatureError) -> any SignatureApiModel {
+    private func createAndApproveSignature(
+        request: CreateSignatureRequest
+    ) async throws(SignatureError) -> any SignatureApiModel {
         let response = try await super.smartWalletService.createSignature(request)
 
         for pendingApproval in response.approvals.pending {

--- a/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
+++ b/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
@@ -42,7 +42,10 @@ public final class SolanaWallet: Wallet, WalletOnChain, @unchecked Sendable {
         }
     }
 
-    @available(*, deprecated, renamed: "sendTransaction(transaction:)", message: "Use the new sendTransaction method. This one will be removed.")
+    @available(
+        *, deprecated, renamed: "sendTransaction(transaction:)",
+        message: "Use the new sendTransaction method. This one will be removed."
+    )
     public func sendTransaction(
         transaction: String
     ) async throws(TransactionError) -> Transaction {

--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import CrossmintAuth
 import Combine
 import Logger
@@ -9,6 +10,7 @@ extension Logger {
 @MainActor private var teeInstances = 0
 
 @MainActor
+// swiftlint:disable:next type_body_length
 public final class CrossmintTEE: ObservableObject {
     public private(set) static var shared: CrossmintTEE?
 
@@ -107,6 +109,7 @@ public final class CrossmintTEE: ObservableObject {
         return try await queueSignRequest(transaction: transaction, keyType: keyType, encoding: encoding)
     }
 
+    // swiftlint:disable:next function_body_length
     private func executeSignTransaction(
         transaction: String,
         keyType: String,

--- a/Sources/Web/CrossmintWebView.swift
+++ b/Sources/Web/CrossmintWebView.swift
@@ -33,7 +33,9 @@ public struct CrossmintWebView: UIViewRepresentable {
         let userContentController = WKUserContentController()
 
         let communicationScript = WKUserScript(
-            source: CrossmintJavaScriptBridge.communicationScript(bundleID: bundleId, handlerName: webViewCommunicationProxy.name),
+            source: CrossmintJavaScriptBridge.communicationScript(
+                bundleID: bundleId, handlerName: webViewCommunicationProxy.name
+            ),
             injectionTime: .atDocumentStart,
             forMainFrameOnly: true
         )

--- a/Sources/Web/WebViewCommunicationProxy.swift
+++ b/Sources/Web/WebViewCommunicationProxy.swift
@@ -29,7 +29,8 @@ extension WebViewCommunicationProxy {
     }
 }
 
-public class DefaultWebViewCommunicationProxy: NSObject, ObservableObject, WKScriptMessageHandler, WebViewCommunicationProxy {
+public class DefaultWebViewCommunicationProxy: NSObject, ObservableObject, WKScriptMessageHandler,
+    WebViewCommunicationProxy {
     public let name = "crossmintMessageHandler"
 
     public weak var webView: WKWebView?

--- a/Sources/Web/WebViewMessageHandler.swift
+++ b/Sources/Web/WebViewMessageHandler.swift
@@ -37,7 +37,10 @@ public class WebViewMessageHandler {
     }
 
     public func reset() {
-        Logger.web.debug("reset() - Resetting message handler, clearing \(messageListeners.count) listeners, \(pendingMessages.count) pending messages, \(messageBuffer.count) buffered messages")
+        Logger.web.debug(
+            "reset() - Resetting message handler, clearing \(messageListeners.count) listeners, " +
+            "\(pendingMessages.count) pending messages, \(messageBuffer.count) buffered messages"
+        )
         isReady = false
         pendingMessages.removeAll()
         messageBuffer.removeAll()
@@ -83,7 +86,10 @@ public class WebViewMessageHandler {
             delegate?.handleWebViewMessage(decodedMessage)
         } else {
             // Log unknown message before delegating
-            Logger.web.warn("Unknown message type: \(messageTypeInfo), data: \(String(data: messageData, encoding: .utf8) ?? "nil")")
+            Logger.web.warn(
+                "Unknown message type: \(messageTypeInfo), " +
+                "data: \(String(data: messageData, encoding: .utf8) ?? "nil")"
+            )
             delegate?.handleUnknownMessage(messageTypeInfo, data: messageData)
         }
     }

--- a/Tests/CrossmintServiceTests/DefaultJSONCoderTest.swift
+++ b/Tests/CrossmintServiceTests/DefaultJSONCoderTest.swift
@@ -280,7 +280,10 @@ struct DefaultJSONCoderTest {
         let decodedModel: TestModelWithDate = try coder.decode(TestModelWithDate.self, from: encodedData)
 
         #expect(decodedModel.name == originalModel.name)
-        #expect(abs(decodedModel.createdAt.timeIntervalSince1970 - originalModel.createdAt.timeIntervalSince1970) < 0.001)
+        let timeDifference = abs(
+            decodedModel.createdAt.timeIntervalSince1970 - originalModel.createdAt.timeIntervalSince1970
+        )
+        #expect(timeDifference < 0.001)
     }
 
     @Test("Handles complex nested structures")

--- a/Tests/WalletTests/Model/BalanceTransformerTest.swift
+++ b/Tests/WalletTests/Model/BalanceTransformerTest.swift
@@ -3,7 +3,6 @@ import Foundation
 import Testing
 @testable import Wallet
 
-// swiftlint:disable:next type_body_length
 struct BalanceTransformerTest {
 
     // MARK: - Helper Methods
@@ -19,6 +18,7 @@ struct BalanceTransformerTest {
     // MARK: - Basic Functionality Tests
 
     @Test("Transform balances with all tokens present")
+    // swiftlint:disable:next function_body_length
     func testTransformWithAllTokensPresent() async {
         let balancesJson = """
         [
@@ -211,6 +211,7 @@ struct BalanceTransformerTest {
     }
 
     @Test("Transform balances with multiple tokens")
+    // swiftlint:disable:next function_body_length
     func testTransformWithMultipleTokens() async {
         let balancesJson = """
         [
@@ -301,6 +302,7 @@ struct BalanceTransformerTest {
     }
 
     @Test("Transform filters out duplicate native token and USDC from requested tokens")
+    // swiftlint:disable:next function_body_length
     func testTransformFiltersOutDuplicates() async {
         let balancesJson = """
         [
@@ -363,6 +365,7 @@ struct BalanceTransformerTest {
     }
 
     @Test("Transform handles unknown tokens")
+    // swiftlint:disable:next function_body_length
     func testTransformWithUnknownTokens() async {
         let balancesJson = """
         [

--- a/Tests/WalletTests/Model/BalancesTest.swift
+++ b/Tests/WalletTests/Model/BalancesTest.swift
@@ -122,6 +122,7 @@ struct BalancesTest {
     }
 
     @Test("Will parse different balances")
+    // swiftlint:disable:next function_body_length
     func willGetDifferentTokensFromTheBalanceResponse() async {
         let balances = getBalances("""
                 [

--- a/Tests/WalletTests/Model/ChainTest.swift
+++ b/Tests/WalletTests/Model/ChainTest.swift
@@ -230,8 +230,14 @@ struct ChainTest {
         "Test chains should equal corresponding EVMChain test variants"
     )
     func testChainsEqualCorrespondingEvmTestChains() async {
-        #expect(Chain.ethereumSepolia == EVMChain.ethereumSepolia, "Chain.ethereumSepolia should equal EVMChain.ethereumSepolia")
-        #expect(EVMChain.ethereumSepolia == Chain.ethereumSepolia, "EVMChain.ethereumSepolia should equal Chain.ethereumSepolia")
+        #expect(
+            Chain.ethereumSepolia == EVMChain.ethereumSepolia,
+            "Chain.ethereumSepolia should equal EVMChain.ethereumSepolia"
+        )
+        #expect(
+            EVMChain.ethereumSepolia == Chain.ethereumSepolia,
+            "EVMChain.ethereumSepolia should equal Chain.ethereumSepolia"
+        )
 
         #expect(Chain.polygonAmoy == EVMChain.polygonAmoy, "Chain.polygonAmoy should equal EVMChain.polygonAmoy")
         #expect(EVMChain.polygonAmoy == Chain.polygonAmoy, "EVMChain.polygonAmoy should equal Chain.polygonAmoy")
@@ -283,7 +289,9 @@ struct ChainTest {
         }
 
         guard let data = json.data(using: .utf8),
-                let chainResponse: ChainResponse = try? JSONDecoder().decode(ChainResponse.self, from: data) else { return nil }
+              let chainResponse: ChainResponse = try? JSONDecoder().decode(
+                ChainResponse.self, from: data
+              ) else { return nil }
         return chainResponse.chain
     }
 }

--- a/Tests/WalletTests/Model/EIP712/EIP712Tests.swift
+++ b/Tests/WalletTests/Model/EIP712/EIP712Tests.swift
@@ -308,6 +308,7 @@ struct EIP712Tests {
     }
 
     @Test
+    // swiftlint:disable:next function_body_length
     func testRealWorldEtherMailExample() throws {
         let domain = EIP712.Domain(
             name: "Ether Mail",
@@ -406,6 +407,7 @@ struct EIP712Tests {
     }
 
     @Test
+    // swiftlint:disable:next function_body_length
     func testParseSignatureResponseWithNullValues() throws {
         // Test parsing the actual signature response JSON
         let response: TypedDataSignatureResponse = try GetFromFile.getModelFrom(

--- a/Tests/WebTests/CrossmintTEETests.swift
+++ b/Tests/WebTests/CrossmintTEETests.swift
@@ -5,7 +5,6 @@ import Testing
 
 @Suite("CrossmintTEE Tests")
 @MainActor
-// swiftlint:disable:next type_body_length
 struct CrossmintTEETests {
     @MainActor
     struct TestFixture {

--- a/Tests/WebTests/Mocks/MockWebViewCommunicationProxy.swift
+++ b/Tests/WebTests/Mocks/MockWebViewCommunicationProxy.swift
@@ -101,7 +101,9 @@ final class MockWebViewCommunicationProxy: NSObject, WebViewCommunicationProxy {
 
     // MARK: - WKScriptMessageHandler
 
-    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+    public func userContentController(
+        _ userContentController: WKUserContentController, didReceive message: WKScriptMessage
+    ) {
         // Mock implementation - not needed for tests
     }
 }

--- a/Tests/WebTests/NonCustodialSignResponseTests.swift
+++ b/Tests/WebTests/NonCustodialSignResponseTests.swift
@@ -37,12 +37,14 @@ struct NonCustodialSignResponseTests {
 
         // Check signature
         let signature = try #require(response.signature)
-        #expect(signature.bytes == "286tF52C47NUK384m5uHmTpYxjMnXZHLTMjAJaChSKetckrYcAtnmBjybYMTXShN9H5yUV93XQEgJcsFrTyifQwE")
+        // swiftlint:disable:next line_length
+        let expectedSigBytes = "286tF52C47NUK384m5uHmTpYxjMnXZHLTMjAJaChSKetckrYcAtnmBjybYMTXShN9H5yUV93XQEgJcsFrTyifQwE"
+        #expect(signature.bytes == expectedSigBytes)
         #expect(signature.encoding == "base58")
         #expect(signature.keyType == "ed25519")
 
         // Check signature bytes convenience property
-        #expect(response.signatureBytes == "286tF52C47NUK384m5uHmTpYxjMnXZHLTMjAJaChSKetckrYcAtnmBjybYMTXShN9H5yUV93XQEgJcsFrTyifQwE")
+        #expect(response.signatureBytes == expectedSigBytes)
 
         // Check public key
         let publicKey = try #require(response.publicKey)

--- a/Tests/WebTests/WebViewMessageHandlerTests.swift
+++ b/Tests/WebTests/WebViewMessageHandlerTests.swift
@@ -5,7 +5,6 @@ import Testing
 
 @Suite("WebViewMessageHandler Tests")
 @MainActor
-// swiftlint:disable:next type_body_length
 struct WebViewMessageHandlerTests {
     final class MockWebViewMessageHandlerDelegate: WebViewMessageHandlerDelegate {
         var receivedMessages: [any WebViewMessage] = []


### PR DESCRIPTION
## Fix SwiftLint warnings

Ever since we added the SwiftLint plugin in #37, all lint warnings from our SDK started appearing in the projects of apps that make use of our SDK, which can be problematic for teams that enforce zero-warning policies or have CI pipelines that fail on warnings

This PR eliminates all SwiftLint warnings across the SDK, tests, and demo apps, through the following changes to our lint config file or to our codebase:

**Configuration (`.swiftlint.yml`)**
- Disable `todo` rule (TODOs are intentional work tracking)
- Exclude `DerivedData` from linting
- Increase `type_name` max length to 60 for descriptive names

**Code fixes**
- Fix line length violations by breaking long lines
- Fix closure parameter position (move to same line as opening brace)
- Remove redundant string enum value in `SolanaPaymentInput`
- Remove superfluous disable commands that were no longer needed

**Disable comments added**
- Long test functions (acceptable in test code)
- Long functions in `CrossmintTEE`, `HeadlessCheckoutOrderManager`, `DataDogLoggerProvider`
- High parameter count in `EIP712` common patterns (permit, metaTransaction)