### PR TITLE
Separate getOrCreateWallet into getWallet and createWallet

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Dashboard/DashboardView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Dashboard/DashboardView.swift
@@ -253,14 +253,14 @@ struct DashboardView: View {
 
         do {
             let options = WalletOptions(deviceSigner: DeviceSignerOptions(biometricPolicy: .always))
-            let wallet: Wallet
-            do {
-                wallet = try await sdk.crossmintWallets.getWallet(
-                    chain: .baseSepolia,
-                    signer: .email(email),
-                    options: options
-                )
-            } catch WalletError.walletNotFound {
+            let wallet: EVMWallet
+            if let existing = try await sdk.crossmintWallets.getWallet(
+                chain: .baseSepolia,
+                signer: .email(email),
+                options: options
+            ) {
+                wallet = existing
+            } else {
                 wallet = try await sdk.crossmintWallets.createWallet(
                     chain: .baseSepolia,
                     signer: .email(email),

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Dashboard/DashboardView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Dashboard/DashboardView.swift
@@ -252,11 +252,21 @@ struct DashboardView: View {
         }
 
         do {
-            let wallet = try await sdk.crossmintWallets.getOrCreateWallet(
-                chain: .baseSepolia,
-                signer: .email(email),
-                options: WalletOptions(deviceSigner: DeviceSignerOptions(biometricPolicy: .always))
-            )
+            let options = WalletOptions(deviceSigner: DeviceSignerOptions(biometricPolicy: .always))
+            let wallet: Wallet
+            do {
+                wallet = try await sdk.crossmintWallets.getWallet(
+                    chain: .baseSepolia,
+                    signer: .email(email),
+                    options: options
+                )
+            } catch WalletError.walletNotFound {
+                wallet = try await sdk.crossmintWallets.createWallet(
+                    chain: .baseSepolia,
+                    signer: .email(email),
+                    options: options
+                )
+            }
 
             await MainActor.run {
                 if updateLoadingStatus {

--- a/Examples/SolanaDemo/SolanaDemo/Dashboard/DashboardView.swift
+++ b/Examples/SolanaDemo/SolanaDemo/Dashboard/DashboardView.swift
@@ -240,17 +240,11 @@ struct DashboardView: View {
         }
 
         do {
-            let wallet: Wallet
-            do {
-                wallet = try await sdk.crossmintWallets.getWallet(
-                    chain: .solana,
-                    signer: .email(email)
-                )
-            } catch WalletError.walletNotFound {
-                wallet = try await sdk.crossmintWallets.createWallet(
-                    chain: .solana,
-                    signer: .email(email)
-                )
+            let wallet: SolanaWallet
+            if let existing = try await sdk.crossmintWallets.getWallet(chain: .solana, signer: .email(email)) {
+                wallet = existing
+            } else {
+                wallet = try await sdk.crossmintWallets.createWallet(chain: .solana, signer: .email(email))
             }
             await MainActor.run {
                 if updateLoadingStatus {

--- a/Examples/SolanaDemo/SolanaDemo/Dashboard/DashboardView.swift
+++ b/Examples/SolanaDemo/SolanaDemo/Dashboard/DashboardView.swift
@@ -229,15 +229,29 @@ struct DashboardView: View {
     }
 
     private func obtainOrCreateWallet(_ updateLoadingStatus: Bool = false) async {
-        do {
-            guard let email = await crossmintAuthManager.email else {
-                throw WalletError.walletGeneric("Email not available")
+        guard let email = await crossmintAuthManager.email else {
+            await MainActor.run {
+                if updateLoadingStatus {
+                    creatingWallet = false
+                }
+                showAlert(with: "There was a problem loading the wallet.\nLogout and try again.")
             }
+            return
+        }
 
-            let wallet = try await sdk.crossmintWallets.getOrCreateWallet(
-                chain: .solana,
-                signer: .email(email)
-            )
+        do {
+            let wallet: Wallet
+            do {
+                wallet = try await sdk.crossmintWallets.getWallet(
+                    chain: .solana,
+                    signer: .email(email)
+                )
+            } catch WalletError.walletNotFound {
+                wallet = try await sdk.crossmintWallets.createWallet(
+                    chain: .solana,
+                    signer: .email(email)
+                )
+            }
             await MainActor.run {
                 if updateLoadingStatus {
                     creatingWallet = false

--- a/Sources/DeviceSigner/DeviceSignerOptions.swift
+++ b/Sources/DeviceSigner/DeviceSignerOptions.swift
@@ -15,7 +15,7 @@ import Foundation
 /// by this key silently, without requiring an OTP prompt on the same device.
 ///
 /// ```swift
-/// let wallet = try await crossmint.wallets.getOrCreateWallet(
+/// let wallet = try await crossmint.wallets.getWallet(
 ///     chain: .polygon,
 ///     signer: emailSigner,
 ///     options: WalletOptions(deviceSigner: DeviceSignerOptions(biometricPolicy: .always))

--- a/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
@@ -54,4 +54,15 @@ public protocol DeviceSignerKeyStorage: Sendable {
 
     /// Deletes a pending key that was never mapped to a wallet address.
     func deletePendingKey(publicKeyBase64: String) async throws(DeviceSignerError)
+
+    /// Returns `true` if a pending key identified by `pubKey64` is present on the current device.
+    ///
+    /// A pending key is one that has been generated but not yet mapped to a wallet address via
+    /// ``mapAddressToKey(address:publicKeyBase64:)``. Use this to check whether any of a wallet's
+    /// existing device signers (from the backend) were originally generated on this device before
+    /// their address was known.
+    ///
+    /// - Parameter pubKey64: The raw 64-byte public key (x‖y) encoded as a base64 string.
+    /// - Returns: `true` if a pending key with this public key exists in local storage.
+    func hasKey(pubKey64: String) -> Bool
 }

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -127,6 +127,10 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
         try keychain.delete(tag: tag)
     }
 
+    public func hasKey(pubKey64: String) -> Bool {
+        keychain.load(tag: "crossmint.device.pending.\(pubKey64)") != nil
+    }
+
     // MARK: - Private helpers
 
     private func makeAccessControl() -> SecAccessControl? {

--- a/Sources/DeviceSigner/Storage/SoftwareDeviceSignerKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SoftwareDeviceSignerKeyStorage.swift
@@ -107,6 +107,10 @@ public final class SoftwareDeviceSignerKeyStorage: DeviceSignerKeyStorage {
         try keychain.delete(tag: tag)
     }
 
+    public func hasKey(pubKey64: String) -> Bool {
+        keychain.load(tag: "crossmint.device.pending.\(pubKey64)") != nil
+    }
+
     // MARK: - Private helpers
 
     private func makeAccessControl() -> SecAccessControl? {

--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -354,9 +354,5 @@ public enum LogEvents {
 
     // MARK: - WalletFactory Error Events
 
-    /// Invalid chain error in getWallet
-    public static let walletFactoryGetWalletError = "walletFactory.getWallet.error"
-
-    /// Invalid chain error in createWallet
-    public static let walletFactoryCreateWalletError = "walletFactory.createWallet.error"
+    public static let walletFactoryInvalidChain = "walletFactory.invalidChain"
 }

--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -128,15 +128,6 @@ public enum LogEvents {
 
     // MARK: - Wallet Factory Events
 
-    /// Getting or creating wallet
-    public static let walletGetOrCreateStart = "wallet.getOrCreate.start"
-
-    /// Found existing wallet
-    public static let walletGetOrCreateExisting = "wallet.getOrCreate.existing"
-
-    /// Creating new wallet
-    public static let walletGetOrCreateCreating = "wallet.getOrCreate.creating"
-
     /// Getting wallet
     public static let walletGetStart = "wallet.get.start"
 
@@ -363,9 +354,9 @@ public enum LogEvents {
 
     // MARK: - WalletFactory Error Events
 
-    /// Invalid chain error in getOrCreateWallet
-    public static let walletFactoryGetOrCreateWalletError = "walletFactory.getOrCreateWallet.error"
-
     /// Invalid chain error in getWallet
     public static let walletFactoryGetWalletError = "walletFactory.getWallet.error"
+
+    /// Invalid chain error in createWallet
+    public static let walletFactoryCreateWalletError = "walletFactory.createWallet.error"
 }

--- a/Sources/Wallet/CrossmintWallets.swift
+++ b/Sources/Wallet/CrossmintWallets.swift
@@ -2,20 +2,6 @@ import CrossmintCommonTypes
 import DeviceSigner
 
 public protocol CrossmintWallets: Sendable {
-    @available(*, deprecated, message: "Use getWallet or createWallet instead")
-    func getOrCreateWallet(
-        chain: Chain,
-        signer: any Signer,
-        options: WalletOptions?
-    ) async throws(WalletError) -> Wallet
-
-    @available(*, deprecated, message: "Use getWallet or createWallet instead")
-    func getOrCreateWallet<C: ChainWithSigners>(
-        chain: C,
-        signer: C.SpecificSigner,
-        options: WalletOptions?
-    ) async throws(WalletError) -> Wallet
-
     func getWallet(
         chain: Chain,
         signer: any Signer,
@@ -30,58 +16,6 @@ public protocol CrossmintWallets: Sendable {
 }
 
 extension CrossmintWallets {
-    @available(*, deprecated, message: "Use getWallet or createWallet instead")
-    public func getOrCreateWallet(
-        chain: EVMChain,
-        signer: EVMSigners,
-        options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await getOrCreateWallet(
-            chain: Chain(chain.name),
-            signer: await signer.signer,
-            options: options
-        )
-    }
-
-    @available(*, deprecated, message: "Use getWallet or createWallet instead")
-    public func getOrCreateWallet(
-        chain: SolanaChain,
-        signer: SolanaSigners,
-        options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await getOrCreateWallet(
-            chain: Chain(chain.name),
-            signer: await signer.signer,
-            options: options
-        )
-    }
-
-    @available(*, deprecated, message: "Use getWallet or createWallet instead")
-    public func getOrCreateWallet(
-        chain: StellarChain,
-        signer: StellarSigners,
-        options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await getOrCreateWallet(
-            chain: Chain(chain.name),
-            signer: await signer.signer,
-            options: options
-        )
-    }
-
-    @available(*, deprecated, message: "Use getWallet or createWallet instead")
-    public func getOrCreateWallet<C: ChainWithSigners>(
-        chain: C,
-        signer: C.SpecificSigner,
-        options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await getOrCreateWallet(
-            chain: Chain(chain.name),
-            signer: await signer.signer,
-            options: options
-        )
-    }
-
     // MARK: - getWallet convenience overloads
 
     public func getWallet(

--- a/Sources/Wallet/CrossmintWallets.swift
+++ b/Sources/Wallet/CrossmintWallets.swift
@@ -6,7 +6,7 @@ public protocol CrossmintWallets: Sendable {
         chain: Chain,
         signer: any Signer,
         options: WalletOptions?
-    ) async throws(WalletError) -> Wallet
+    ) async throws(WalletError) -> Wallet?
 
     func createWallet(
         chain: Chain,
@@ -22,48 +22,64 @@ extension CrossmintWallets {
         chain: EVMChain,
         signer: EVMSigners,
         options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await getWallet(
+    ) async throws(WalletError) -> EVMWallet? {
+        guard let wallet = try await getWallet(
             chain: Chain(chain.name),
             signer: await signer.signer,
             options: options
-        )
+        ) else { return nil }
+        guard let evmWallet = wallet as? EVMWallet else {
+            throw WalletError.walletInvalidType("Expected EVMWallet for chain \(chain.name)")
+        }
+        return evmWallet
     }
 
     public func getWallet(
         chain: SolanaChain,
         signer: SolanaSigners,
         options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await getWallet(
+    ) async throws(WalletError) -> SolanaWallet? {
+        guard let wallet = try await getWallet(
             chain: Chain(chain.name),
             signer: await signer.signer,
             options: options
-        )
+        ) else { return nil }
+        guard let solanaWallet = wallet as? SolanaWallet else {
+            throw WalletError.walletInvalidType("Expected SolanaWallet for chain \(chain.name)")
+        }
+        return solanaWallet
     }
 
     public func getWallet(
         chain: StellarChain,
         signer: StellarSigners,
         options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await getWallet(
+    ) async throws(WalletError) -> StellarWallet? {
+        guard let wallet = try await getWallet(
             chain: Chain(chain.name),
             signer: await signer.signer,
             options: options
-        )
+        ) else { return nil }
+        guard let stellarWallet = wallet as? StellarWallet else {
+            throw WalletError.walletInvalidType("Expected StellarWallet for chain \(chain.name)")
+        }
+        return stellarWallet
     }
 
     public func getWallet<C: ChainWithSigners>(
         chain: C,
         signer: C.SpecificSigner,
         options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await getWallet(
+    ) async throws(WalletError) -> C.WalletType? {
+        guard let wallet = try await getWallet(
             chain: Chain(chain.name),
             signer: await signer.signer,
             options: options
-        )
+        ) else { return nil }
+        guard let typed = wallet as? C.WalletType else {
+            throw WalletError.walletInvalidType("Unexpected wallet type for chain \(chain.name)")
+        }
+        return typed
     }
 
     // MARK: - createWallet convenience overloads
@@ -72,48 +88,64 @@ extension CrossmintWallets {
         chain: EVMChain,
         signer: EVMSigners,
         options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await createWallet(
+    ) async throws(WalletError) -> EVMWallet {
+        let wallet = try await createWallet(
             chain: Chain(chain.name),
             signer: await signer.signer,
             options: options
         )
+        guard let evmWallet = wallet as? EVMWallet else {
+            throw WalletError.walletInvalidType("Expected EVMWallet for chain \(chain.name)")
+        }
+        return evmWallet
     }
 
     public func createWallet(
         chain: SolanaChain,
         signer: SolanaSigners,
         options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await createWallet(
+    ) async throws(WalletError) -> SolanaWallet {
+        let wallet = try await createWallet(
             chain: Chain(chain.name),
             signer: await signer.signer,
             options: options
         )
+        guard let solanaWallet = wallet as? SolanaWallet else {
+            throw WalletError.walletInvalidType("Expected SolanaWallet for chain \(chain.name)")
+        }
+        return solanaWallet
     }
 
     public func createWallet(
         chain: StellarChain,
         signer: StellarSigners,
         options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await createWallet(
+    ) async throws(WalletError) -> StellarWallet {
+        let wallet = try await createWallet(
             chain: Chain(chain.name),
             signer: await signer.signer,
             options: options
         )
+        guard let stellarWallet = wallet as? StellarWallet else {
+            throw WalletError.walletInvalidType("Expected StellarWallet for chain \(chain.name)")
+        }
+        return stellarWallet
     }
 
     public func createWallet<C: ChainWithSigners>(
         chain: C,
         signer: C.SpecificSigner,
         options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await createWallet(
+    ) async throws(WalletError) -> C.WalletType {
+        let wallet = try await createWallet(
             chain: Chain(chain.name),
             signer: await signer.signer,
             options: options
         )
+        guard let typed = wallet as? C.WalletType else {
+            throw WalletError.walletInvalidType("Unexpected wallet type for chain \(chain.name)")
+        }
+        return typed
     }
 }
 

--- a/Sources/Wallet/CrossmintWallets.swift
+++ b/Sources/Wallet/CrossmintWallets.swift
@@ -2,13 +2,14 @@ import CrossmintCommonTypes
 import DeviceSigner
 
 public protocol CrossmintWallets: Sendable {
-    @available(*, deprecated, message: "Use type-safe getOrCreateWallet methods with EVMSigners or SolanaSigners")
+    @available(*, deprecated, message: "Use getWallet or createWallet instead")
     func getOrCreateWallet(
         chain: Chain,
         signer: any Signer,
         options: WalletOptions?
     ) async throws(WalletError) -> Wallet
 
+    @available(*, deprecated, message: "Use getWallet or createWallet instead")
     func getOrCreateWallet<C: ChainWithSigners>(
         chain: C,
         signer: C.SpecificSigner,
@@ -29,6 +30,7 @@ public protocol CrossmintWallets: Sendable {
 }
 
 extension CrossmintWallets {
+    @available(*, deprecated, message: "Use getWallet or createWallet instead")
     public func getOrCreateWallet(
         chain: EVMChain,
         signer: EVMSigners,
@@ -41,6 +43,7 @@ extension CrossmintWallets {
         )
     }
 
+    @available(*, deprecated, message: "Use getWallet or createWallet instead")
     public func getOrCreateWallet(
         chain: SolanaChain,
         signer: SolanaSigners,
@@ -53,6 +56,7 @@ extension CrossmintWallets {
         )
     }
 
+    @available(*, deprecated, message: "Use getWallet or createWallet instead")
     public func getOrCreateWallet(
         chain: StellarChain,
         signer: StellarSigners,
@@ -65,6 +69,7 @@ extension CrossmintWallets {
         )
     }
 
+    @available(*, deprecated, message: "Use getWallet or createWallet instead")
     public func getOrCreateWallet<C: ChainWithSigners>(
         chain: C,
         signer: C.SpecificSigner,

--- a/Sources/Wallet/CrossmintWallets.swift
+++ b/Sources/Wallet/CrossmintWallets.swift
@@ -14,6 +14,18 @@ public protocol CrossmintWallets: Sendable {
         signer: C.SpecificSigner,
         options: WalletOptions?
     ) async throws(WalletError) -> Wallet
+
+    func getWallet(
+        chain: Chain,
+        signer: any Signer,
+        options: WalletOptions?
+    ) async throws(WalletError) -> Wallet
+
+    func createWallet(
+        chain: Chain,
+        signer: any Signer,
+        options: WalletOptions?
+    ) async throws(WalletError) -> Wallet
 }
 
 extension CrossmintWallets {
@@ -59,6 +71,106 @@ extension CrossmintWallets {
         options: WalletOptions? = nil
     ) async throws(WalletError) -> Wallet {
         try await getOrCreateWallet(
+            chain: Chain(chain.name),
+            signer: await signer.signer,
+            options: options
+        )
+    }
+
+    // MARK: - getWallet convenience overloads
+
+    public func getWallet(
+        chain: EVMChain,
+        signer: EVMSigners,
+        options: WalletOptions? = nil
+    ) async throws(WalletError) -> Wallet {
+        try await getWallet(
+            chain: Chain(chain.name),
+            signer: await signer.signer,
+            options: options
+        )
+    }
+
+    public func getWallet(
+        chain: SolanaChain,
+        signer: SolanaSigners,
+        options: WalletOptions? = nil
+    ) async throws(WalletError) -> Wallet {
+        try await getWallet(
+            chain: Chain(chain.name),
+            signer: await signer.signer,
+            options: options
+        )
+    }
+
+    public func getWallet(
+        chain: StellarChain,
+        signer: StellarSigners,
+        options: WalletOptions? = nil
+    ) async throws(WalletError) -> Wallet {
+        try await getWallet(
+            chain: Chain(chain.name),
+            signer: await signer.signer,
+            options: options
+        )
+    }
+
+    public func getWallet<C: ChainWithSigners>(
+        chain: C,
+        signer: C.SpecificSigner,
+        options: WalletOptions? = nil
+    ) async throws(WalletError) -> Wallet {
+        try await getWallet(
+            chain: Chain(chain.name),
+            signer: await signer.signer,
+            options: options
+        )
+    }
+
+    // MARK: - createWallet convenience overloads
+
+    public func createWallet(
+        chain: EVMChain,
+        signer: EVMSigners,
+        options: WalletOptions? = nil
+    ) async throws(WalletError) -> Wallet {
+        try await createWallet(
+            chain: Chain(chain.name),
+            signer: await signer.signer,
+            options: options
+        )
+    }
+
+    public func createWallet(
+        chain: SolanaChain,
+        signer: SolanaSigners,
+        options: WalletOptions? = nil
+    ) async throws(WalletError) -> Wallet {
+        try await createWallet(
+            chain: Chain(chain.name),
+            signer: await signer.signer,
+            options: options
+        )
+    }
+
+    public func createWallet(
+        chain: StellarChain,
+        signer: StellarSigners,
+        options: WalletOptions? = nil
+    ) async throws(WalletError) -> Wallet {
+        try await createWallet(
+            chain: Chain(chain.name),
+            signer: await signer.signer,
+            options: options
+        )
+    }
+
+    public func createWallet<C: ChainWithSigners>(
+        chain: C,
+        signer: C.SpecificSigner,
+        options: WalletOptions? = nil
+    ) async throws(WalletError) -> Wallet {
+        try await createWallet(
             chain: Chain(chain.name),
             signer: await signer.signer,
             options: options

--- a/Sources/Wallet/Data/CreateWallet/Signers/ChainWithSigners.swift
+++ b/Sources/Wallet/Data/CreateWallet/Signers/ChainWithSigners.swift
@@ -14,18 +14,22 @@ import CrossmintCommonTypes
 /// requiring separate method overloads per chain type.
 public protocol ChainWithSigners: SpecificChain {
     associatedtype SpecificSigner: SignerProvider
+    associatedtype WalletType: Wallet
 }
 
 // MARK: - Chain Conformances
 
 extension EVMChain: ChainWithSigners {
     public typealias SpecificSigner = EVMSigners
+    public typealias WalletType = EVMWallet
 }
 
 extension SolanaChain: ChainWithSigners {
     public typealias SpecificSigner = SolanaSigners
+    public typealias WalletType = SolanaWallet
 }
 
 extension StellarChain: ChainWithSigners {
     public typealias SpecificSigner = StellarSigners
+    public typealias WalletType = StellarWallet
 }

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -24,7 +24,7 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
         signer: any Signer,
         options: WalletOptions? = nil
     ) async throws(WalletError) -> Wallet? {
-        guard isValid(chain: chain) else {
+        guard isValid(chain) else {
             Logger.smartWallet.error(LogEvents.walletFactoryGetWalletError, attributes: [
                 "error": "The chain \(chain.name) is not supported for the current environment"
             ])
@@ -80,7 +80,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
         signer: any Signer,
         options: WalletOptions? = nil
     ) async throws(WalletError) -> Wallet {
-        guard isValid(chain: chain) else {
+        guard isValid(chain) else {
             let errorMessage = "The chain \(chain.name) is not supported for the current environment"
             Logger.smartWallet.error(LogEvents.walletFactoryCreateWalletError, attributes: [
                 "error": errorMessage
@@ -119,7 +119,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
         return wallet
     }
 
-    private func isValid(chain: AnyChain) -> Bool {
+    private func isValid(_ chain: AnyChain) -> Bool {
         chain.isValid(isProductionEnvironment: smartWalletService.isProductionEnvironment)
     }
 
@@ -273,7 +273,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
                 deviceSignerKeyStorage: deviceSignerStorage
             )
         case .unknown:
-            throw .walletGeneric("Unknown wallet chain")
+            throw .walletGeneric("Unknown wallet chain: \(chain.rawValue)")
         }
     }
 

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -273,7 +273,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
                 deviceSignerKeyStorage: deviceSignerStorage
             )
         case .unknown:
-            throw .walletGeneric("Unknown wallet chain: \(chain.rawValue)")
+            throw .walletGeneric("Unknown wallet chain: \(chain.name)")
         }
     }
 

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -26,11 +26,10 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
         options: WalletOptions? = nil
     ) async throws(WalletError) -> Wallet {
         guard isValid(chain: chain) else {
-            let errorMessage = "The chain \(chain.name) is not supported for the current environment"
             Logger.smartWallet.error(LogEvents.walletFactoryGetWalletError, attributes: [
-                "error": errorMessage
+                "error": "The chain \(chain.name) is not supported for the current environment"
             ])
-            throw WalletError.walletCreationFailed(errorMessage)
+            throw WalletError.invalidChain(chain: chain)
         }
 
         Logger.smartWallet.debug(LogEvents.walletGetStart, attributes: [

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -5,7 +5,6 @@ import DeviceSigner
 import Logger
 import SecureStorage
 
-// swiftlint:disable:next type_body_length
 public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
     private let smartWalletService: SmartWalletService
     private let secureWalletStorage: SecureWalletStorage
@@ -18,126 +17,6 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
         self.secureWalletStorage = secureWalletStorage
 
         Logger.smartWallet.info(LogEvents.sdkInitialized)
-    }
-
-    // swiftlint:disable:next function_body_length
-    public func getOrCreateWallet(
-        chain: Chain,
-        signer: any Signer,
-        options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        guard isValid(chain: chain) else {
-            let errorMessage = "The chain \(chain.name) is not supported for the current environment"
-            Logger.smartWallet.error(LogEvents.walletFactoryGetOrCreateWalletError, attributes: [
-                "error": errorMessage
-            ])
-            throw WalletError.walletCreationFailed(errorMessage)
-        }
-
-        Logger.smartWallet.debug(LogEvents.walletGetOrCreateStart, attributes: [
-            "chain": chain.name,
-            "signerType": signer.signerType.rawValue
-        ])
-
-        let deviceSignerStorage = makeDeviceSignerStorage(options: options)
-
-        let walletApiModel: WalletApiModel
-        do {
-            walletApiModel = try await smartWalletService.getWallet(GetMeWalletRequest(chainType: chain.chainType))
-            let signers = walletApiModel.config.delegatedSigners?.compactMap(\.locator) ?? []
-            let existingDelegatedLocators = signers.isEmpty ? "none" : signers.joined(separator: ", ")
-            Logger.smartWallet.debug(LogEvents.walletGetOrCreateExisting, attributes: [
-                "chain": chain.name,
-                "address": walletApiModel.address,
-                "delegatedSigners": existingDelegatedLocators
-            ])
-
-            // Existing wallet: register device signer if not yet present or not registered on backend
-            if let storage = deviceSignerStorage {
-                let existingPublicKeyBase64 = await storage.getKey(address: walletApiModel.address)
-                let isRegistered = isDeviceSignerRegistered(existingPublicKeyBase64, in: walletApiModel)
-                if !isRegistered {
-                    Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerStart, attributes: [
-                        "address": walletApiModel.address
-                    ])
-                    var publicKeyBase64: String?
-                    do {
-                        let key: String
-                        if let existing = existingPublicKeyBase64 {
-                            key = existing
-                        } else {
-                            key = try await storage.generateKey(address: nil)
-                        }
-                        publicKeyBase64 = key
-                        let entry = try makeDelegatedSignerEntry(publicKeyBase64: key)
-                        let registration = try await smartWalletService.addDelegatedSigner(
-                            entry, chainType: chain.chainType, chainName: chain.name
-                        )
-                        if let chainEntry = registration.chains?[chain.name],
-                           chainEntry.status == "awaiting-approval",
-                           let signatureId = chainEntry.id,
-                           let pending = chainEntry.approvals?.pending, !pending.isEmpty {
-                            try await approveDelegatedSignerRegistration(
-                                signatureId: signatureId,
-                                pendingApprovals: pending,
-                                signer: signer,
-                                chainType: chain.chainType
-                            )
-                        }
-                        // Only rename if we generated a new pending key; existing keys are already under wallet tag
-                        if existingPublicKeyBase64 == nil {
-                            try await storage.mapAddressToKey(
-                                address: walletApiModel.address,
-                                publicKeyBase64: key
-                            )
-                        }
-                        Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerSuccess, attributes: [
-                            "address": walletApiModel.address
-                        ])
-                    } catch {
-                        if existingPublicKeyBase64 == nil, let publicKeyBase64 {
-                            try? await storage.deletePendingKey(publicKeyBase64: publicKeyBase64)
-                        }
-                        Logger.smartWallet.warn(LogEvents.walletAddDelegatedSignerError, attributes: [
-                            "error": "\(error)"
-                        ])
-                        // Device signer registration failed — continue without it
-                    }
-                }
-            }
-        } catch WalletError.walletNotFound {
-            Logger.smartWallet.debug(LogEvents.walletGetOrCreateCreating, attributes: [
-                "chain": chain.name
-            ])
-            walletApiModel = try await createWalletApiModel(
-                signer: signer,
-                chainType: chain.chainType,
-                walletType: .smart,
-                options: options,
-                deviceSignerStorage: deviceSignerStorage
-            )
-        }
-
-        let wallet = try buildWallet(
-            from: walletApiModel,
-            chain: chain,
-            signer: signer,
-            options: options,
-            deviceSignerStorage: deviceSignerStorage
-        )
-
-        do {
-            try await (signer as? any EmailSigner)?.load()
-        } catch {
-            Logger.smartWallet.warn(
-                """
-There was an error initializing the Email signer. \(error.errorDescription)
-Review if the .crossmintEnvironmentObject modifier is used as expected.
-"""
-            )
-        }
-
-        return wallet
     }
 
     // swiftlint:disable:next function_body_length
@@ -222,7 +101,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
     ) async throws(WalletError) -> Wallet {
         guard isValid(chain: chain) else {
             let errorMessage = "The chain \(chain.name) is not supported for the current environment"
-            Logger.smartWallet.error(LogEvents.walletFactoryGetOrCreateWalletError, attributes: [
+            Logger.smartWallet.error(LogEvents.walletFactoryCreateWalletError, attributes: [
                 "error": errorMessage
             ])
             throw WalletError.walletCreationFailed(errorMessage)

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -24,12 +24,7 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
         signer: any Signer,
         options: WalletOptions? = nil
     ) async throws(WalletError) -> Wallet? {
-        guard isValid(chain) else {
-            Logger.smartWallet.error(LogEvents.walletFactoryGetWalletError, attributes: [
-                "error": "The chain \(chain.name) is not supported for the current environment"
-            ])
-            throw WalletError.invalidChain(chain: chain)
-        }
+        try assertValid(chain)
 
         Logger.smartWallet.debug(LogEvents.walletGetStart, attributes: [
             "chain": chain.name,
@@ -80,13 +75,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
         signer: any Signer,
         options: WalletOptions? = nil
     ) async throws(WalletError) -> Wallet {
-        guard isValid(chain) else {
-            let errorMessage = "The chain \(chain.name) is not supported for the current environment"
-            Logger.smartWallet.error(LogEvents.walletFactoryCreateWalletError, attributes: [
-                "error": errorMessage
-            ])
-            throw WalletError.walletCreationFailed(errorMessage)
-        }
+        try assertValid(chain)
 
         let deviceSignerStorage = makeDeviceSignerStorage(options: options)
         let walletApiModel = try await createWalletApiModel(
@@ -117,6 +106,15 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
         }
 
         return wallet
+    }
+
+    private func assertValid(_ chain: Chain) throws(WalletError) {
+        guard isValid(chain) else {
+            Logger.smartWallet.error(LogEvents.walletFactoryInvalidChain, attributes: [
+                "error": "The chain \(chain.name) is not supported for the current environment"
+            ])
+            throw WalletError.invalidChain(chain: chain)
+        }
     }
 
     private func isValid(_ chain: AnyChain) -> Bool {

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -19,12 +19,11 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
         Logger.smartWallet.info(LogEvents.sdkInitialized)
     }
 
-    // swiftlint:disable:next function_body_length
     public func getWallet(
         chain: Chain,
         signer: any Signer,
         options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
+    ) async throws(WalletError) -> Wallet? {
         guard isValid(chain: chain) else {
             Logger.smartWallet.error(LogEvents.walletFactoryGetWalletError, attributes: [
                 "error": "The chain \(chain.name) is not supported for the current environment"
@@ -38,37 +37,20 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
         ])
 
         let deviceSignerStorage = makeDeviceSignerStorage(options: options)
-        let walletApiModel = try await smartWalletService.getWallet(GetMeWalletRequest(chainType: chain.chainType))
+        let walletApiModel: WalletApiModel
+        do {
+            walletApiModel = try await smartWalletService.getWallet(GetMeWalletRequest(chainType: chain.chainType))
+        } catch WalletError.walletNotFound {
+            return nil
+        }
 
         Logger.smartWallet.debug(LogEvents.walletGetSuccess, attributes: [
             "chain": chain.name,
             "address": walletApiModel.address
         ])
 
-        // Device signer assignment flow for getWallet
         if let storage = deviceSignerStorage {
-            let existingPublicKeyBase64 = await storage.getKey(address: walletApiModel.address)
-
-            // Step 1: Check if device signer is already assigned to this wallet address
-            if !isDeviceSignerRegistered(existingPublicKeyBase64, in: walletApiModel) {
-                // Step 2: Check if any of the wallet's existing device signers are on this device (pending keys)
-                if let matchingPubKey = findMatchingDeviceSignerKey(in: walletApiModel, storage: storage) {
-                    do {
-                        try await storage.mapAddressToKey(
-                            address: walletApiModel.address,
-                            publicKeyBase64: matchingPubKey
-                        )
-                        Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerSuccess, attributes: [
-                            "address": walletApiModel.address
-                        ])
-                    } catch {
-                        Logger.smartWallet.warn(LogEvents.walletAddDelegatedSignerError, attributes: [
-                            "error": "\(error)"
-                        ])
-                    }
-                }
-                // Step 3: No matching key found — deferred to first transaction (handled by Wallet)
-            }
+            await assignPendingDeviceSignerKey(storage: storage, walletApiModel: walletApiModel)
         }
 
         let wallet = try buildWallet(
@@ -292,6 +274,29 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
             )
         case .unknown:
             throw .walletGeneric("Unknown wallet chain")
+        }
+    }
+
+    private func assignPendingDeviceSignerKey(
+        storage: any DeviceSignerKeyStorage,
+        walletApiModel: WalletApiModel
+    ) async {
+        let existingPublicKeyBase64 = await storage.getKey(address: walletApiModel.address)
+        guard !isDeviceSignerRegistered(existingPublicKeyBase64, in: walletApiModel) else { return }
+        guard let deviceSignerPendingAssignment = findMatchingDeviceSignerKey(in: walletApiModel, storage: storage) else { return }
+
+        do {
+            try await storage.mapAddressToKey(
+                address: walletApiModel.address,
+                publicKeyBase64: deviceSignerPendingAssignment
+            )
+            Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerSuccess, attributes: [
+                "address": walletApiModel.address
+            ])
+        } catch {
+            Logger.smartWallet.warn(LogEvents.walletAddDelegatedSignerError, attributes: [
+                "error": "\(error)"
+            ])
         }
     }
 

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -5,6 +5,7 @@ import DeviceSigner
 import Logger
 import SecureStorage
 
+// swiftlint:disable:next type_body_length
 public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
     private let smartWalletService: SmartWalletService
     private let secureWalletStorage: SecureWalletStorage
@@ -19,7 +20,7 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
         Logger.smartWallet.info(LogEvents.sdkInitialized)
     }
 
-    // swiftlint:disable:next function_body_length cyclomatic_complexity
+    // swiftlint:disable:next function_body_length
     public func getOrCreateWallet(
         chain: Chain,
         signer: any Signer,
@@ -108,7 +109,7 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
             Logger.smartWallet.debug(LogEvents.walletGetOrCreateCreating, attributes: [
                 "chain": chain.name
             ])
-            walletApiModel = try await createWallet(
+            walletApiModel = try await createWalletApiModel(
                 signer: signer,
                 chainType: chain.chainType,
                 walletType: .smart,
@@ -117,50 +118,132 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
             )
         }
 
-        let wallet: Wallet
-        switch walletApiModel.chainType {
-        case .evm:
-            guard let evmChain: EVMChain = EVMChain(chain.name) else {
-                throw WalletError.walletInvalidType("The wallet received is not compatible with EVM")
-            }
+        let wallet = try buildWallet(
+            from: walletApiModel,
+            chain: chain,
+            signer: signer,
+            options: options,
+            deviceSignerStorage: deviceSignerStorage
+        )
 
-            wallet = try EVMWallet(
-                smartWalletService: smartWalletService,
-                signer: signer,
-                baseModel: walletApiModel,
-                evmChain: evmChain,
-                onTransactionStart: options?.experimentalCallbacks?.onTransactionStart,
-                deviceSignerKeyStorage: deviceSignerStorage
+        do {
+            try await (signer as? any EmailSigner)?.load()
+        } catch {
+            Logger.smartWallet.warn(
+                """
+There was an error initializing the Email signer. \(error.errorDescription)
+Review if the .crossmintEnvironmentObject modifier is used as expected.
+"""
             )
-        case .solana:
-            guard let solanaChain: SolanaChain = SolanaChain(chain.name) else {
-                throw WalletError.walletInvalidType("The wallet received is not compatible with Solana")
-            }
-
-            wallet = try SolanaWallet(
-                smartWalletService: smartWalletService,
-                signer: signer,
-                baseModel: walletApiModel,
-                solanaChain: solanaChain,
-                onTransactionStart: options?.experimentalCallbacks?.onTransactionStart,
-                deviceSignerKeyStorage: deviceSignerStorage
-            )
-        case .stellar:
-            guard let stellarChain: StellarChain = StellarChain(chain.name) else {
-                throw WalletError.walletInvalidType("The wallet received is not compatible with Stellar")
-            }
-
-            wallet = try StellarWallet(
-                smartWalletService: smartWalletService,
-                signer: signer,
-                baseModel: walletApiModel,
-                stellarChain: stellarChain,
-                onTransactionStart: options?.experimentalCallbacks?.onTransactionStart,
-                deviceSignerKeyStorage: deviceSignerStorage
-            )
-        case .unknown:
-            throw .walletGeneric("Unknown wallet chain")
         }
+
+        return wallet
+    }
+
+    // swiftlint:disable:next function_body_length
+    public func getWallet(
+        chain: Chain,
+        signer: any Signer,
+        options: WalletOptions? = nil
+    ) async throws(WalletError) -> Wallet {
+        guard isValid(chain: chain) else {
+            let errorMessage = "The chain \(chain.name) is not supported for the current environment"
+            Logger.smartWallet.error(LogEvents.walletFactoryGetWalletError, attributes: [
+                "error": errorMessage
+            ])
+            throw WalletError.walletCreationFailed(errorMessage)
+        }
+
+        Logger.smartWallet.debug(LogEvents.walletGetStart, attributes: [
+            "chain": chain.name,
+            "signerType": signer.signerType.rawValue
+        ])
+
+        let deviceSignerStorage = makeDeviceSignerStorage(options: options)
+        let walletApiModel = try await smartWalletService.getWallet(GetMeWalletRequest(chainType: chain.chainType))
+
+        Logger.smartWallet.debug(LogEvents.walletGetSuccess, attributes: [
+            "chain": chain.name,
+            "address": walletApiModel.address
+        ])
+
+        // Device signer assignment flow for getWallet
+        if let storage = deviceSignerStorage {
+            let existingPublicKeyBase64 = await storage.getKey(address: walletApiModel.address)
+
+            // Step 1: Check if device signer is already assigned to this wallet address
+            if !isDeviceSignerRegistered(existingPublicKeyBase64, in: walletApiModel) {
+                // Step 2: Check if any of the wallet's existing device signers are on this device (pending keys)
+                if let matchingPubKey = findMatchingDeviceSignerKey(in: walletApiModel, storage: storage) {
+                    do {
+                        try await storage.mapAddressToKey(
+                            address: walletApiModel.address,
+                            publicKeyBase64: matchingPubKey
+                        )
+                        Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerSuccess, attributes: [
+                            "address": walletApiModel.address
+                        ])
+                    } catch {
+                        Logger.smartWallet.warn(LogEvents.walletAddDelegatedSignerError, attributes: [
+                            "error": "\(error)"
+                        ])
+                    }
+                }
+                // Step 3: No matching key found — deferred to first transaction (handled by Wallet)
+            }
+        }
+
+        let wallet = try buildWallet(
+            from: walletApiModel,
+            chain: chain,
+            signer: signer,
+            options: options,
+            deviceSignerStorage: deviceSignerStorage
+        )
+
+        do {
+            try await (signer as? any EmailSigner)?.load()
+        } catch {
+            Logger.smartWallet.warn(
+                """
+There was an error initializing the Email signer. \(error.errorDescription)
+Review if the .crossmintEnvironmentObject modifier is used as expected.
+"""
+            )
+        }
+
+        return wallet
+    }
+
+    public func createWallet(
+        chain: Chain,
+        signer: any Signer,
+        options: WalletOptions? = nil
+    ) async throws(WalletError) -> Wallet {
+        guard isValid(chain: chain) else {
+            let errorMessage = "The chain \(chain.name) is not supported for the current environment"
+            Logger.smartWallet.error(LogEvents.walletFactoryGetOrCreateWalletError, attributes: [
+                "error": errorMessage
+            ])
+            throw WalletError.walletCreationFailed(errorMessage)
+        }
+
+        let deviceSignerStorage = makeDeviceSignerStorage(options: options)
+        let walletApiModel = try await createWalletApiModel(
+            signer: signer,
+            chainType: chain.chainType,
+            walletType: .smart,
+            options: options,
+            deviceSignerStorage: deviceSignerStorage
+        )
+
+        let wallet = try buildWallet(
+            from: walletApiModel,
+            chain: chain,
+            signer: signer,
+            options: options,
+            deviceSignerStorage: deviceSignerStorage
+        )
 
         do {
             try await (signer as? any EmailSigner)?.load()
@@ -205,7 +288,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
     }
 
     // swiftlint:disable:next function_body_length
-    private func createWallet(
+    private func createWalletApiModel(
         signer: any Signer,
         chainType: ChainType,
         walletType: WalletType,
@@ -283,6 +366,76 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
             ])
             throw error
         }
+    }
+
+    private func buildWallet(
+        from walletApiModel: WalletApiModel,
+        chain: Chain,
+        signer: any Signer,
+        options: WalletOptions?,
+        deviceSignerStorage: (any DeviceSignerKeyStorage)?
+    ) throws(WalletError) -> Wallet {
+        switch walletApiModel.chainType {
+        case .evm:
+            guard let evmChain: EVMChain = EVMChain(chain.name) else {
+                throw WalletError.walletInvalidType("The wallet received is not compatible with EVM")
+            }
+            return try EVMWallet(
+                smartWalletService: smartWalletService,
+                signer: signer,
+                baseModel: walletApiModel,
+                evmChain: evmChain,
+                onTransactionStart: options?.experimentalCallbacks?.onTransactionStart,
+                deviceSignerKeyStorage: deviceSignerStorage
+            )
+        case .solana:
+            guard let solanaChain: SolanaChain = SolanaChain(chain.name) else {
+                throw WalletError.walletInvalidType("The wallet received is not compatible with Solana")
+            }
+            return try SolanaWallet(
+                smartWalletService: smartWalletService,
+                signer: signer,
+                baseModel: walletApiModel,
+                solanaChain: solanaChain,
+                onTransactionStart: options?.experimentalCallbacks?.onTransactionStart,
+                deviceSignerKeyStorage: deviceSignerStorage
+            )
+        case .stellar:
+            guard let stellarChain: StellarChain = StellarChain(chain.name) else {
+                throw WalletError.walletInvalidType("The wallet received is not compatible with Stellar")
+            }
+            return try StellarWallet(
+                smartWalletService: smartWalletService,
+                signer: signer,
+                baseModel: walletApiModel,
+                stellarChain: stellarChain,
+                onTransactionStart: options?.experimentalCallbacks?.onTransactionStart,
+                deviceSignerKeyStorage: deviceSignerStorage
+            )
+        case .unknown:
+            throw .walletGeneric("Unknown wallet chain")
+        }
+    }
+
+    /// Searches the wallet's delegated signers for a pending device key stored on this device.
+    ///
+    /// Returns the 64-byte raw public key (base64-encoded) of the first matching pending key,
+    /// or `nil` if none are found.
+    private func findMatchingDeviceSignerKey(
+        in wallet: WalletApiModel,
+        storage: any DeviceSignerKeyStorage
+    ) -> String? {
+        guard let delegatedSigners = wallet.config.delegatedSigners else { return nil }
+        for entry in delegatedSigners {
+            guard let locator = entry.locator, locator.hasPrefix("device:") else { continue }
+            let b64 = String(locator.dropFirst("device:".count))
+            guard let data = Data(base64Encoded: b64), data.count == 65, data.first == 0x04 else { continue }
+            let pubKey64 = data.dropFirst().base64EncodedString()
+            if storage.hasKey(pubKey64: pubKey64) {
+                return pubKey64
+            }
+        }
+        return nil
     }
 
     private func makeDeviceSignerStorage(options: WalletOptions?) -> (any DeviceSignerKeyStorage)? {

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -339,6 +339,7 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
         ])
 
         var publicKeyBase64: String?
+        var registeredOnBackend = false
         do {
             let pubKey = try await storage.generateKey(address: nil)
             publicKeyBase64 = pubKey
@@ -354,6 +355,7 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
                 chainType: chain.chainType,
                 chainName: chain.name
             )
+            registeredOnBackend = true
 
             if let chainEntry = registration.chains?[chain.name],
                chainEntry.status == "awaiting-approval",
@@ -378,7 +380,7 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
                 "address": address
             ])
         } catch {
-            if let pubKey = publicKeyBase64 {
+            if let pubKey = publicKeyBase64, !registeredOnBackend {
                 try? await storage.deletePendingKey(publicKeyBase64: pubKey)
             }
             Logger.smartWallet.warn(LogEvents.walletAddDelegatedSignerError, attributes: [

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import CrossmintCommonTypes
 import DeviceSigner
 import Foundation
@@ -324,6 +325,68 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
         }
     }
 
+    /// Lazily registers a new device signer if one is configured but no key exists for this wallet address.
+    ///
+    /// Called before the first transfer transaction so the device signer is in place when the
+    /// backend routes the transaction through it. Best-effort: any error is logged and the
+    /// wallet continues without a device signer.
+    internal func ensureDeviceSignerRegistered() async {
+        guard let storage = deviceSignerKeyStorage,
+              await storage.getKey(address: address) == nil else { return }
+
+        Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerStart, attributes: [
+            "address": address
+        ])
+
+        var publicKeyBase64: String?
+        do {
+            let pubKey = try await storage.generateKey(address: nil)
+            publicKeyBase64 = pubKey
+
+            guard let rawPublicKey = Data(base64Encoded: pubKey), rawPublicKey.count == 64 else {
+                throw DeviceSignerError.keyGenerationFailed
+            }
+            let uncompressed = Data([0x04]) + rawPublicKey
+            let entry = DelegatedSignerEntry(signer: "device:\(uncompressed.base64EncodedString())")
+
+            let registration = try await smartWalletService.addDelegatedSigner(
+                entry,
+                chainType: chain.chainType,
+                chainName: chain.name
+            )
+
+            if let chainEntry = registration.chains?[chain.name],
+               chainEntry.status == "awaiting-approval",
+               let signatureId = chainEntry.id,
+               let pending = chainEntry.approvals?.pending, !pending.isEmpty {
+                let updatedSigner = await updateSignerIfRequired()
+                try await updatedSigner.initialize(smartWalletService)
+                for approval in pending {
+                    let signRequest = SignRequestApi(
+                        approvals: try await updatedSigner.approvals(
+                            withSignature: try await updatedSigner.sign(message: approval.message)
+                        )
+                    )
+                    try await smartWalletService.approveSignature(
+                        .init(transactionId: signatureId, apiRequest: signRequest, chainType: chain.chainType)
+                    )
+                }
+            }
+
+            try await storage.mapAddressToKey(address: address, publicKeyBase64: pubKey)
+            Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerSuccess, attributes: [
+                "address": address
+            ])
+        } catch {
+            if let pubKey = publicKeyBase64 {
+                try? await storage.deletePendingKey(publicKeyBase64: pubKey)
+            }
+            Logger.smartWallet.warn(LogEvents.walletAddDelegatedSignerError, attributes: [
+                "error": "\(error)"
+            ])
+        }
+    }
+
     private func deviceSignerLocator() async -> String? {
         guard let storage = deviceSignerKeyStorage,
               let publicKeyBase64 = await storage.getKey(address: address),
@@ -340,6 +403,7 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
         idempotencyKey: String? = nil
     ) async throws(TransactionError) -> Transaction? {
         onTransactionStart?()
+        await ensureDeviceSignerRegistered()
         let signerLocator = await deviceSignerLocator()
         let createdTransaction = try await smartWalletService.transferToken(
             chainType: chain.chainType.rawValue,
@@ -413,7 +477,7 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
         return transaction
     }
 
-    // swiftlint:disable:next function_body_length
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     private func approveTransaction(
         transactionId: String,
         signerLocator: String,

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -357,23 +357,7 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
             )
             registeredOnBackend = true
 
-            if let chainEntry = registration.chains?[chain.name],
-               chainEntry.status == "awaiting-approval",
-               let signatureId = chainEntry.id,
-               let pending = chainEntry.approvals?.pending, !pending.isEmpty {
-                let updatedSigner = await updateSignerIfRequired()
-                try await updatedSigner.initialize(smartWalletService)
-                for approval in pending {
-                    let signRequest = SignRequestApi(
-                        approvals: try await updatedSigner.approvals(
-                            withSignature: try await updatedSigner.sign(message: approval.message)
-                        )
-                    )
-                    try await smartWalletService.approveSignature(
-                        .init(transactionId: signatureId, apiRequest: signRequest, chainType: chain.chainType)
-                    )
-                }
-            }
+            try await approveAddDelegatedSigner(registration: registration)
 
             try await storage.mapAddressToKey(address: address, publicKeyBase64: pubKey)
             Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerSuccess, attributes: [
@@ -386,6 +370,26 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
             Logger.smartWallet.warn(LogEvents.walletAddDelegatedSignerError, attributes: [
                 "error": "\(error)"
             ])
+        }
+    }
+
+    private func approveAddDelegatedSigner(registration: AddDelegatedSignerResponse) async throws {
+        guard let chainEntry = registration.chains?[chain.name],
+              chainEntry.status == "awaiting-approval",
+              let signatureId = chainEntry.id,
+              let pending = chainEntry.approvals?.pending, !pending.isEmpty else { return }
+
+        let updatedSigner = await updateSignerIfRequired()
+        try await updatedSigner.initialize(smartWalletService)
+        for approval in pending {
+            let signRequest = SignRequestApi(
+                approvals: try await updatedSigner.approvals(
+                    withSignature: try await updatedSigner.sign(message: approval.message)
+                )
+            )
+            try await smartWalletService.approveSignature(
+                .init(transactionId: signatureId, apiRequest: signRequest, chainType: chain.chainType)
+            )
         }
     }
 


### PR DESCRIPTION
`getOrCreateWallet` has been removed in favour of explicit `getWallet` and `createWallet` methods, matching the TS SDK (crossmint-sdk#1622).

`getWallet` now handles device signer assignment for existing wallets. It uses the new `hasKey(pubKey64:)` on `DeviceSignerKeyStorage` to detect pending keys already on the device, maps them to the wallet address, and defers registration for new devices to the first transaction.

## Changes
- Remove `getOrCreateWallet` from the `CrossmintWallets` protocol and its implementation
- Add `getWallet` and `createWallet` as first-class public methods with typed-chain convenience overloads
- Implement 3-step device signer flow in `getWallet` (map pending → match existing → defer to first tx)
- Add `hasKey(pubKey64:)` to `DeviceSignerKeyStorage` for pending key lookup
- Add `ensureDeviceSignerRegistered()` on `Wallet`, called before each transfer
- Update both demo apps to use the new methods

<!-- greptile_comment -->

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift`, line 104 ([link](https://github.com/crossmint/crossmint-swift-sdk/blob/217453f5041ee691d6a8e8e3c9fc232700505478/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift#L104)) 

   **`hasKey` is the only synchronous method in this protocol**

   All other methods in `DeviceSignerKeyStorage` are `async`, but `hasKey(pubKey64:)` is synchronous. While this works fine for the current keychain-backed implementations, it is inconsistent with the rest of the protocol and would force any future implementation that needs async I/O (e.g., cloud-backed key storage, remote HSM) to either block synchronously or perform a non-trivial workaround. Consider declaring it `async` for consistency:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
   Line: 104

   Comment:
   **`hasKey` is the only synchronous method in this protocol**

   All other methods in `DeviceSignerKeyStorage` are `async`, but `hasKey(pubKey64:)` is synchronous. While this works fine for the current keychain-backed implementations, it is inconsistent with the rest of the protocol and would force any future implementation that needs async I/O (e.g., cloud-backed key storage, remote HSM) to either block synchronously or perform a non-trivial workaround. Consider declaring it `async` for consistency:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

2. `Sources/Wallet/DefaultCrossmintWallets.swift`, line 347-364 ([link](https://github.com/crossmint/crossmint-swift-sdk/blob/8240b168b67c58b0a828397feaaae678b5eea0d3/Sources/Wallet/DefaultCrossmintWallets.swift#L347-L364)) 

   **Dead code: `approveDelegatedSignerRegistration` is unreachable**

   `approveDelegatedSignerRegistration` is now a private method with no callers. In the original `getOrCreateWallet`, it was called as part of the device signer registration flow when an existing wallet was found. That call site was removed as part of this refactoring, and the equivalent approval logic was inlined into `Wallet.ensureDeviceSignerRegistered` instead.

   Running a project-wide search confirms no other call site exists. This method should be removed to avoid confusion and keep the codebase lean.


3. `Examples/SolanaDemo/SolanaDemo/Dashboard/DashboardView.swift`, line 261-276 ([link](https://github.com/crossmint/crossmint-swift-sdk/blob/8240b168b67c58b0a828397feaaae678b5eea0d3/Examples/SolanaDemo/SolanaDemo/Dashboard/DashboardView.swift#L261-L276)) 

   **Outer `catch` contains a dead `else` branch**

   Because both `getWallet` and `createWallet` use typed throws `throws(WalletError)`, the only error type that can reach the outer `catch` block is `WalletError`. The `if let walletError = error as? WalletError` cast will therefore always succeed, and the `else { showAlert(with: "Error: \(error)") }` branch can never be reached.

   You can replace the runtime cast with a direct typed catch, matching the style used in `SmartWalletsDemo`:

   ```swift
   } catch {
       await MainActor.run {
           if updateLoadingStatus {
               creatingWallet = false
           }
           let walletError = error as WalletError
           switch walletError {
           case .walletCreationCancelled:
               break
           default:
               showAlert(with: walletError.errorMessage)
           }
       }
   }
   ```

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Sources/Wallet/DefaultCrossmintWallets.swift
Line: 347-364

Comment:
**Dead code: `approveDelegatedSignerRegistration` is unreachable**

`approveDelegatedSignerRegistration` is now a private method with no callers. In the original `getOrCreateWallet`, it was called as part of the device signer registration flow when an existing wallet was found. That call site was removed as part of this refactoring, and the equivalent approval logic was inlined into `Wallet.ensureDeviceSignerRegistered` instead.

Running a project-wide search confirms no other call site exists. This method should be removed to avoid confusion and keep the codebase lean.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: Examples/SolanaDemo/SolanaDemo/Dashboard/DashboardView.swift
Line: 261-276

Comment:
**Outer `catch` contains a dead `else` branch**

Because both `getWallet` and `createWallet` use typed throws `throws(WalletError)`, the only error type that can reach the outer `catch` block is `WalletError`. The `if let walletError = error as? WalletError` cast will therefore always succeed, and the `else { showAlert(with: "Error: \(error)") }` branch can never be reached.

You can replace the runtime cast with a direct typed catch, matching the style used in `SmartWalletsDemo`:

```swift
} catch {
    await MainActor.run {
        if updateLoadingStatus {
            creatingWallet = false
        }
        let walletError = error as WalletError
        switch walletError {
        case .walletCreationCancelled:
            break
        default:
            showAlert(with: walletError.errorMessage)
        }
    }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 8240b16</sub>

**Context used:**

- Rule used - Remove unused code from PRs to keep them lean. Add... ([source](https://app.greptile.com/review/custom-context?memory=83771aea-3c5f-4a37-9170-8ac881cd5efd))

**Learnt From**
[Paella-Labs/crossbit-main#20960](https://github.com/Paella-Labs/crossbit-main/pull/20960)

<!-- /greptile_comment -->