### PR TITLE
Support device signer on physical devices without Secure Enclave

### DIFF
--- a/Sources/DeviceSigner/DeviceSignerError.swift
+++ b/Sources/DeviceSigner/DeviceSignerError.swift
@@ -9,8 +9,6 @@ import Foundation
 
 /// Errors that can occur during device signer operations.
 public enum DeviceSignerError: Error, Sendable {
-    /// Secure Enclave is not available on this device.
-    case hardwareUnavailable
     /// No key found in storage for the given wallet address.
     case keyNotFound
     /// Key generation failed.
@@ -26,7 +24,6 @@ public enum DeviceSignerError: Error, Sendable {
     /// Intended to conform to `CrossmintError.code` when that protocol is introduced.
     public var code: String {
         switch self {
-        case .hardwareUnavailable:  "DEVICE_SIGNER_HARDWARE_UNAVAILABLE"
         case .keyNotFound:          "DEVICE_SIGNER_KEY_NOT_FOUND"
         case .keyGenerationFailed:  "DEVICE_SIGNER_KEY_GENERATION_FAILED"
         case .signingFailed:        "DEVICE_SIGNER_SIGNING_FAILED"
@@ -39,8 +36,6 @@ public enum DeviceSignerError: Error, Sendable {
     /// Intended to conform to `CrossmintError.recoverySuggestion` when that protocol is introduced.
     public var recoverySuggestion: String? {
         switch self {
-        case .hardwareUnavailable:
-            "Secure Enclave is not available on this device. The SDK will fall back to Keychain-backed key storage."
         case .keyNotFound:
             "The device signer key for this wallet was not found. The wallet may need to re-register a device signer."
         case .keyGenerationFailed:

--- a/Sources/DeviceSigner/DeviceSignerError.swift
+++ b/Sources/DeviceSigner/DeviceSignerError.swift
@@ -40,7 +40,7 @@ public enum DeviceSignerError: Error, Sendable {
     public var recoverySuggestion: String? {
         switch self {
         case .hardwareUnavailable:
-            "Secure Enclave is not available on this device. The SDK will fall back to software key storage."
+            "Secure Enclave is not available on this device. The SDK will fall back to Keychain-backed key storage."
         case .keyNotFound:
             "The device signer key for this wallet was not found. The wallet may need to re-register a device signer."
         case .keyGenerationFailed:

--- a/Sources/DeviceSigner/DeviceSignerOptions.swift
+++ b/Sources/DeviceSigner/DeviceSignerOptions.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Configuration for the device signer feature.
 ///
 /// When provided via ``WalletOptions/deviceSigner``, the SDK generates a hardware-backed
-/// P-256 signing key in the Secure Enclave (or a software fallback on simulators) and
+/// P-256 signing key in the Secure Enclave (or a Keychain-based fallback when Secure Enclave is unavailable) and
 /// registers it as a delegated signer on the wallet. Subsequent transactions are co-signed
 /// by this key silently, without requiring an OTP prompt on the same device.
 ///

--- a/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
+++ b/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
@@ -55,29 +55,11 @@ struct DeviceSignerKeychainStorage {
     }
 
     func rename(from oldTag: String, to newTag: String) throws(DeviceSignerError) {
-        // Remove any existing item at the target tag to avoid errSecDuplicateItem (-25299).
-        let deleteTarget: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: newTag
-        ]
-        let deleteStatus = SecItemDelete(deleteTarget as CFDictionary)
-        guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
-            throw DeviceSignerError.storageError(deleteStatus)
+        guard let data = load(tag: oldTag) else {
+            throw DeviceSignerError.keyNotFound
         }
-
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: oldTag
-        ]
-        let attributes: [CFString: Any] = [
-            kSecAttrAccount: newTag
-        ]
-        let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
-        guard status == errSecSuccess else {
-            throw DeviceSignerError.storageError(status)
-        }
+        try delete(tag: oldTag)
+        try save(data, tag: newTag)
     }
 
     func delete(tag: String) throws(DeviceSignerError) {

--- a/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
+++ b/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
@@ -1,4 +1,5 @@
 import Foundation
+import LocalAuthentication
 import Security
 
 private let service = "com.crossmint.devicesigner"
@@ -32,14 +33,21 @@ struct DeviceSignerKeychainStorage {
         }
     }
 
-    func load(tag: String) -> Data? {
-        let query: [CFString: Any] = [
+    func load(tag: String, prompt: String? = nil, authContext: LAContext? = nil) -> Data? {
+        var query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
             kSecAttrAccount: tag,
             kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne
         ]
+        if let authContext {
+            query[kSecUseAuthenticationContext] = authContext
+        } else if let prompt {
+            let context = LAContext()
+            context.localizedReason = prompt
+            query[kSecUseAuthenticationContext] = context
+        }
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         guard status == errSecSuccess else { return nil }
@@ -47,6 +55,17 @@ struct DeviceSignerKeychainStorage {
     }
 
     func rename(from oldTag: String, to newTag: String) throws(DeviceSignerError) {
+        // Remove any existing item at the target tag to avoid errSecDuplicateItem (-25299).
+        let deleteTarget: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: newTag
+        ]
+        let deleteStatus = SecItemDelete(deleteTarget as CFDictionary)
+        guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+            throw DeviceSignerError.storageError(deleteStatus)
+        }
+
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,

--- a/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
@@ -12,7 +12,7 @@ import Security
 /// Implementations manage the full lifecycle of a P-256 signing key tied to a wallet address:
 /// generation, retrieval, signing, and deletion. Two implementations are provided:
 /// - ``SecureEnclaveKeyStorage``: hardware-backed, for physical devices with Secure Enclave.
-/// - ``SoftwareDeviceSignerKeyStorage``: software fallback for simulators and older devices.
+/// - ``KeychainDeviceSignerKeyStorage``: Keychain-backed fallback for simulators and devices without Secure Enclave.
 public protocol DeviceSignerKeyStorage: Sendable {
     /// Returns `true` if this storage backend is available on the current device.
     func isAvailable() async -> Bool

--- a/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
@@ -9,10 +9,9 @@ import Security
 
 /// Storage abstraction for device signer keys.
 ///
-/// Implementations manage the full lifecycle of a P-256 signing key tied to a wallet address:
-/// generation, retrieval, signing, and deletion. Two implementations are provided:
-/// - ``SecureEnclaveKeyStorage``: hardware-backed, for physical devices with Secure Enclave.
-/// - ``KeychainDeviceSignerKeyStorage``: Keychain-backed fallback for simulators and devices without Secure Enclave.
+/// Manages the full lifecycle of a P-256 signing key tied to a wallet address:
+/// generation, retrieval, signing, and deletion.
+///
 public protocol DeviceSignerKeyStorage: Sendable {
     /// Returns `true` if this storage backend is available on the current device.
     func isAvailable() async -> Bool

--- a/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
@@ -5,6 +5,7 @@
 //  Created by Tomas Martins on 3/3/26.
 //
 
+import Foundation
 import Security
 
 /// Storage abstraction for device signer keys.
@@ -64,4 +65,17 @@ public protocol DeviceSignerKeyStorage: Sendable {
     /// - Parameter pubKey64: The raw 64-byte public key (x‖y) encoded as a base64 string.
     /// - Returns: `true` if a pending key with this public key exists in local storage.
     func hasKey(pubKey64: String) -> Bool
+}
+
+extension DeviceSignerKeyStorage {
+    var walletKeyPrefix: String { "crossmint.device.wallet." }
+    var pendingKeyPrefix: String { "crossmint.device.pending." }
+
+    func uncompressedPublicKey(from rawRepresentation: Data) -> String {
+        (Data([0x04]) + rawRepresentation).base64EncodedString()
+    }
+
+    func hexString<D: DataProtocol>(from data: D) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
 }

--- a/Sources/DeviceSigner/Storage/KeychainDeviceSignerKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/KeychainDeviceSignerKeyStorage.swift
@@ -9,7 +9,7 @@ import CryptoKit
 import Foundation
 import Security
 
-/// A ``DeviceSignerKeyStorage`` implementation using software P-256 keys stored in the Keychain.
+/// A ``DeviceSignerKeyStorage`` implementation using P-256 keys stored in the Keychain.
 ///
 /// Keys are stored as Keychain-protected items rather than in dedicated hardware. This is the
 /// legitimate fallback for simulators and physical devices that lack a Secure Enclave.

--- a/Sources/DeviceSigner/Storage/KeychainDeviceSignerKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/KeychainDeviceSignerKeyStorage.swift
@@ -1,5 +1,5 @@
 //
-//  SoftwareDeviceSignerKeyStorage.swift
+//  KeychainDeviceSignerKeyStorage.swift
 //  CrossmintSDK
 //
 //  Created by Tomas Martins on 3/3/26.
@@ -11,20 +11,16 @@ import Security
 
 /// A ``DeviceSignerKeyStorage`` implementation using software P-256 keys stored in the Keychain.
 ///
-/// This implementation is intended for use on **simulators only**. Keys are stored as raw key
-/// material in the Keychain rather than in dedicated hardware, providing no hardware-backed isolation.
+/// Keys are stored as Keychain-protected items rather than in dedicated hardware. This is the
+/// legitimate fallback for simulators and physical devices that lack a Secure Enclave.
 ///
-/// On physical devices that lack a Secure Enclave, the device signer feature should not be used.
-/// Use an alternative signer (e.g., email or passkey) instead.
-///
-/// - Important: Do not ship this implementation to production. ``DefaultCrossmintWallets`` selects
-///   ``SecureEnclaveKeyStorage`` on real devices and falls back to this implementation only
-///   when ``SecureEnclave/isAvailable`` returns `false`.
-public final class SoftwareDeviceSignerKeyStorage: DeviceSignerKeyStorage {
+/// ``DefaultCrossmintWallets`` selects ``SecureEnclaveKeyStorage`` on devices with Secure Enclave
+/// and falls back to this implementation when ``SecureEnclave/isAvailable`` returns `false`.
+public final class KeychainDeviceSignerKeyStorage: DeviceSignerKeyStorage {
     private let biometricPolicy: BiometricPolicy
     private let keychain = DeviceSignerKeychainStorage()
 
-    /// Creates a software key storage with the given biometric policy.
+    /// Creates a Keychain key storage with the given biometric policy.
     ///
     /// - Parameter biometricPolicy: When to require biometric authentication for signing.
     ///   Defaults to ``BiometricPolicy/none``.

--- a/Sources/DeviceSigner/Storage/KeychainKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/KeychainKeyStorage.swift
@@ -1,5 +1,5 @@
 //
-//  KeychainDeviceSignerKeyStorage.swift
+//  KeychainKeyStorage.swift
 //  CrossmintSDK
 //
 //  Created by Tomas Martins on 3/3/26.
@@ -12,11 +12,11 @@ import Security
 /// A ``DeviceSignerKeyStorage`` implementation using P-256 keys stored in the Keychain.
 ///
 /// Keys are stored as Keychain-protected items rather than in dedicated hardware. This is the
-/// legitimate fallback for simulators and physical devices that lack a Secure Enclave.
+/// fallback used when Secure Enclave is unavailable.
 ///
-/// ``DefaultCrossmintWallets`` selects ``SecureEnclaveKeyStorage`` on devices with Secure Enclave
-/// and falls back to this implementation when ``SecureEnclave/isAvailable`` returns `false`.
-public final class KeychainDeviceSignerKeyStorage: DeviceSignerKeyStorage {
+/// ``DefaultCrossmintWallets`` selects ``SecureEnclaveKeyStorage`` when Secure Enclave is
+/// available and falls back to this implementation when ``SecureEnclave/isAvailable`` returns `false`.
+public final class KeychainKeyStorage: DeviceSignerKeyStorage {
     private let biometricPolicy: BiometricPolicy
     private let keychain = DeviceSignerKeychainStorage()
 

--- a/Sources/DeviceSigner/Storage/KeychainKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/KeychainKeyStorage.swift
@@ -34,15 +34,13 @@ public final class KeychainKeyStorage: DeviceSignerKeyStorage {
 
     public func generateKey(address: String?) async throws(DeviceSignerError) -> String {
         let key = P256.Signing.PrivateKey()
-        var uncompressed = Data([0x04])
-        uncompressed.append(key.publicKey.rawRepresentation)  // 65 bytes: 0x04 ‖ x ‖ y
-        let publicKeyBase64 = uncompressed.base64EncodedString()
+        let publicKeyBase64 = uncompressedPublicKey(from: key.publicKey.rawRepresentation)
 
         let tag: String
         if let address {
-            tag = "crossmint.device.wallet.\(address)"
+            tag = "\(walletKeyPrefix)\(address)"
         } else {
-            tag = "crossmint.device.pending.\(publicKeyBase64)"
+            tag = "\(pendingKeyPrefix)\(publicKeyBase64)"
         }
 
         // Store the 32-byte private key scalar
@@ -52,27 +50,26 @@ public final class KeychainKeyStorage: DeviceSignerKeyStorage {
     }
 
     public func mapAddressToKey(address: String, publicKeyBase64: String) async throws(DeviceSignerError) {
-        let oldTag = "crossmint.device.pending.\(publicKeyBase64)"
-        let newTag = "crossmint.device.wallet.\(address)"
-        try keychain.rename(from: oldTag, to: newTag)
+        try keychain.rename(
+            from: "\(pendingKeyPrefix)\(publicKeyBase64)",
+            to: "\(walletKeyPrefix)\(address)"
+        )
     }
 
     public func getKey(address: String) async -> String? {
-        let tag = "crossmint.device.wallet.\(address)"
+        let tag = "\(walletKeyPrefix)\(address)"
         guard let keyData = keychain.load(tag: tag),
               let key = try? P256.Signing.PrivateKey(rawRepresentation: keyData) else {
             return nil
         }
-        var uncompressed = Data([0x04])
-        uncompressed.append(key.publicKey.rawRepresentation)
-        return uncompressed.base64EncodedString()
+        return uncompressedPublicKey(from: key.publicKey.rawRepresentation)
     }
 
     public func signMessage(
         address: String,
         message: String
     ) async throws(DeviceSignerError) -> (r: String, s: String) {
-        let tag = "crossmint.device.wallet.\(address)"
+        let tag = "\(walletKeyPrefix)\(address)"
         guard let keyData = keychain.load(tag: tag),
               let key = try? P256.Signing.PrivateKey(rawRepresentation: keyData) else {
             throw DeviceSignerError.keyNotFound
@@ -97,17 +94,15 @@ public final class KeychainKeyStorage: DeviceSignerKeyStorage {
     }
 
     public func deleteKey(address: String) async throws(DeviceSignerError) {
-        let tag = "crossmint.device.wallet.\(address)"
-        try keychain.delete(tag: tag)
+        try keychain.delete(tag: "\(walletKeyPrefix)\(address)")
     }
 
     public func deletePendingKey(publicKeyBase64: String) async throws(DeviceSignerError) {
-        let tag = "crossmint.device.pending.\(publicKeyBase64)"
-        try keychain.delete(tag: tag)
+        try keychain.delete(tag: "\(pendingKeyPrefix)\(publicKeyBase64)")
     }
 
     public func hasKey(pubKey64: String) -> Bool {
-        keychain.load(tag: "crossmint.device.pending.\(pubKey64)") != nil
+        keychain.load(tag: "\(pendingKeyPrefix)\(pubKey64)") != nil
     }
 
     // MARK: - Private helpers
@@ -126,7 +121,4 @@ public final class KeychainKeyStorage: DeviceSignerKeyStorage {
         }
     }
 
-    private func hexString<D: DataProtocol>(from data: D) -> String {
-        data.map { String(format: "%02x", $0) }.joined()
-    }
 }

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -15,9 +15,8 @@ import Security
 /// Secure Enclave hardware. Signing operations execute inside the enclave; the raw key
 /// material never leaves the chip.
 ///
-/// Check ``SecureEnclave/isAvailable`` before instantiating this class. When SE is unavailable
-/// (simulators or devices without Secure Enclave), use ``KeychainDeviceSignerKeyStorage`` as
-/// the fallback.
+/// ``DefaultCrossmintWallets`` selects this implementation automatically when Secure Enclave
+/// is available, and falls back to ``KeychainKeyStorage`` when it is not.
 public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
     private let keychain = DeviceSignerKeychainStorage()
     private let biometricPolicy: BiometricPolicy

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -16,7 +16,7 @@ import Security
 /// material never leaves the chip.
 ///
 /// ``DefaultCrossmintWallets`` selects this implementation automatically when Secure Enclave
-/// is available, and falls back to ``KeychainKeyStorage`` when it is not.
+/// is available, and falls back to ``KeychainDeviceSignerKeyStorage`` when it is not.
 public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
     private let keychain = DeviceSignerKeychainStorage()
     private let biometricPolicy: BiometricPolicy
@@ -50,8 +50,9 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
             throw DeviceSignerError.keyGenerationFailed
         }
 
-        let rawPublicKey = key.publicKey.rawRepresentation  // 64 bytes: x‖y
-        let publicKeyBase64 = rawPublicKey.base64EncodedString()
+        // Prepend 0x04 to produce a standard 65-byte uncompressed P-256 point.
+        let uncompressed = Data([0x04]) + key.publicKey.rawRepresentation
+        let publicKeyBase64 = uncompressed.base64EncodedString()
 
         let tag: String
         if let address {
@@ -77,7 +78,8 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
               let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData) else {
             return nil
         }
-        return key.publicKey.rawRepresentation.base64EncodedString()
+        let uncompressed = Data([0x04]) + key.publicKey.rawRepresentation
+        return uncompressed.base64EncodedString()
     }
 
     public func signMessage(

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -46,15 +46,13 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
             throw DeviceSignerError.keyGenerationFailed
         }
 
-        // Prepend 0x04 to produce a standard 65-byte uncompressed P-256 point.
-        let uncompressed = Data([0x04]) + key.publicKey.rawRepresentation
-        let publicKeyBase64 = uncompressed.base64EncodedString()
+        let publicKeyBase64 = uncompressedPublicKey(from: key.publicKey.rawRepresentation)
 
         let tag: String
         if let address {
-            tag = "crossmint.device.wallet.\(address)"
+            tag = "\(walletKeyPrefix)\(address)"
         } else {
-            tag = "crossmint.device.pending.\(publicKeyBase64)"
+            tag = "\(pendingKeyPrefix)\(publicKeyBase64)"
         }
 
         try keychain.save(key.dataRepresentation, tag: tag)
@@ -63,26 +61,26 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
     }
 
     public func mapAddressToKey(address: String, publicKeyBase64: String) async throws(DeviceSignerError) {
-        let oldTag = "crossmint.device.pending.\(publicKeyBase64)"
-        let newTag = "crossmint.device.wallet.\(address)"
-        try keychain.rename(from: oldTag, to: newTag)
+        try keychain.rename(
+            from: "\(pendingKeyPrefix)\(publicKeyBase64)",
+            to: "\(walletKeyPrefix)\(address)"
+        )
     }
 
     public func getKey(address: String) async -> String? {
-        let tag = "crossmint.device.wallet.\(address)"
+        let tag = "\(walletKeyPrefix)\(address)"
         guard let keyData = keychain.load(tag: tag),
               let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData) else {
             return nil
         }
-        let uncompressed = Data([0x04]) + key.publicKey.rawRepresentation
-        return uncompressed.base64EncodedString()
+        return uncompressedPublicKey(from: key.publicKey.rawRepresentation)
     }
 
     public func signMessage(
         address: String,
         message: String
     ) async throws(DeviceSignerError) -> (r: String, s: String) {
-        let tag = "crossmint.device.wallet.\(address)"
+        let tag = "\(walletKeyPrefix)\(address)"
         guard let keyData = keychain.load(tag: tag) else {
             throw DeviceSignerError.keyNotFound
         }
@@ -114,20 +112,18 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
     }
 
     public func deleteKey(address: String) async throws(DeviceSignerError) {
-        let tag = "crossmint.device.wallet.\(address)"
-        try keychain.delete(tag: tag)
+        try keychain.delete(tag: "\(walletKeyPrefix)\(address)")
     }
 
     public func deletePendingKey(publicKeyBase64: String) async throws(DeviceSignerError) {
-        let tag = "crossmint.device.pending.\(publicKeyBase64)"
-        try keychain.delete(tag: tag)
+        try keychain.delete(tag: "\(pendingKeyPrefix)\(publicKeyBase64)")
     }
 
     public func hasKey(pubKey64: String) -> Bool {
-        keychain.load(tag: "crossmint.device.pending.\(pubKey64)") != nil
+        keychain.load(tag: "\(pendingKeyPrefix)\(pubKey64)") != nil
     }
 
-    // MARK: - Private helpers
+    // MARK: - Private helper
 
     private func makeAccessControl() -> SecAccessControl? {
         let flags: SecAccessControlCreateFlags
@@ -145,7 +141,4 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
         )
     }
 
-    private func hexString<D: DataProtocol>(from data: D) -> String {
-        data.map { String(format: "%02x", $0) }.joined()
-    }
 }

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -15,10 +15,9 @@ import Security
 /// Secure Enclave hardware. Signing operations execute inside the enclave; the raw key
 /// material never leaves the chip.
 ///
-/// Check ``SecureEnclave/isAvailable`` before instantiating this class. On simulators,
-/// use ``SoftwareDeviceSignerKeyStorage`` for development only. On physical devices without
-/// a Secure Enclave, the device signer feature should not be used — prefer an alternative
-/// signer such as email or passkey.
+/// Check ``SecureEnclave/isAvailable`` before instantiating this class. When SE is unavailable
+/// (simulators or devices without Secure Enclave), use ``KeychainDeviceSignerKeyStorage`` as
+/// the fallback.
 public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
     private let keychain = DeviceSignerKeychainStorage()
     private let biometricPolicy: BiometricPolicy

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -34,10 +34,6 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
     }
 
     public func generateKey(address: String?) async throws(DeviceSignerError) -> String {
-        guard SecureEnclave.isAvailable else {
-            throw DeviceSignerError.hardwareUnavailable
-        }
-
         let accessControl = makeAccessControl()
         guard let access = accessControl else {
             throw DeviceSignerError.keyGenerationFailed

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -290,7 +290,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
         if SecureEnclave.isAvailable {
             return SecureEnclaveKeyStorage(biometricPolicy: deviceSignerOptions.biometricPolicy)
         } else {
-            return KeychainDeviceSignerKeyStorage(biometricPolicy: deviceSignerOptions.biometricPolicy)
+            return KeychainKeyStorage(biometricPolicy: deviceSignerOptions.biometricPolicy)
         }
     }
 

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -290,7 +290,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
         if SecureEnclave.isAvailable {
             return SecureEnclaveKeyStorage(biometricPolicy: deviceSignerOptions.biometricPolicy)
         } else {
-            return SoftwareDeviceSignerKeyStorage(biometricPolicy: deviceSignerOptions.biometricPolicy)
+            return KeychainDeviceSignerKeyStorage(biometricPolicy: deviceSignerOptions.biometricPolicy)
         }
     }
 


### PR DESCRIPTION
Renamed `SoftwareDeviceSignerKeyStorage` to `KeychainKeyStorage` and updated docs and error messages to reflect that it serves as the legitimate fallback for simulators and devices without Secure Enclave access. No functional changes.