### PR TITLE
Fix Swift 6 actor isolation errors in DeviceInfoCache

### DIFF
--- a/Sources/Logger/Remote/DataDogLoggerProvider.swift
+++ b/Sources/Logger/Remote/DataDogLoggerProvider.swift
@@ -58,15 +58,14 @@ actor DataDogLoggerProvider: LoggerProvider {
     }
 
     private func captureDeviceInfo() async {
-        let info = await MainActor.run {
-            if let cached = Self.cachedDeviceInfo {
-                return cached
-            }
-            let captured = DeviceInfoCache.capture()
-            Self.cachedDeviceInfo = captured
-            return captured
+        if let cached = await MainActor.run(body: { Self.cachedDeviceInfo }) {
+            self.deviceInfo = cached
+            return
         }
-        self.deviceInfo = info
+
+        let captured = await DeviceInfoCache.capture()
+        await MainActor.run { Self.cachedDeviceInfo = captured }
+        self.deviceInfo = captured
     }
 
     // MARK: - LoggerProvider Protocol

--- a/Sources/Logger/Utils/DeviceInfoCache.swift
+++ b/Sources/Logger/Utils/DeviceInfoCache.swift
@@ -155,7 +155,7 @@ struct DeviceInfoCache: Sendable {
     }
     #else
 
-    static func capture() -> DeviceInfoCache {
+    static func capture() async -> DeviceInfoCache {
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         let appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
 

--- a/Sources/Logger/Utils/DeviceInfoCache.swift
+++ b/Sources/Logger/Utils/DeviceInfoCache.swift
@@ -8,11 +8,11 @@
 import Foundation
 import Network
 #if canImport(UIKit)
-@preconcurrency import UIKit
+import UIKit
 import CoreTelephony
 #endif
 
-struct DeviceInfoCache: @unchecked Sendable {
+struct DeviceInfoCache: Sendable {
     let model: String
     let deviceName: String
     let osName: String
@@ -25,36 +25,24 @@ struct DeviceInfoCache: @unchecked Sendable {
     let cellularTechnology: String?
 
     #if canImport(UIKit)
-    private nonisolated(unsafe) static func getDeviceModel() -> String {
-        if Thread.isMainThread {
-            return UIDevice.current.model
-        } else {
-            return DispatchQueue.main.sync { UIDevice.current.model }
-        }
+    @MainActor
+    private static func getDeviceModel() -> String {
+        UIDevice.current.model
     }
 
-    private nonisolated(unsafe) static func getDeviceName() -> String {
-        if Thread.isMainThread {
-            return UIDevice.current.name
-        } else {
-            return DispatchQueue.main.sync { UIDevice.current.name }
-        }
+    @MainActor
+    private static func getDeviceName() -> String {
+        UIDevice.current.name
     }
 
-    private nonisolated(unsafe) static func getOSName() -> String {
-        if Thread.isMainThread {
-            return UIDevice.current.systemName
-        } else {
-            return DispatchQueue.main.sync { UIDevice.current.systemName }
-        }
+    @MainActor
+    private static func getOSName() -> String {
+        UIDevice.current.systemName
     }
 
-    private nonisolated(unsafe) static func getOSVersion() -> String {
-        if Thread.isMainThread {
-            return UIDevice.current.systemVersion
-        } else {
-            return DispatchQueue.main.sync { UIDevice.current.systemVersion }
-        }
+    @MainActor
+    private static func getOSVersion() -> String {
+        UIDevice.current.systemVersion
     }
 
     private static func getOSBuild() -> String {
@@ -141,6 +129,7 @@ struct DeviceInfoCache: @unchecked Sendable {
         }
     }
 
+    @MainActor
     static func capture() -> DeviceInfoCache {
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         let appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
@@ -173,7 +162,9 @@ struct DeviceInfoCache: @unchecked Sendable {
             osBuild: "unknown",
             architecture: "unknown",
             appVersion: appVersion,
-            appBuild: appBuild
+            appBuild: appBuild,
+            networkConnectionType: "unknown",
+            cellularTechnology: nil
         )
     }
     #endif


### PR DESCRIPTION
This pull request fixes an error on DeviceInfoCache which was preventing the SDK from being used in host apps with strict Swift 6 concurrency rules

The issue was that UIDevice, which is a helper class provided by the iOS SDK to get information about the device that the host app is running on, is isolated to the main-thread on Swift 6, meaning that we could only access it on a process that happened in the main-thread. However, since we wanted all our logging operations to run in a background thread, we initially using unchecked and preconcurrency statements to silence the warnings when attempting to access UIDevice, but that ended up resulting in build errors for apps that have set the Swift 6 concurrency ruleset to be strict

To fix this, all methods that access UIDevice have been isolated to the main-thread by adding the @MainActor annotation. The device capture logic has been split so network detection (which blocks briefly with a semaphore) runs on a background thread, while UIDevice access happens on the main actor to avoid blocking the main thread. Device information is fetched once during SDK initialization and cached, so it can be safely accessed on background threads for all subsequent logging operations

## Changes

- **DeviceInfoCache**: Removed `@preconcurrency` and `@unchecked Sendable`, marked UIDevice accessor functions as `@MainActor`, made `capture()` async to avoid main thread blocking
- **DataDogLoggerProvider**: Captures device info asynchronously after init with static caching and fallback defaults
