### PR TITLE
Updated podspec tag

### DIFF
--- a/CrossmintDeviceSigner.podspec
+++ b/CrossmintDeviceSigner.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CrossmintDeviceSigner'
-  s.version          = '0.1.0'
+  s.version          = '0.11.1'
   s.summary          = 'Hardware-backed device signer key storage for Crossmint wallets (iOS).'
   s.homepage         = 'https://github.com/Crossmint/crossmint-swift-sdk'
   s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
   s.source           = {
     :git => 'https://github.com/Crossmint/crossmint-swift-sdk.git',
-    :tag => "CrossmintDeviceSigner/#{s.version}"
+    :tag => s.version.to_s
   }
 
   s.source_files     = 'Sources/DeviceSigner/**/*.swift'


### PR DESCRIPTION
Updated podspec version, which will be the one to expose the native device signer to CocoaPods trunk
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-swift-sdk/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
