### PR TITLE
Update swift-secp256k1 library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", exact: "0.18.0"),
+        .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", exact: "0.20.0"),
         .package(url: "https://github.com/airbnb/lottie-spm", from: "4.5.1"),
 //        .package(url: "https://github.com/checkout/checkout-ios-components", exact: "1.2.6"),
         .package(url: "https://github.com/bitflying/SwiftKeccak", exact: "0.1.2"),
@@ -90,7 +90,8 @@ let package = Package(
                 "CrossmintCommonTypes",
                 "SecureStorage",
                 "Passkeys",
-                .product(name: "secp256k1", package: "swift-secp256k1"),
+                .product(name: "P256K", package: "swift-secp256k1"),
+                .product(name: "libsecp256k1", package: "swift-secp256k1"),
                 .product(name: "SwiftKeccak", package: "SwiftKeccak"),
                 .product(name: "BigInt", package: "BigInt"),
                 "Web"

--- a/Sources/Wallet/Data/CreateWallet/Signers/EVMKeyPairSigner.swift
+++ b/Sources/Wallet/Data/CreateWallet/Signers/EVMKeyPairSigner.swift
@@ -1,11 +1,12 @@
 import CrossmintCommonTypes
 import Foundation
-import secp256k1
+import P256K
+import libsecp256k1
 import Security
 import SwiftKeccak
 
-public typealias Secp256k1PrivateKey = secp256k1.Signing.PrivateKey
-public typealias Secp256k1PublicKey = secp256k1.Signing.PublicKey
+public typealias Secp256k1PrivateKey = P256K.Signing.PrivateKey
+public typealias Secp256k1PublicKey = P256K.Signing.PublicKey
 
 // swiftlint:disable:next large_tuple
 private typealias Signature = (r: [UInt8], s: [UInt8], v: UInt)


### PR DESCRIPTION
This pull request updates the installed version of the `21-DOT-DEV/swift-secp256k1` package from `0.18.0` to `0.20.0` in order to use the latest target naming, since the previous one could conflict with other popular crypto libraries

Apart from the updated nomenclature, no existing functionality should be affected. I've ran all unit tests on my local environment and tested fetching wallets, performing and signing and transaction and fetching the list of transactions, which all succeeded