### PR TITLE
Added List Transfers request

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo.xcodeproj/project.pbxproj
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		EB9BDDE22DC4CFBF003999C7 /* BalanceDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9BDDE12DC4CFBF003999C7 /* BalanceDashboardView.swift */; };
 		EB9BDDE42DC4CFCF003999C7 /* TransferDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9BDDE32DC4CFCF003999C7 /* TransferDashboardView.swift */; };
 		EB9BDDE62DC4CFE2003999C7 /* NFTDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9BDDE52DC4CFE2003999C7 /* NFTDashboardView.swift */; };
+		EBHISTORY12F000000000001 /* TransferHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBHISTORY02F000000000001 /* TransferHistoryView.swift */; };
 		EB9BDDEB2DC4D219003999C7 /* GetTestTokenButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9BDDE92DC4D219003999C7 /* GetTestTokenButton.swift */; };
 		EB9BDDEC2DC4D219003999C7 /* WalletBalanceEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9BDDEA2DC4D219003999C7 /* WalletBalanceEntryView.swift */; };
 		EB9BDDF02DC4E3F1003999C7 /* MiddleEllipsisText.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9BDDEF2DC4E3F1003999C7 /* MiddleEllipsisText.swift */; };
@@ -50,6 +51,7 @@
 		EB9BDDE12DC4CFBF003999C7 /* BalanceDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceDashboardView.swift; sourceTree = "<group>"; };
 		EB9BDDE32DC4CFCF003999C7 /* TransferDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferDashboardView.swift; sourceTree = "<group>"; };
 		EB9BDDE52DC4CFE2003999C7 /* NFTDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFTDashboardView.swift; sourceTree = "<group>"; };
+		EBHISTORY02F000000000001 /* TransferHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferHistoryView.swift; sourceTree = "<group>"; };
 		EB9BDDE92DC4D219003999C7 /* GetTestTokenButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTestTokenButton.swift; sourceTree = "<group>"; };
 		EB9BDDEA2DC4D219003999C7 /* WalletBalanceEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletBalanceEntryView.swift; sourceTree = "<group>"; };
 		EB9BDDEF2DC4E3F1003999C7 /* MiddleEllipsisText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleEllipsisText.swift; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 			children = (
 				EBB46CD72DC8F8E00026AA88 /* AlertViewModel.swift */,
 				EB9BDDE52DC4CFE2003999C7 /* NFTDashboardView.swift */,
+				EBHISTORY02F000000000001 /* TransferHistoryView.swift */,
 				EB9BDDE32DC4CFCF003999C7 /* TransferDashboardView.swift */,
 				EB9BDDE12DC4CFBF003999C7 /* BalanceDashboardView.swift */,
 				AC0102062DD800000000001 /* DashboardView.swift */,
@@ -248,6 +251,7 @@
 				EB5D83162E45FA36002F8EF1 /* OTPValidatorView.swift in Sources */,
 				EBEC0BD52DC396EA000B59F1 /* SecondaryButton.swift in Sources */,
 				EB9BDDE62DC4CFE2003999C7 /* NFTDashboardView.swift in Sources */,
+				EBHISTORY12F000000000001 /* TransferHistoryView.swift in Sources */,
 				AC0101072DC600000000004 /* SmartWalletsDemoApp.swift in Sources */,
 				EBEC0BCE2DC37AE4000B59F1 /* CrossmintPoweredView.swift in Sources */,
 				EB9BDDE42DC4CFCF003999C7 /* TransferDashboardView.swift in Sources */,

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Dashboard/DashboardView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Dashboard/DashboardView.swift
@@ -24,7 +24,7 @@ struct DashboardView: View {
     }
 
     enum Tab {
-        case balance, transfer, nft
+        case balance, transfer, history, nft
     }
 
     var body: some View {
@@ -55,6 +55,12 @@ struct DashboardView: View {
                     TabButton(title: "Transfer", isSelected: selectedTab == .transfer) {
                         withAnimation(AnimationConstants.easeInOut(duration: AnimationConstants.shortDuration)) {
                             selectedTab = .transfer
+                        }
+                    }
+
+                    TabButton(title: "History", isSelected: selectedTab == .history) {
+                        withAnimation(AnimationConstants.easeInOut(duration: AnimationConstants.shortDuration)) {
+                            selectedTab = .history
                         }
                     }
 
@@ -99,6 +105,8 @@ struct DashboardView: View {
             }
             TransferDashboardView(wallet: wallet, balances: $balance)
                 .opacity(selectedTab == .transfer ? 1.0 : 0.0)
+            TransferHistoryView(wallet: wallet)
+                .opacity(selectedTab == .history ? 1.0 : 0.0)
             NFTDashboardView(wallet: wallet)
                 .opacity(selectedTab == .nft ? 1.0 : 0.0)
         }

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Dashboard/TransferHistoryView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Dashboard/TransferHistoryView.swift
@@ -1,0 +1,248 @@
+//
+//  TransferHistoryView.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 21/01/26.
+//
+
+import CrossmintCommonTypes
+import SwiftUI
+import Wallet
+
+struct TransferHistoryView: View {
+    let wallet: Wallet
+
+    @State private var transfers: [Transfer] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    private let tokens: [CryptoCurrency] = [.eth, .usdc, .usdxm]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Activity History")
+                .font(.title2)
+                .fontWeight(.bold)
+
+            Text("Recent activity for this wallet")
+                .font(.subheadline)
+                .foregroundColor(.gray)
+
+            if isLoading && transfers.isEmpty {
+                loadingView
+            } else if let errorMessage = errorMessage, transfers.isEmpty {
+                errorView(message: errorMessage)
+            } else if transfers.isEmpty {
+                emptyView
+            } else {
+                transferListView
+            }
+        }
+        .padding(.top, 16)
+        .padding(.horizontal)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Color(UIColor.systemBackground))
+        .onAppear {
+            if transfers.isEmpty {
+                fetchTransfers()
+            }
+        }
+    }
+
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .frame(maxWidth: .infinity, minHeight: 120)
+
+            Text("Loading activity history...")
+                .font(.subheadline)
+                .foregroundColor(.gray)
+        }
+    }
+
+    private func errorView(message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 40))
+                .foregroundColor(.orange)
+                .padding(.bottom, 8)
+
+            Text("Error loading activity")
+                .font(.headline)
+
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(.gray)
+                .multilineTextAlignment(.center)
+
+            Button("Retry") {
+                fetchTransfers()
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 8)
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(8)
+            .padding(.top, 8)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "arrow.left.arrow.right")
+                .font(.system(size: 40))
+                .foregroundColor(.gray)
+                .padding(.bottom, 8)
+
+            Text("No activity yet")
+                .font(.headline)
+
+            Text("Your activity history will appear here once you make or receive transfers.")
+                .font(.subheadline)
+                .foregroundColor(.gray)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+    }
+
+    private var transferListView: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(transfers) { transfer in
+                    TransferRowView(transfer: transfer, walletAddress: wallet.address)
+                }
+            }
+            .padding(.bottom, 16)
+        }
+        .refreshable {
+            fetchTransfers(showLoading: false)
+        }
+    }
+
+    private func fetchTransfers(showLoading: Bool = true) {
+        if showLoading {
+            isLoading = true
+        }
+        errorMessage = nil
+
+        Task {
+            do {
+                let result = try await wallet.listTransfers(tokens: tokens)
+
+                await MainActor.run {
+                    transfers = result.transfers
+                    isLoading = false
+                }
+            } catch let walletError as WalletError {
+                await MainActor.run {
+                    errorMessage = walletError.errorMessage
+                    isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    isLoading = false
+                }
+            }
+        }
+    }
+}
+
+struct TransferRowView: View {
+    let transfer: Transfer
+    let walletAddress: String
+
+    private var isOutgoing: Bool {
+        transfer.isOutgoing(from: walletAddress)
+    }
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: transfer.timestamp)
+    }
+
+    private var formattedAmount: String {
+        let symbol = transfer.tokenSymbol?.uppercased() ?? "TOKEN"
+        return "\(transfer.amount) \(symbol)"
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Direction icon
+            Image(systemName: isOutgoing ? "arrow.up.right" : "arrow.down.left")
+                .font(.system(size: 20, weight: .medium))
+                .foregroundColor(isOutgoing ? .orange : .green)
+                .frame(width: 40, height: 40)
+                .background(
+                    Circle()
+                        .fill(isOutgoing ? Color.orange.opacity(0.1) : Color.green.opacity(0.1))
+                )
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(isOutgoing ? "Sent" : "Received")
+                        .font(.headline)
+                        .fontWeight(.semibold)
+
+                    Spacer()
+
+                    Text("\(isOutgoing ? "-" : "+")\(formattedAmount)")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(isOutgoing ? .primary : .green)
+                }
+
+                HStack {
+                    Text(isOutgoing ? "To: " : "From: ")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+
+                    Text(truncateAddress(isOutgoing ? transfer.toAddress : transfer.fromAddress))
+                        .font(.caption)
+                        .foregroundColor(.gray)
+
+                    Spacer()
+
+                    // Activity type badge
+                    Text(transfer.type)
+                        .font(.caption2)
+                        .fontWeight(.medium)
+                        .foregroundColor(.blue)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill(Color.blue.opacity(0.1))
+                        )
+                }
+
+                Text(formattedDate)
+                    .font(.caption2)
+                    .foregroundColor(.gray)
+
+                // Transaction hash link
+                HStack(spacing: 4) {
+                    Text("Tx: \(truncateAddress(transfer.transactionHash))")
+                        .font(.caption2)
+                        .foregroundColor(.gray)
+                }
+            }
+        }
+        .padding()
+        .background(Color.white)
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.05), radius: 2, x: 0, y: 1)
+    }
+
+    private func truncateAddress(_ address: String) -> String {
+        guard address.count > 12 else { return address }
+        let prefix = address.prefix(6)
+        let suffix = address.suffix(4)
+        return "\(prefix)...\(suffix)"
+    }
+}

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Dashboard/TransferHistoryView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Dashboard/TransferHistoryView.swift
@@ -112,7 +112,7 @@ struct TransferHistoryView: View {
         ScrollView {
             LazyVStack(spacing: 12) {
                 ForEach(transfers) { transfer in
-                    TransferRowView(transfer: transfer, walletAddress: wallet.address)
+                    TransferRowView(transfer: transfer)
                 }
             }
             .padding(.bottom, 16)
@@ -153,10 +153,9 @@ struct TransferHistoryView: View {
 
 struct TransferRowView: View {
     let transfer: Transfer
-    let walletAddress: String
 
     private var isOutgoing: Bool {
-        transfer.isOutgoing(from: walletAddress)
+        transfer.type == .outgoing
     }
 
     private var formattedDate: String {
@@ -209,7 +208,7 @@ struct TransferRowView: View {
                     Spacer()
 
                     // Activity type badge
-                    Text(transfer.type)
+                    Text(isOutgoing ? "Outgoing" : "Incoming")
                         .font(.caption2)
                         .fontWeight(.medium)
                         .foregroundColor(.blue)

--- a/Package.swift
+++ b/Package.swift
@@ -194,7 +194,8 @@ let package = Package(
                 .process("Resources/WalletEVMApiKey.json"),
                 .process("Resources/WalletEVMEmail.json"),
                 .process("Resources/WalletSolanaEmail.json"),
-                .process("Resources/WalletEVMPhone.json")
+                .process("Resources/WalletEVMPhone.json"),
+                .process("Resources/Transfer/ListTransfersResponse.json")
             ],
             plugins: basePlugins
         ),

--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -216,6 +216,15 @@ public enum LogEvents {
     /// API: Send successful
     public static let apiSendSuccess = "wallets.api.send.success"
 
+    /// API: Listing transfers
+    public static let apiListTransfersStart = "wallets.api.listTransfers"
+
+    /// API: List transfers failed
+    public static let apiListTransfersError = "wallets.api.listTransfers.error"
+
+    /// API: List transfers successful
+    public static let apiListTransfersSuccess = "wallets.api.listTransfers.success"
+
     // MARK: - SDK Initialization
 
     /// SDK initialized

--- a/Sources/Wallet/Data/DefaultSmartWalletService.swift
+++ b/Sources/Wallet/Data/DefaultSmartWalletService.swift
@@ -401,9 +401,7 @@ public final class DefaultSmartWalletService: SmartWalletService {
             )
 
             let result = TransferListResult(
-                transfers: response.data.map { Transfer.map($0) },
-                nextCursor: response.nextCursor,
-                previousCursor: response.previousCursor
+                transfers: response.data.compactMap { Transfer.map($0) }
             )
 
             Logger.smartWallet.info(LogEvents.apiListTransfersSuccess, attributes: [

--- a/Sources/Wallet/Data/Queries/ListTransfersQueryParams.swift
+++ b/Sources/Wallet/Data/Queries/ListTransfersQueryParams.swift
@@ -1,0 +1,31 @@
+//
+//  ListTransfersQueryParams.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 21/01/26.
+//
+
+import CrossmintCommonTypes
+import Foundation
+
+/// Query parameters for listing wallet activity.
+public struct ListTransfersQueryParams: Sendable {
+    /// The wallet locator to fetch activity for.
+    public let walletLocator: WalletLocator
+
+    /// The blockchain to query activity from.
+    public let chain: Chain
+
+    /// The tokens to filter activity by.
+    public let tokens: [CryptoCurrency]
+
+    public init(
+        walletLocator: WalletLocator,
+        chain: Chain,
+        tokens: [CryptoCurrency]
+    ) {
+        self.walletLocator = walletLocator
+        self.chain = chain
+        self.tokens = tokens
+    }
+}

--- a/Sources/Wallet/Data/Responses/TransferListApiModel.swift
+++ b/Sources/Wallet/Data/Responses/TransferListApiModel.swift
@@ -1,0 +1,53 @@
+//
+//  TransferListApiModel.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 21/01/26.
+//
+
+import CrossmintCommonTypes
+import Foundation
+
+/// API response model for the wallet activity endpoint.
+struct TransferListApiModel: Decodable {
+    /// Array of activity events.
+    let events: [ActivityEventApiModel]
+}
+
+/// API model representing a single activity event.
+struct ActivityEventApiModel: Decodable {
+    /// The symbol of the token involved in the activity.
+    let tokenSymbol: String?
+
+    /// The hash of the token (for NFTs).
+    let mintHash: String?
+
+    /// The hash of the transaction.
+    let transactionHash: String
+
+    /// The destination address of the transaction.
+    let toAddress: String
+
+    /// The source address of the transaction.
+    let fromAddress: String
+
+    /// The timestamp when the activity occurred (Unix timestamp).
+    let timestamp: Double
+
+    /// The amount of the token involved in the activity.
+    let amount: String
+
+    /// The type of activity (e.g., "TRANSFER").
+    let type: String
+
+    enum CodingKeys: String, CodingKey {
+        case tokenSymbol = "token_symbol"
+        case mintHash = "mint_hash"
+        case transactionHash = "transaction_hash"
+        case toAddress = "to_address"
+        case fromAddress = "from_address"
+        case timestamp
+        case amount
+        case type
+    }
+}

--- a/Sources/Wallet/Data/Responses/TransferListApiModel.swift
+++ b/Sources/Wallet/Data/Responses/TransferListApiModel.swift
@@ -8,46 +8,47 @@
 import CrossmintCommonTypes
 import Foundation
 
-/// API response model for the wallet activity endpoint.
+/// API response model for the unstable transfers endpoint.
 struct TransferListApiModel: Decodable {
-    /// Array of activity events.
-    let events: [ActivityEventApiModel]
+    let data: [TransferApiModel]
+    let nextCursor: String?
+    let previousCursor: String?
 }
 
-/// API model representing a single activity event.
-struct ActivityEventApiModel: Decodable {
-    /// The symbol of the token involved in the activity.
-    let tokenSymbol: String?
-
-    /// The hash of the token (for NFTs).
-    let mintHash: String?
-
-    /// The hash of the transaction.
-    let transactionHash: String
-
-    /// The destination address of the transaction.
-    let toAddress: String
-
-    /// The source address of the transaction.
-    let fromAddress: String
-
-    /// The timestamp when the activity occurred (Unix timestamp).
-    let timestamp: Double
-
-    /// The amount of the token involved in the activity.
-    let amount: String
-
-    /// The type of activity (e.g., "TRANSFER").
+/// API model representing a single transfer.
+struct TransferApiModel: Decodable {
     let type: String
+    let sender: TransferParticipantApiModel
+    let recipient: TransferParticipantApiModel
+    let token: TransferTokenApiModel
+    let status: String
+    let onChain: TransferOnChainApiModel?
+    let completedAt: String
+    let error: TransferErrorApiModel?
+}
 
-    enum CodingKeys: String, CodingKey {
-        case tokenSymbol = "token_symbol"
-        case mintHash = "mint_hash"
-        case transactionHash = "transaction_hash"
-        case toAddress = "to_address"
-        case fromAddress = "from_address"
-        case timestamp
-        case amount
-        case type
-    }
+struct TransferParticipantApiModel: Decodable {
+    let address: String
+    let chain: String
+    let locator: String
+    let owner: String?
+}
+
+struct TransferTokenApiModel: Decodable {
+    let type: String
+    let chain: String
+    let locator: String
+    let amount: String
+    let symbol: String
+    let decimals: Int
+}
+
+struct TransferOnChainApiModel: Decodable {
+    let txId: String
+    let explorerLink: String?
+}
+
+struct TransferErrorApiModel: Decodable {
+    let code: String
+    let message: String
 }

--- a/Sources/Wallet/Data/Responses/TransferListApiModel.swift
+++ b/Sources/Wallet/Data/Responses/TransferListApiModel.swift
@@ -10,8 +10,6 @@ import Foundation
 
 struct TransferListApiModel: Decodable {
     let data: [TransferApiModel]
-    let nextCursor: String?
-    let previousCursor: String?
 }
 
 struct TransferApiModel: Decodable {

--- a/Sources/Wallet/Data/Responses/TransferListApiModel.swift
+++ b/Sources/Wallet/Data/Responses/TransferListApiModel.swift
@@ -14,7 +14,6 @@ struct TransferListApiModel: Decodable {
     let previousCursor: String?
 }
 
-/// API model representing a single transfer.
 struct TransferApiModel: Decodable {
     let type: String
     let sender: TransferParticipantApiModel

--- a/Sources/Wallet/Data/Responses/TransferListApiModel.swift
+++ b/Sources/Wallet/Data/Responses/TransferListApiModel.swift
@@ -8,7 +8,6 @@
 import CrossmintCommonTypes
 import Foundation
 
-/// API response model for the unstable transfers endpoint.
 struct TransferListApiModel: Decodable {
     let data: [TransferApiModel]
     let nextCursor: String?

--- a/Sources/Wallet/Data/SmartWalletService.swift
+++ b/Sources/Wallet/Data/SmartWalletService.swift
@@ -58,4 +58,14 @@ public protocol SmartWalletService: AuthenticatedService, Sendable {
         _ signatureId: String,
         chainType: ChainType
     ) async throws(SignatureError) -> any SignatureApiModel
+
+    /// Fetches the transfer history for a wallet.
+    ///
+    /// - Note: This endpoint uses the `/unstable/` API prefix, meaning the API may change
+    ///   without notice. Use with caution in production environments.
+    /// - Parameter params: Query parameters including wallet locator, chain, tokens, and pagination options.
+    /// - Returns: A `TransferListResult` containing the list of transfers and pagination cursors.
+    func listTransfers(
+        _ params: ListTransfersQueryParams
+    ) async throws(WalletError) -> TransferListResult
 }

--- a/Sources/Wallet/Model/Transfer/Transfer.swift
+++ b/Sources/Wallet/Model/Transfer/Transfer.swift
@@ -7,6 +7,7 @@
 
 import CrossmintCommonTypes
 import Foundation
+import Logger
 
 /// The direction of a transfer relative to the wallet.
 public enum TransferType: String, Sendable, Hashable {
@@ -108,6 +109,9 @@ extension Transfer {
     static func map(_ apiModel: TransferApiModel) -> Transfer? {
         let timestamp = Self.parseDate(apiModel.completedAt) ?? Date()
         guard let type = TransferType(rawValue: apiModel.type) else {
+            Logger.smartWallet.warn("Unrecognized transfer type", attributes: [
+                "type": apiModel.type
+            ])
             return nil
         }
 

--- a/Sources/Wallet/Model/Transfer/Transfer.swift
+++ b/Sources/Wallet/Model/Transfer/Transfer.swift
@@ -1,0 +1,159 @@
+//
+//  Transfer.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 21/01/26.
+//
+
+import CrossmintCommonTypes
+import Foundation
+
+/// Represents a wallet activity event such as a token transfer or NFT transfer.
+///
+/// Use this model to display transaction history in your application. Each transfer
+/// contains information about the sender, recipient, token, amount, and timestamp.
+///
+/// ## Determining Transfer Direction
+///
+/// Use ``isOutgoing(from:)`` or ``isIncoming(to:)`` to determine if a transfer
+/// was sent from or received by a specific wallet address:
+///
+/// ```swift
+/// let result = try await wallet.listTransfers(tokens: [.eth, .usdc])
+/// for transfer in result.transfers {
+///     if transfer.isOutgoing(from: wallet.address) {
+///         print("Sent \(transfer.amount) \(transfer.tokenSymbol ?? "tokens")")
+///     } else {
+///         print("Received \(transfer.amount) \(transfer.tokenSymbol ?? "tokens")")
+///     }
+/// }
+/// ```
+///
+public struct Transfer: Sendable, Hashable, Equatable, Identifiable {
+    /// Unique identifier for the transfer.
+    ///
+    /// This is the same as ``transactionHash`` and can be used to look up
+    /// the transaction on a blockchain explorer.
+    public var id: String {
+        transactionHash
+    }
+
+    /// The type of activity.
+    ///
+    /// Common values include:
+    /// - `"TRANSFER"` - A standard token transfer
+    /// - `"NFT_TRANSFER"` - An NFT transfer
+    public let type: String
+
+    /// The blockchain address that sent the transfer.
+    public let fromAddress: String
+
+    /// The blockchain address that received the transfer.
+    public let toAddress: String
+
+    /// The unique hash identifying this transaction on the blockchain.
+    ///
+    /// This can be used to look up the transaction on a blockchain explorer.
+    public let transactionHash: String
+
+    /// The symbol of the token involved in the transfer.
+    ///
+    /// For example: `"ETH"`, `"USDC"`, `"SOL"`. May be `nil` for some transfer types.
+    public let tokenSymbol: String?
+
+    /// The human-readable amount of tokens transferred.
+    ///
+    /// This value has already been adjusted for the token's decimals.
+    /// For example, if 1.5 USDC was transferred, this will be `1.5`.
+    public let amount: Decimal
+
+    /// The raw amount string as returned by the API.
+    ///
+    /// Use this if you need the exact string representation for display or further processing.
+    public let rawAmount: String
+
+    /// The date and time when the transfer occurred.
+    public let timestamp: Date
+
+    /// The mint hash for NFT transfers.
+    ///
+    /// This identifies the specific NFT that was transferred. Will be `nil` for
+    /// fungible token transfers.
+    public let mintHash: String?
+
+    public init(
+        type: String,
+        fromAddress: String,
+        toAddress: String,
+        transactionHash: String,
+        tokenSymbol: String?,
+        amount: Decimal,
+        rawAmount: String,
+        timestamp: Date,
+        mintHash: String?
+    ) {
+        self.type = type
+        self.fromAddress = fromAddress
+        self.toAddress = toAddress
+        self.transactionHash = transactionHash
+        self.tokenSymbol = tokenSymbol
+        self.amount = amount
+        self.rawAmount = rawAmount
+        self.timestamp = timestamp
+        self.mintHash = mintHash
+    }
+
+    /// Determines if this transfer was sent from the given wallet address.
+    ///
+    /// - Parameter walletAddress: The wallet address to check against. The comparison is case-insensitive.
+    /// - Returns: `true` if this transfer was sent from the specified address, `false` otherwise.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let transfer = result.transfers.first!
+    /// if transfer.isOutgoing(from: wallet.address) {
+    ///     print("You sent \(transfer.amount) \(transfer.tokenSymbol ?? "")")
+    /// }
+    /// ```
+    public func isOutgoing(from walletAddress: String) -> Bool {
+        fromAddress.lowercased() == walletAddress.lowercased()
+    }
+
+    /// Determines if this transfer was received by the given wallet address.
+    ///
+    /// - Parameter walletAddress: The wallet address to check against. The comparison is case-insensitive.
+    /// - Returns: `true` if this transfer was received by the specified address, `false` otherwise.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let transfer = result.transfers.first!
+    /// if transfer.isIncoming(to: wallet.address) {
+    ///     print("You received \(transfer.amount) \(transfer.tokenSymbol ?? "")")
+    /// }
+    /// ```
+    public func isIncoming(to walletAddress: String) -> Bool {
+        toAddress.lowercased() == walletAddress.lowercased()
+    }
+}
+
+// MARK: - Mapping
+
+extension Transfer {
+    static func map(_ apiModel: ActivityEventApiModel) -> Transfer {
+        let timestamp = Date(timeIntervalSince1970: apiModel.timestamp)
+
+        return Transfer(
+            type: apiModel.type,
+            fromAddress: apiModel.fromAddress,
+            toAddress: apiModel.toAddress,
+            transactionHash: apiModel.transactionHash,
+            tokenSymbol: apiModel.tokenSymbol,
+            amount: Decimal(string: apiModel.amount) ?? 0,
+            rawAmount: apiModel.amount,
+            timestamp: timestamp,
+            mintHash: apiModel.mintHash
+        )
+    }
+}

--- a/Sources/Wallet/Model/Transfer/Transfer.swift
+++ b/Sources/Wallet/Model/Transfer/Transfer.swift
@@ -141,19 +141,29 @@ public struct Transfer: Sendable, Hashable, Equatable, Identifiable {
 // MARK: - Mapping
 
 extension Transfer {
-    static func map(_ apiModel: ActivityEventApiModel) -> Transfer {
-        let timestamp = Date(timeIntervalSince1970: apiModel.timestamp)
+    static func map(_ apiModel: TransferApiModel) -> Transfer {
+        let timestamp = Self.parseDate(apiModel.completedAt) ?? Date()
 
         return Transfer(
             type: apiModel.type,
-            fromAddress: apiModel.fromAddress,
-            toAddress: apiModel.toAddress,
-            transactionHash: apiModel.transactionHash,
-            tokenSymbol: apiModel.tokenSymbol,
-            amount: Decimal(string: apiModel.amount) ?? 0,
-            rawAmount: apiModel.amount,
+            fromAddress: apiModel.sender.address,
+            toAddress: apiModel.recipient.address,
+            transactionHash: apiModel.onChain?.txId ?? "",
+            tokenSymbol: apiModel.token.symbol,
+            amount: Decimal(string: apiModel.token.amount) ?? 0,
+            rawAmount: apiModel.token.amount,
             timestamp: timestamp,
-            mintHash: apiModel.mintHash
+            mintHash: nil
         )
+    }
+
+    private static func parseDate(_ dateString: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: dateString) {
+            return date
+        }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: dateString)
     }
 }

--- a/Sources/Wallet/Model/Transfer/Transfer.swift
+++ b/Sources/Wallet/Model/Transfer/Transfer.swift
@@ -121,7 +121,10 @@ extension Transfer {
             toAddress: apiModel.recipient.address,
             transactionHash: apiModel.onChain?.txId ?? "",
             tokenSymbol: apiModel.token.symbol,
-            amount: Decimal(string: apiModel.token.amount) ?? 0,
+            guard let amount = Decimal(string: apiModel.token.amount) else { return nil }
+            return Transfer(
+                ...
+                amount: amount,
             rawAmount: apiModel.token.amount,
             timestamp: timestamp,
             mintHash: nil

--- a/Sources/Wallet/Model/Transfer/TransferListResult.swift
+++ b/Sources/Wallet/Model/Transfer/TransferListResult.swift
@@ -7,29 +7,22 @@
 
 import Foundation
 
-/// The result of fetching wallet transfer activity.
+/// The result of fetching wallet transfer history.
 ///
 /// This struct contains an array of ``Transfer`` events representing the wallet's
 /// transaction history. The transfers are sorted by timestamp in descending order
 /// (most recent first).
 ///
-/// ## Basic Usage
+/// ## Example
 ///
 /// ```swift
 /// let result = try await wallet.listTransfers(tokens: [.eth, .usdc])
 ///
 /// for transfer in result.transfers {
-///     print("\(transfer.timestamp): \(transfer.amount) \(transfer.tokenSymbol ?? "")")
+///     let direction = transfer.isOutgoing(from: wallet.address) ? "Sent" : "Received"
+///     print("\(direction): \(transfer.amount) \(transfer.tokenSymbol ?? "")")
 /// }
 /// ```
-///
-/// ## Pagination
-///
-/// The result includes cursor-based pagination support. Use ``hasNextPage`` and
-/// ``hasPreviousPage`` to check if more results are available.
-///
-/// > Note: Pagination is reserved for future use. Currently, all available
-/// > transfers are returned in a single response.
 public struct TransferListResult: Sendable {
     /// The array of transfer events.
     ///
@@ -38,39 +31,7 @@ public struct TransferListResult: Sendable {
     /// specified tokens.
     public let transfers: [Transfer]
 
-    /// Cursor for fetching the next page of results.
-    ///
-    /// This will be `nil` if there are no more results available.
-    /// Reserved for future pagination support.
-    public let nextCursor: String?
-
-    /// Cursor for fetching the previous page of results.
-    ///
-    /// This will be `nil` if this is the first page of results.
-    /// Reserved for future pagination support.
-    public let previousCursor: String?
-
-    public init(
-        transfers: [Transfer],
-        nextCursor: String?,
-        previousCursor: String?
-    ) {
+    public init(transfers: [Transfer]) {
         self.transfers = transfers
-        self.nextCursor = nextCursor
-        self.previousCursor = previousCursor
-    }
-
-    /// Indicates whether more results are available after this page.
-    ///
-    /// Returns `true` if ``nextCursor`` is not `nil`.
-    public var hasNextPage: Bool {
-        nextCursor != nil
-    }
-
-    /// Indicates whether results exist before this page.
-    ///
-    /// Returns `true` if ``previousCursor`` is not `nil`.
-    public var hasPreviousPage: Bool {
-        previousCursor != nil
     }
 }

--- a/Sources/Wallet/Model/Transfer/TransferListResult.swift
+++ b/Sources/Wallet/Model/Transfer/TransferListResult.swift
@@ -1,0 +1,76 @@
+//
+//  TransferListResult.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 21/01/26.
+//
+
+import Foundation
+
+/// The result of fetching wallet transfer activity.
+///
+/// This struct contains an array of ``Transfer`` events representing the wallet's
+/// transaction history. The transfers are sorted by timestamp in descending order
+/// (most recent first).
+///
+/// ## Basic Usage
+///
+/// ```swift
+/// let result = try await wallet.listTransfers(tokens: [.eth, .usdc])
+///
+/// for transfer in result.transfers {
+///     print("\(transfer.timestamp): \(transfer.amount) \(transfer.tokenSymbol ?? "")")
+/// }
+/// ```
+///
+/// ## Pagination
+///
+/// The result includes cursor-based pagination support. Use ``hasNextPage`` and
+/// ``hasPreviousPage`` to check if more results are available.
+///
+/// > Note: Pagination is reserved for future use. Currently, all available
+/// > transfers are returned in a single response.
+public struct TransferListResult: Sendable {
+    /// The array of transfer events.
+    ///
+    /// Transfers are sorted by timestamp in descending order (most recent first).
+    /// This array may be empty if the wallet has no transfer history for the
+    /// specified tokens.
+    public let transfers: [Transfer]
+
+    /// Cursor for fetching the next page of results.
+    ///
+    /// This will be `nil` if there are no more results available.
+    /// Reserved for future pagination support.
+    public let nextCursor: String?
+
+    /// Cursor for fetching the previous page of results.
+    ///
+    /// This will be `nil` if this is the first page of results.
+    /// Reserved for future pagination support.
+    public let previousCursor: String?
+
+    public init(
+        transfers: [Transfer],
+        nextCursor: String?,
+        previousCursor: String?
+    ) {
+        self.transfers = transfers
+        self.nextCursor = nextCursor
+        self.previousCursor = previousCursor
+    }
+
+    /// Indicates whether more results are available after this page.
+    ///
+    /// Returns `true` if ``nextCursor`` is not `nil`.
+    public var hasNextPage: Bool {
+        nextCursor != nil
+    }
+
+    /// Indicates whether results exist before this page.
+    ///
+    /// Returns `true` if ``previousCursor`` is not `nil`.
+    public var hasPreviousPage: Bool {
+        previousCursor != nil
+    }
+}

--- a/Sources/Wallet/Model/Transfer/TransferListResult.swift
+++ b/Sources/Wallet/Model/Transfer/TransferListResult.swift
@@ -12,17 +12,6 @@ import Foundation
 /// This struct contains an array of ``Transfer`` events representing the wallet's
 /// transaction history. The transfers are sorted by timestamp in descending order
 /// (most recent first).
-///
-/// ## Example
-///
-/// ```swift
-/// let result = try await wallet.listTransfers(tokens: [.eth, .usdc])
-///
-/// for transfer in result.transfers {
-///     let direction = transfer.isOutgoing(from: wallet.address) ? "Sent" : "Received"
-///     print("\(direction): \(transfer.amount) \(transfer.tokenSymbol ?? "")")
-/// }
-/// ```
 public struct TransferListResult: Sendable {
     /// The array of transfer events.
     ///

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -66,8 +66,14 @@ open class Wallet: @unchecked Sendable {
     /// let result = try await wallet.listTransfers(tokens: [.eth, .usdc])
     ///
     /// for transfer in result.transfers {
-    ///     let direction = transfer.isOutgoing(from: wallet.address) ? "Sent" : "Received"
-    ///     print("\(direction): \(transfer.amount) \(transfer.tokenSymbol ?? "tokens")")
+    ///     switch transfer.type {
+    ///     case .outgoing:
+    ///         print("Sent \(transfer.amount) \(transfer.tokenSymbol ?? "tokens")")
+    ///     case .incoming:
+    ///         print("Received \(transfer.amount) \(transfer.tokenSymbol ?? "tokens")")
+    ///     case .unknown:
+    ///         break
+    ///     }
     /// }
     /// ```
     public func listTransfers(

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -46,6 +46,42 @@ open class Wallet: @unchecked Sendable {
         )
     }
 
+    /// Fetches the transfer history for this wallet.
+    ///
+    /// Returns a list of incoming and outgoing transfers for the specified tokens.
+    /// Use this method to display transaction history in your application.
+    ///
+    /// - Parameter tokens: The cryptocurrency tokens to fetch transfers for.
+    ///   Common values include `.eth`, `.usdc`, `.sol`, etc.
+    ///
+    /// - Returns: A ``TransferListResult`` containing the transfer events sorted
+    ///   by timestamp (most recent first).
+    ///
+    /// - Throws: ``WalletError`` if the request fails.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// // Fetch ETH and USDC transfers
+    /// let result = try await wallet.listTransfers(tokens: [.eth, .usdc])
+    ///
+    /// for transfer in result.transfers {
+    ///     let direction = transfer.isOutgoing(from: wallet.address) ? "Sent" : "Received"
+    ///     print("\(direction): \(transfer.amount) \(transfer.tokenSymbol ?? "tokens")")
+    /// }
+    /// ```
+    public func listTransfers(
+        tokens: [CryptoCurrency]
+    ) async throws(WalletError) -> TransferListResult {
+        try await smartWalletService.listTransfers(
+            ListTransfersQueryParams(
+                walletLocator: .address(blockchainAddress),
+                chain: chain,
+                tokens: tokens
+            )
+        )
+    }
+
     public func approve(transactionId id: String) async throws(TransactionError) -> Transaction {
         Logger.smartWallet.info(LogEvents.walletApproveStart, attributes: [
             "transactionId": id

--- a/Tests/WalletTests/Model/TransferTests.swift
+++ b/Tests/WalletTests/Model/TransferTests.swift
@@ -13,14 +13,16 @@ import TestsUtils
 @testable import Wallet
 
 struct TransferTests {
-    @Test("Will decode an activity response with events")
-    func willDecodeActivityResponse() async throws {
+    @Test("Will decode a list transfers response with pagination")
+    func willDecodeListTransfersResponse() async throws {
         let response: TransferListApiModel = try GetFromFile.getModelFrom(
             fileName: "ListTransfersResponse",
             bundle: Bundle.module
         )
 
-        #expect(response.events.count == 3)
+        #expect(response.nextCursor == "eyJsYXN0SWQiOiIxMjM0NTY3ODkwIn0=")
+        #expect(response.previousCursor == nil)
+        #expect(response.data.count == 3)
     }
 
     @Test("Will map outgoing transfer correctly")
@@ -31,8 +33,9 @@ struct TransferTests {
         )
 
         let walletAddress = "0x1234567890123456789012345678901234567890"
-        let transfer = Transfer.map(response.events[0])
+        let transfer = Transfer.map(response.data[0])
 
+        #expect(transfer.type == "outgoing")
         #expect(transfer.isOutgoing(from: walletAddress) == true)
         #expect(transfer.isIncoming(to: walletAddress) == false)
         #expect(transfer.fromAddress == walletAddress)
@@ -40,9 +43,7 @@ struct TransferTests {
         #expect(transfer.tokenSymbol == "USDC")
         #expect(transfer.amount == Decimal(string: "10.5"))
         #expect(transfer.rawAmount == "10.5")
-        #expect(transfer.type == "TRANSFER")
         #expect(transfer.transactionHash == "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
-        #expect(transfer.mintHash == nil)
     }
 
     @Test("Will map incoming transfer correctly")
@@ -53,64 +54,25 @@ struct TransferTests {
         )
 
         let walletAddress = "0x1234567890123456789012345678901234567890"
-        let transfer = Transfer.map(response.events[1])
+        let transfer = Transfer.map(response.data[1])
 
+        #expect(transfer.type == "incoming")
         #expect(transfer.isOutgoing(from: walletAddress) == false)
         #expect(transfer.isIncoming(to: walletAddress) == true)
         #expect(transfer.fromAddress == "0x0987654321098765432109876543210987654321")
         #expect(transfer.toAddress == walletAddress)
         #expect(transfer.tokenSymbol == "ETH")
         #expect(transfer.amount == Decimal(string: "0.05"))
-        #expect(transfer.type == "TRANSFER")
     }
 
-    @Test("Will map transfer with mint hash (NFT) correctly")
-    func willMapNFTTransfer() async throws {
+    @Test("Will parse ISO8601 date with fractional seconds")
+    func willParseDateWithFractionalSeconds() async throws {
         let response: TransferListApiModel = try GetFromFile.getModelFrom(
             fileName: "ListTransfersResponse",
             bundle: Bundle.module
         )
 
-        let transfer = Transfer.map(response.events[2])
-
-        #expect(transfer.type == "NFT_TRANSFER")
-        #expect(transfer.mintHash == "0xnftmintha5h000000000000000000000000000000000000000000000000000")
-        #expect(transfer.tokenSymbol == "USDC")
-        #expect(transfer.amount == Decimal(string: "25.00"))
-    }
-
-    @Test("Will parse timestamp from Unix time")
-    func willParseTimestamp() async throws {
-        let response: TransferListApiModel = try GetFromFile.getModelFrom(
-            fileName: "ListTransfersResponse",
-            bundle: Bundle.module
-        )
-
-        let transfer = Transfer.map(response.events[0])
-
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
-        let components = calendar.dateComponents(
-            [.year, .month, .day, .hour, .minute, .second],
-            from: transfer.timestamp
-        )
-
-        #expect(components.year == 2024)
-        #expect(components.month == 1)
-        #expect(components.day == 15)
-        #expect(components.hour == 10)
-        #expect(components.minute == 50)
-        #expect(components.second == 0)
-    }
-
-    @Test("Will parse timestamp with fractional seconds")
-    func willParseTimestampWithFractionalSeconds() async throws {
-        let response: TransferListApiModel = try GetFromFile.getModelFrom(
-            fileName: "ListTransfersResponse",
-            bundle: Bundle.module
-        )
-
-        let transfer = Transfer.map(response.events[1])
+        let transfer = Transfer.map(response.data[1])
 
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
@@ -123,8 +85,32 @@ struct TransferTests {
         #expect(components.month == 1)
         #expect(components.day == 14)
         #expect(components.hour == 8)
-        #expect(components.minute == 35)
+        #expect(components.minute == 15)
         #expect(components.second == 30)
+    }
+
+    @Test("Will parse ISO8601 date without fractional seconds")
+    func willParseDateWithoutFractionalSeconds() async throws {
+        let response: TransferListApiModel = try GetFromFile.getModelFrom(
+            fileName: "ListTransfersResponse",
+            bundle: Bundle.module
+        )
+
+        let transfer = Transfer.map(response.data[2])
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        let components = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: transfer.timestamp
+        )
+
+        #expect(components.year == 2024)
+        #expect(components.month == 1)
+        #expect(components.day == 13)
+        #expect(components.hour == 14)
+        #expect(components.minute == 0)
+        #expect(components.second == 0)
     }
 
     @Test("TransferListResult pagination helpers work correctly")
@@ -134,34 +120,25 @@ struct TransferTests {
             bundle: Bundle.module
         )
 
-        let resultWithNextPage = TransferListResult(
-            transfers: response.events.map { Transfer.map($0) },
-            nextCursor: "some-cursor",
-            previousCursor: nil
+        let result = TransferListResult(
+            transfers: response.data.map { Transfer.map($0) },
+            nextCursor: response.nextCursor,
+            previousCursor: response.previousCursor
         )
 
-        #expect(resultWithNextPage.hasNextPage == true)
-        #expect(resultWithNextPage.hasPreviousPage == false)
-        #expect(resultWithNextPage.transfers.count == 3)
-
-        let resultWithNoCursors = TransferListResult(
-            transfers: response.events.map { Transfer.map($0) },
-            nextCursor: nil,
-            previousCursor: nil
-        )
-
-        #expect(resultWithNoCursors.hasNextPage == false)
-        #expect(resultWithNoCursors.hasPreviousPage == false)
+        #expect(result.hasNextPage == true)
+        #expect(result.hasPreviousPage == false)
+        #expect(result.transfers.count == 3)
     }
 
-    @Test("Transfer is Identifiable with transactionHash as id")
+    @Test("Transfer is Identifiable with txId as id")
     func transferIsIdentifiable() async throws {
         let response: TransferListApiModel = try GetFromFile.getModelFrom(
             fileName: "ListTransfersResponse",
             bundle: Bundle.module
         )
 
-        let transfer = Transfer.map(response.events[0])
+        let transfer = Transfer.map(response.data[0])
 
         #expect(transfer.id == "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
     }

--- a/Tests/WalletTests/Model/TransferTests.swift
+++ b/Tests/WalletTests/Model/TransferTests.swift
@@ -13,15 +13,13 @@ import TestsUtils
 @testable import Wallet
 
 struct TransferTests {
-    @Test("Will decode a list transfers response with pagination")
+    @Test("Will decode a list transfers response")
     func willDecodeListTransfersResponse() async throws {
         let response: TransferListApiModel = try GetFromFile.getModelFrom(
             fileName: "ListTransfersResponse",
             bundle: Bundle.module
         )
 
-        #expect(response.nextCursor == "eyJsYXN0SWQiOiIxMjM0NTY3ODkwIn0=")
-        #expect(response.previousCursor == nil)
         #expect(response.data.count == 3)
     }
 
@@ -32,13 +30,10 @@ struct TransferTests {
             bundle: Bundle.module
         )
 
-        let walletAddress = "0x1234567890123456789012345678901234567890"
-        let transfer = Transfer.map(response.data[0])
+        let transfer = try #require(Transfer.map(response.data[0]))
 
-        #expect(transfer.type == "outgoing")
-        #expect(transfer.isOutgoing(from: walletAddress) == true)
-        #expect(transfer.isIncoming(to: walletAddress) == false)
-        #expect(transfer.fromAddress == walletAddress)
+        #expect(transfer.type == .outgoing)
+        #expect(transfer.fromAddress == "0x1234567890123456789012345678901234567890")
         #expect(transfer.toAddress == "0x0987654321098765432109876543210987654321")
         #expect(transfer.tokenSymbol == "USDC")
         #expect(transfer.amount == Decimal(string: "10.5"))
@@ -53,14 +48,11 @@ struct TransferTests {
             bundle: Bundle.module
         )
 
-        let walletAddress = "0x1234567890123456789012345678901234567890"
-        let transfer = Transfer.map(response.data[1])
+        let transfer = try #require(Transfer.map(response.data[1]))
 
-        #expect(transfer.type == "incoming")
-        #expect(transfer.isOutgoing(from: walletAddress) == false)
-        #expect(transfer.isIncoming(to: walletAddress) == true)
+        #expect(transfer.type == .incoming)
         #expect(transfer.fromAddress == "0x0987654321098765432109876543210987654321")
-        #expect(transfer.toAddress == walletAddress)
+        #expect(transfer.toAddress == "0x1234567890123456789012345678901234567890")
         #expect(transfer.tokenSymbol == "ETH")
         #expect(transfer.amount == Decimal(string: "0.05"))
     }
@@ -72,7 +64,7 @@ struct TransferTests {
             bundle: Bundle.module
         )
 
-        let transfer = Transfer.map(response.data[1])
+        let transfer = try #require(Transfer.map(response.data[1]))
 
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
@@ -96,7 +88,7 @@ struct TransferTests {
             bundle: Bundle.module
         )
 
-        let transfer = Transfer.map(response.data[2])
+        let transfer = try #require(Transfer.map(response.data[2]))
 
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
@@ -113,24 +105,6 @@ struct TransferTests {
         #expect(components.second == 0)
     }
 
-    @Test("TransferListResult pagination helpers work correctly")
-    func transferListResultPaginationHelpers() async throws {
-        let response: TransferListApiModel = try GetFromFile.getModelFrom(
-            fileName: "ListTransfersResponse",
-            bundle: Bundle.module
-        )
-
-        let result = TransferListResult(
-            transfers: response.data.map { Transfer.map($0) },
-            nextCursor: response.nextCursor,
-            previousCursor: response.previousCursor
-        )
-
-        #expect(result.hasNextPage == true)
-        #expect(result.hasPreviousPage == false)
-        #expect(result.transfers.count == 3)
-    }
-
     @Test("Transfer is Identifiable with txId as id")
     func transferIsIdentifiable() async throws {
         let response: TransferListApiModel = try GetFromFile.getModelFrom(
@@ -138,7 +112,7 @@ struct TransferTests {
             bundle: Bundle.module
         )
 
-        let transfer = Transfer.map(response.data[0])
+        let transfer = try #require(Transfer.map(response.data[0]))
 
         #expect(transfer.id == "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
     }

--- a/Tests/WalletTests/Model/TransferTests.swift
+++ b/Tests/WalletTests/Model/TransferTests.swift
@@ -1,0 +1,168 @@
+//
+//  TransferTests.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 21/01/26.
+//
+
+import CrossmintCommonTypes
+import Foundation
+import Testing
+import TestsUtils
+
+@testable import Wallet
+
+struct TransferTests {
+    @Test("Will decode an activity response with events")
+    func willDecodeActivityResponse() async throws {
+        let response: TransferListApiModel = try GetFromFile.getModelFrom(
+            fileName: "ListTransfersResponse",
+            bundle: Bundle.module
+        )
+
+        #expect(response.events.count == 3)
+    }
+
+    @Test("Will map outgoing transfer correctly")
+    func willMapOutgoingTransfer() async throws {
+        let response: TransferListApiModel = try GetFromFile.getModelFrom(
+            fileName: "ListTransfersResponse",
+            bundle: Bundle.module
+        )
+
+        let walletAddress = "0x1234567890123456789012345678901234567890"
+        let transfer = Transfer.map(response.events[0])
+
+        #expect(transfer.isOutgoing(from: walletAddress) == true)
+        #expect(transfer.isIncoming(to: walletAddress) == false)
+        #expect(transfer.fromAddress == walletAddress)
+        #expect(transfer.toAddress == "0x0987654321098765432109876543210987654321")
+        #expect(transfer.tokenSymbol == "USDC")
+        #expect(transfer.amount == Decimal(string: "10.5"))
+        #expect(transfer.rawAmount == "10.5")
+        #expect(transfer.type == "TRANSFER")
+        #expect(transfer.transactionHash == "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+        #expect(transfer.mintHash == nil)
+    }
+
+    @Test("Will map incoming transfer correctly")
+    func willMapIncomingTransfer() async throws {
+        let response: TransferListApiModel = try GetFromFile.getModelFrom(
+            fileName: "ListTransfersResponse",
+            bundle: Bundle.module
+        )
+
+        let walletAddress = "0x1234567890123456789012345678901234567890"
+        let transfer = Transfer.map(response.events[1])
+
+        #expect(transfer.isOutgoing(from: walletAddress) == false)
+        #expect(transfer.isIncoming(to: walletAddress) == true)
+        #expect(transfer.fromAddress == "0x0987654321098765432109876543210987654321")
+        #expect(transfer.toAddress == walletAddress)
+        #expect(transfer.tokenSymbol == "ETH")
+        #expect(transfer.amount == Decimal(string: "0.05"))
+        #expect(transfer.type == "TRANSFER")
+    }
+
+    @Test("Will map transfer with mint hash (NFT) correctly")
+    func willMapNFTTransfer() async throws {
+        let response: TransferListApiModel = try GetFromFile.getModelFrom(
+            fileName: "ListTransfersResponse",
+            bundle: Bundle.module
+        )
+
+        let transfer = Transfer.map(response.events[2])
+
+        #expect(transfer.type == "NFT_TRANSFER")
+        #expect(transfer.mintHash == "0xnftmintha5h000000000000000000000000000000000000000000000000000")
+        #expect(transfer.tokenSymbol == "USDC")
+        #expect(transfer.amount == Decimal(string: "25.00"))
+    }
+
+    @Test("Will parse timestamp from Unix time")
+    func willParseTimestamp() async throws {
+        let response: TransferListApiModel = try GetFromFile.getModelFrom(
+            fileName: "ListTransfersResponse",
+            bundle: Bundle.module
+        )
+
+        let transfer = Transfer.map(response.events[0])
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        let components = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: transfer.timestamp
+        )
+
+        #expect(components.year == 2024)
+        #expect(components.month == 1)
+        #expect(components.day == 15)
+        #expect(components.hour == 10)
+        #expect(components.minute == 50)
+        #expect(components.second == 0)
+    }
+
+    @Test("Will parse timestamp with fractional seconds")
+    func willParseTimestampWithFractionalSeconds() async throws {
+        let response: TransferListApiModel = try GetFromFile.getModelFrom(
+            fileName: "ListTransfersResponse",
+            bundle: Bundle.module
+        )
+
+        let transfer = Transfer.map(response.events[1])
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        let components = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: transfer.timestamp
+        )
+
+        #expect(components.year == 2024)
+        #expect(components.month == 1)
+        #expect(components.day == 14)
+        #expect(components.hour == 8)
+        #expect(components.minute == 35)
+        #expect(components.second == 30)
+    }
+
+    @Test("TransferListResult pagination helpers work correctly")
+    func transferListResultPaginationHelpers() async throws {
+        let response: TransferListApiModel = try GetFromFile.getModelFrom(
+            fileName: "ListTransfersResponse",
+            bundle: Bundle.module
+        )
+
+        let resultWithNextPage = TransferListResult(
+            transfers: response.events.map { Transfer.map($0) },
+            nextCursor: "some-cursor",
+            previousCursor: nil
+        )
+
+        #expect(resultWithNextPage.hasNextPage == true)
+        #expect(resultWithNextPage.hasPreviousPage == false)
+        #expect(resultWithNextPage.transfers.count == 3)
+
+        let resultWithNoCursors = TransferListResult(
+            transfers: response.events.map { Transfer.map($0) },
+            nextCursor: nil,
+            previousCursor: nil
+        )
+
+        #expect(resultWithNoCursors.hasNextPage == false)
+        #expect(resultWithNoCursors.hasPreviousPage == false)
+    }
+
+    @Test("Transfer is Identifiable with transactionHash as id")
+    func transferIsIdentifiable() async throws {
+        let response: TransferListApiModel = try GetFromFile.getModelFrom(
+            fileName: "ListTransfersResponse",
+            bundle: Bundle.module
+        )
+
+        let transfer = Transfer.map(response.events[0])
+
+        #expect(transfer.id == "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+    }
+}

--- a/Tests/WalletTests/Resources/Transfer/ListTransfersResponse.json
+++ b/Tests/WalletTests/Resources/Transfer/ListTransfersResponse.json
@@ -1,34 +1,96 @@
 {
-  "events": [
+  "data": [
     {
-      "token_symbol": "USDC",
-      "mint_hash": null,
-      "transaction_hash": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-      "to_address": "0x0987654321098765432109876543210987654321",
-      "from_address": "0x1234567890123456789012345678901234567890",
-      "timestamp": 1705315800.0,
-      "amount": "10.5",
-      "type": "TRANSFER"
+      "type": "outgoing",
+      "sender": {
+        "address": "0x1234567890123456789012345678901234567890",
+        "chain": "base-sepolia",
+        "locator": "base-sepolia:0x1234567890123456789012345678901234567890",
+        "owner": "email:user@example.com"
+      },
+      "recipient": {
+        "address": "0x0987654321098765432109876543210987654321",
+        "chain": "base-sepolia",
+        "locator": "base-sepolia:0x0987654321098765432109876543210987654321",
+        "owner": null
+      },
+      "token": {
+        "type": "ft",
+        "chain": "base-sepolia",
+        "locator": "base-sepolia:usdc",
+        "amount": "10.5",
+        "symbol": "USDC",
+        "decimals": 6
+      },
+      "status": "successful",
+      "onChain": {
+        "txId": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        "explorerLink": "https://sepolia.basescan.org/tx/0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+      },
+      "completedAt": "2024-01-15T10:30:00.000Z",
+      "error": null
     },
     {
-      "token_symbol": "ETH",
-      "mint_hash": null,
-      "transaction_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-      "to_address": "0x1234567890123456789012345678901234567890",
-      "from_address": "0x0987654321098765432109876543210987654321",
-      "timestamp": 1705221330.5,
-      "amount": "0.05",
-      "type": "TRANSFER"
+      "type": "incoming",
+      "sender": {
+        "address": "0x0987654321098765432109876543210987654321",
+        "chain": "base-sepolia",
+        "locator": "base-sepolia:0x0987654321098765432109876543210987654321",
+        "owner": null
+      },
+      "recipient": {
+        "address": "0x1234567890123456789012345678901234567890",
+        "chain": "base-sepolia",
+        "locator": "base-sepolia:0x1234567890123456789012345678901234567890",
+        "owner": "email:user@example.com"
+      },
+      "token": {
+        "type": "ft",
+        "chain": "base-sepolia",
+        "locator": "base-sepolia:eth",
+        "amount": "0.05",
+        "symbol": "ETH",
+        "decimals": 18
+      },
+      "status": "successful",
+      "onChain": {
+        "txId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+        "explorerLink": "https://sepolia.basescan.org/tx/0x1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "completedAt": "2024-01-14T08:15:30.500Z",
+      "error": null
     },
     {
-      "token_symbol": "USDC",
-      "mint_hash": "0xnftmintha5h000000000000000000000000000000000000000000000000000",
-      "transaction_hash": "0x2222222222222222222222222222222222222222222222222222222222222222",
-      "to_address": "0x2222222222222222222222222222222222222222",
-      "from_address": "0x1234567890123456789012345678901234567890",
-      "timestamp": 1705147200.0,
-      "amount": "25.00",
-      "type": "NFT_TRANSFER"
+      "type": "outgoing",
+      "sender": {
+        "address": "0x1234567890123456789012345678901234567890",
+        "chain": "base-sepolia",
+        "locator": "base-sepolia:0x1234567890123456789012345678901234567890",
+        "owner": "email:user@example.com"
+      },
+      "recipient": {
+        "address": "0x2222222222222222222222222222222222222222",
+        "chain": "base-sepolia",
+        "locator": "base-sepolia:0x2222222222222222222222222222222222222222",
+        "owner": null
+      },
+      "token": {
+        "type": "ft",
+        "chain": "base-sepolia",
+        "locator": "base-sepolia:usdc",
+        "amount": "25.00",
+        "symbol": "USDC",
+        "decimals": 6
+      },
+      "status": "successful",
+      "onChain": {
+        "txId": "0x3333333333333333333333333333333333333333333333333333333333333333",
+        "explorerLink": "https://sepolia.basescan.org/tx/0x3333333333333333333333333333333333333333333333333333333333333333"
+      },
+      "completedAt": "2024-01-13T14:00:00Z",
+      "error": null
     }
-  ]
+  ],
+  "nextCursor": "eyJsYXN0SWQiOiIxMjM0NTY3ODkwIn0=",
+  "previousCursor": null
 }

--- a/Tests/WalletTests/Resources/Transfer/ListTransfersResponse.json
+++ b/Tests/WalletTests/Resources/Transfer/ListTransfersResponse.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "type": "outgoing",
+      "type": "wallets.transfer.out",
       "sender": {
         "address": "0x1234567890123456789012345678901234567890",
         "chain": "base-sepolia",
@@ -31,7 +31,7 @@
       "error": null
     },
     {
-      "type": "incoming",
+      "type": "wallets.transfer.in",
       "sender": {
         "address": "0x0987654321098765432109876543210987654321",
         "chain": "base-sepolia",
@@ -61,7 +61,7 @@
       "error": null
     },
     {
-      "type": "outgoing",
+      "type": "wallets.transfer.out",
       "sender": {
         "address": "0x1234567890123456789012345678901234567890",
         "chain": "base-sepolia",

--- a/Tests/WalletTests/Resources/Transfer/ListTransfersResponse.json
+++ b/Tests/WalletTests/Resources/Transfer/ListTransfersResponse.json
@@ -1,0 +1,34 @@
+{
+  "events": [
+    {
+      "token_symbol": "USDC",
+      "mint_hash": null,
+      "transaction_hash": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+      "to_address": "0x0987654321098765432109876543210987654321",
+      "from_address": "0x1234567890123456789012345678901234567890",
+      "timestamp": 1705315800.0,
+      "amount": "10.5",
+      "type": "TRANSFER"
+    },
+    {
+      "token_symbol": "ETH",
+      "mint_hash": null,
+      "transaction_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "to_address": "0x1234567890123456789012345678901234567890",
+      "from_address": "0x0987654321098765432109876543210987654321",
+      "timestamp": 1705221330.5,
+      "amount": "0.05",
+      "type": "TRANSFER"
+    },
+    {
+      "token_symbol": "USDC",
+      "mint_hash": "0xnftmintha5h000000000000000000000000000000000000000000000000000",
+      "transaction_hash": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      "to_address": "0x2222222222222222222222222222222222222222",
+      "from_address": "0x1234567890123456789012345678901234567890",
+      "timestamp": 1705147200.0,
+      "amount": "25.00",
+      "type": "NFT_TRANSFER"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request implements the List Transfers API, allowing the SDK to fetch the transfer history of a wallet through the new `listTransfers()` method in the `Wallet` class.

**New public API**

- `Wallet.listTransfers(tokens:)` - Fetches transfer history for specified tokens
- `Transfer` - Model representing a transfer event (sender, recipient, amount, timestamp, transaction hash)
- `TransferListResult` - Result container with transfers array

**Example**

```swift
let result = try await wallet.listTransfers(tokens: [.eth, .usdc])

for transfer in result.transfers {
    if transfer.isOutgoing(from: wallet.address) {
        print("Sent \(transfer.amount) \(transfer.tokenSymbol ?? "")")
    } else {
        print("Received \(transfer.amount) \(transfer.tokenSymbol ?? "")")
    }
}
```

**Demo app**

Added a new "History" tab to SmartWalletsDemo showing transfer history

<p align="center">
  <img src="https://github.com/user-attachments/assets/f3f8d8d2-8581-4c9b-b4f1-b42d4e7ecebf" width="320" />
</p>

<!-- greptile_comment -->

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->