### PR TITLE
Fix UIDevice main actor-isolation errors for Swift 6 strict concurrency

### DIFF
--- a/Sources/Logger/Utils/DeviceInfoCache.swift
+++ b/Sources/Logger/Utils/DeviceInfoCache.swift
@@ -35,11 +35,13 @@ struct DeviceInfoCache: @unchecked Sendable {
                 }
             }
         } else {
-            let work = unsafeBitCast(operation, to: (@Sendable () -> T).self)
-            if Thread.isMainThread {
-                return work()
-            } else {
-                return DispatchQueue.main.sync { work() }
+            return withoutActuallyEscaping(operation) { escapable in
+                let work = unsafeBitCast(escapable, to: (@Sendable () -> T).self)
+                if Thread.isMainThread {
+                    return work()
+                } else {
+                    return DispatchQueue.main.sync { work() }
+                }
             }
         }
     }


### PR DESCRIPTION
# Fix UIDevice main actor-isolation errors for Swift 6 strict concurrency

## Summary

Fixes "Main actor-isolated class property 'current' can not be referenced from a nonisolated context" errors in `DeviceInfoCache.swift`. These occur because `UIDevice.current` is `@MainActor`-isolated in Swift 6, and the previous `nonisolated(unsafe)` annotation on the functions doesn't suppress isolation checking for property accesses *within* the function body.

Replaces the four `nonisolated(unsafe)` helper functions with a single generic `runOnMainActor` helper that:
- **iOS 17+**: Uses `MainActor.assumeIsolated` (Apple's official API for this)
- **iOS 15–16**: Falls back to `unsafeBitCast` to strip the `@MainActor` annotation from the closure, which is safe because the `Thread.isMainThread` / `DispatchQueue.main.sync` guards guarantee main-thread execution

No behavioral changes — UIDevice properties are still always read on the main thread, same as before.

## Review & Testing Checklist for Human

- [ ] **Build in Xcode with Swift 6 strict concurrency** — this was written on a Linux machine without Xcode, so compilation has NOT been verified locally. This is the most important thing to check.
- [ ] **Review `unsafeBitCast` fallback** (line 38) — stripping `@MainActor` from a closure type via `unsafeBitCast` is a widely-used pattern but is technically unsafe. Verify you're comfortable with this for the iOS 15–16 code path.
- [ ] **Run on a device or simulator** and confirm DataDog logs still contain correct device model, name, OS name, and OS version values.

### Notes
- [Link to Devin run](https://crossmint.devinenterprise.com/sessions/a2d48cf35d04416aadaca9defc87e6bc)
- Requested by: @jorge2393
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-swift-sdk/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
