### PR TITLE
Update Signer nomenclature and add hasKey to device signer interface

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Dashboard/DashboardView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Dashboard/DashboardView.swift
@@ -254,7 +254,7 @@ struct DashboardView: View {
         do {
             let wallet = try await sdk.crossmintWallets.getOrCreateWallet(
                 chain: .baseSepolia,
-                signer: .email(email),
+                recovery: .email(email),
                 options: WalletOptions(deviceSigner: DeviceSignerOptions(biometricPolicy: .always))
             )
 

--- a/Examples/SolanaDemo/SolanaDemo/Dashboard/DashboardView.swift
+++ b/Examples/SolanaDemo/SolanaDemo/Dashboard/DashboardView.swift
@@ -236,7 +236,7 @@ struct DashboardView: View {
 
             let wallet = try await sdk.crossmintWallets.getOrCreateWallet(
                 chain: .solana,
-                signer: .email(email)
+                recovery: .email(email)
             )
             await MainActor.run {
                 if updateLoadingStatus {

--- a/Sources/DeviceSigner/DeviceSignerOptions.swift
+++ b/Sources/DeviceSigner/DeviceSignerOptions.swift
@@ -17,7 +17,7 @@ import Foundation
 /// ```swift
 /// let wallet = try await crossmint.wallets.getOrCreateWallet(
 ///     chain: .polygon,
-///     signer: emailSigner,
+///     recovery: emailSigner,
 ///     options: WalletOptions(deviceSigner: DeviceSignerOptions(biometricPolicy: .always))
 /// )
 /// ```

--- a/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
+++ b/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
@@ -1,6 +1,9 @@
 import Foundation
 import LocalAuthentication
+import OSLog
 import Security
+
+private let logger = Logger(subsystem: "com.crossmint.devicesigner", category: "KeychainStorage")
 
 private let service = "com.crossmint.devicesigner"
 
@@ -81,8 +84,14 @@ struct DeviceSignerKeychainStorage {
             kSecMatchLimit: kSecMatchLimitAll
         ]
         var result: AnyObject?
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-              let items = result as? [[CFString: Any]] else {
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else {
+            if status != errSecItemNotFound {
+                logger.error("Unexpected Keychain error in allTags: \(status)")
+            }
+            return []
+        }
+        guard let items = result as? [[CFString: Any]] else {
             return []
         }
         return items.compactMap { $0[kSecAttrAccount] as? String }.filter { $0.hasPrefix(prefix) }

--- a/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
+++ b/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
@@ -4,6 +4,9 @@ import Security
 private let service = "com.crossmint.devicesigner"
 
 struct DeviceSignerKeychainStorage {
+    static let pendingKeyPrefix = "crossmint.device.pending."
+    static let walletKeyPrefix = "crossmint.device.wallet."
+
     func save(_ data: Data, tag: String, accessControl: SecAccessControl? = nil) throws(DeviceSignerError) {
         let deleteQuery: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
@@ -59,6 +62,29 @@ struct DeviceSignerKeychainStorage {
         guard status == errSecSuccess else {
             throw DeviceSignerError.storageError(status)
         }
+    }
+
+    func hasMatchingKey(publicKeyBase64: String, reconstructPublicKey: (Data) -> String?) -> Bool {
+        if load(tag: "\(Self.pendingKeyPrefix)\(publicKeyBase64)") != nil { return true }
+        return allTags(prefix: Self.walletKeyPrefix).contains { tag in
+            guard let keyData = load(tag: tag) else { return false }
+            return reconstructPublicKey(keyData) == publicKeyBase64
+        }
+    }
+
+    func allTags(prefix: String) -> [String] {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecReturnAttributes: true,
+            kSecMatchLimit: kSecMatchLimitAll
+        ]
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let items = result as? [[CFString: Any]] else {
+            return []
+        }
+        return items.compactMap { $0[kSecAttrAccount] as? String }.filter { $0.hasPrefix(prefix) }
     }
 
     func delete(tag: String) throws(DeviceSignerError) {

--- a/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
@@ -62,7 +62,7 @@ public protocol DeviceSignerKeyStorage: Sendable {
     /// device signers belongs to the current device.
     ///
     /// - Parameter publicKeyBase64: The base64-encoded 65-byte uncompressed public key (0x04 ‖ x ‖ y).
-    func hasKey(publicKeyBase64: String) async -> Bool
+    func hasKey(publicKeyBase64: String) -> Bool
 }
 
 extension DeviceSignerKeyStorage {

--- a/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/DeviceSignerKeyStorage.swift
@@ -54,4 +54,13 @@ public protocol DeviceSignerKeyStorage: Sendable {
 
     /// Deletes a pending key that was never mapped to a wallet address.
     func deletePendingKey(publicKeyBase64: String) async throws(DeviceSignerError)
+
+    /// Returns `true` if the given public key belongs to a key stored on this device,
+    /// whether as a pending key or as a key already mapped to a wallet address.
+    ///
+    /// Use this during wallet initialisation to check whether any of the wallet's registered
+    /// device signers belongs to the current device.
+    ///
+    /// - Parameter publicKeyBase64: The base64-encoded 65-byte uncompressed public key (0x04 ‖ x ‖ y).
+    func hasKey(publicKeyBase64: String) async -> Bool
 }

--- a/Sources/DeviceSigner/Storage/KeychainKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/KeychainKeyStorage.swift
@@ -101,7 +101,7 @@ public final class KeychainKeyStorage: DeviceSignerKeyStorage {
         try keychain.delete(tag: "\(pendingKeyPrefix)\(publicKeyBase64)")
     }
 
-    public func hasKey(publicKeyBase64: String) async -> Bool {
+    public func hasKey(publicKeyBase64: String) -> Bool {
         keychain.hasMatchingKey(publicKeyBase64: publicKeyBase64) { [self] keyData in
             guard let key = try? P256.Signing.PrivateKey(rawRepresentation: keyData) else { return nil }
             return uncompressedPublicKey(from: key.publicKey.rawRepresentation)

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -119,7 +119,7 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
         try keychain.delete(tag: "\(pendingKeyPrefix)\(publicKeyBase64)")
     }
 
-    public func hasKey(publicKeyBase64: String) async -> Bool {
+    public func hasKey(publicKeyBase64: String) -> Bool {
         keychain.hasMatchingKey(publicKeyBase64: publicKeyBase64) { [self] keyData in
             guard let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData) else { return nil }
             return uncompressedPublicKey(from: key.publicKey.rawRepresentation)

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -130,6 +130,15 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
         try keychain.delete(tag: tag)
     }
 
+    public func hasKey(publicKeyBase64: String) async -> Bool {
+        keychain.hasMatchingKey(publicKeyBase64: publicKeyBase64) { keyData in
+            guard let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData) else { return nil }
+            var uncompressed = Data([0x04])
+            uncompressed.append(key.publicKey.rawRepresentation)
+            return uncompressed.base64EncodedString()
+        }
+    }
+
     // MARK: - Private helpers
 
     private func makeAccessControl() -> SecAccessControl? {

--- a/Sources/DeviceSigner/Storage/SoftwareDeviceSignerKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SoftwareDeviceSignerKeyStorage.swift
@@ -110,6 +110,15 @@ public final class SoftwareDeviceSignerKeyStorage: DeviceSignerKeyStorage {
         try keychain.delete(tag: tag)
     }
 
+    public func hasKey(publicKeyBase64: String) async -> Bool {
+        keychain.hasMatchingKey(publicKeyBase64: publicKeyBase64) { keyData in
+            guard let key = try? P256.Signing.PrivateKey(rawRepresentation: keyData) else { return nil }
+            var uncompressed = Data([0x04])
+            uncompressed.append(key.publicKey.rawRepresentation)
+            return uncompressed.base64EncodedString()
+        }
+    }
+
     // MARK: - Private helpers
 
     private func makeAccessControl() -> SecAccessControl? {

--- a/Sources/Wallet/CrossmintWallets.swift
+++ b/Sources/Wallet/CrossmintWallets.swift
@@ -2,67 +2,19 @@ import CrossmintCommonTypes
 import DeviceSigner
 
 public protocol CrossmintWallets: Sendable {
-    @available(*, deprecated, message: "Use type-safe getOrCreateWallet methods with EVMSigners or SolanaSigners")
-    func getOrCreateWallet(
-        chain: Chain,
-        signer: any Signer,
-        options: WalletOptions?
-    ) async throws(WalletError) -> Wallet
-
     func getOrCreateWallet<C: ChainWithSigners>(
         chain: C,
-        signer: C.SpecificSigner,
+        recovery: C.SpecificSigner,
         options: WalletOptions?
     ) async throws(WalletError) -> Wallet
 }
 
 extension CrossmintWallets {
-    public func getOrCreateWallet(
-        chain: EVMChain,
-        signer: EVMSigners,
-        options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await getOrCreateWallet(
-            chain: Chain(chain.name),
-            signer: await signer.signer,
-            options: options
-        )
-    }
-
-    public func getOrCreateWallet(
-        chain: SolanaChain,
-        signer: SolanaSigners,
-        options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await getOrCreateWallet(
-            chain: Chain(chain.name),
-            signer: await signer.signer,
-            options: options
-        )
-    }
-
-    public func getOrCreateWallet(
-        chain: StellarChain,
-        signer: StellarSigners,
-        options: WalletOptions? = nil
-    ) async throws(WalletError) -> Wallet {
-        try await getOrCreateWallet(
-            chain: Chain(chain.name),
-            signer: await signer.signer,
-            options: options
-        )
-    }
-
     public func getOrCreateWallet<C: ChainWithSigners>(
         chain: C,
-        signer: C.SpecificSigner,
-        options: WalletOptions? = nil
+        recovery: C.SpecificSigner
     ) async throws(WalletError) -> Wallet {
-        try await getOrCreateWallet(
-            chain: Chain(chain.name),
-            signer: await signer.signer,
-            options: options
-        )
+        try await getOrCreateWallet(chain: chain, recovery: recovery, options: nil)
     }
 }
 

--- a/Sources/Wallet/Data/DefaultSmartWalletService.swift
+++ b/Sources/Wallet/Data/DefaultSmartWalletService.swift
@@ -372,7 +372,7 @@ public final class DefaultSmartWalletService: SmartWalletService {
         }
     }
 
-    public func addDelegatedSigner(
+    public func addSigner(
         _ entry: DelegatedSignerEntry,
         chainType: ChainType,
         chainName: String

--- a/Sources/Wallet/Data/GetWallet/Response/WalletConfigApiModel.swift
+++ b/Sources/Wallet/Data/GetWallet/Response/WalletConfigApiModel.swift
@@ -7,35 +7,35 @@ public struct WalletDelegatedSignerConfigApiModel: Decodable {
 }
 
 public struct WalletConfigApiModel: Decodable {
-    public let adminSigner: AdminSignerApiModel
-    public let delegatedSigners: [WalletDelegatedSignerConfigApiModel]?
+    public let recovery: AdminSignerApiModel
+    public let signers: [WalletDelegatedSignerConfigApiModel]?
 
     enum CodingKeys: String, CodingKey {
-        case adminSigner
-        case delegatedSigners
+        case recovery = "adminSigner"
+        case signers = "delegatedSigners"
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         // Decode the "type" field first to determine the correct signer type
-        let tempContainer = try container.nestedContainer(keyedBy: AdminSignerCodingKeys.self, forKey: .adminSigner)
+        let tempContainer = try container.nestedContainer(keyedBy: AdminSignerCodingKeys.self, forKey: .recovery)
         let type = try tempContainer.decode(AdminSignerDataType.self, forKey: .type)
 
         switch type {
         case .passkey:
-            adminSigner = try container.decode(EvmPasskeySignerApiModel.self, forKey: .adminSigner)
+            recovery = try container.decode(EvmPasskeySignerApiModel.self, forKey: .recovery)
         case .email:
-            adminSigner = try container.decode(EmailSignerApiModel.self, forKey: .adminSigner)
+            recovery = try container.decode(EmailSignerApiModel.self, forKey: .recovery)
         case .phone:
-            adminSigner = try container.decode(PhoneSignerApiModel.self, forKey: .adminSigner)
+            recovery = try container.decode(PhoneSignerApiModel.self, forKey: .recovery)
         case .apiKey:
-            adminSigner = try container.decode(ApiKeySignerApiModel.self, forKey: .adminSigner)
+            recovery = try container.decode(ApiKeySignerApiModel.self, forKey: .recovery)
         case .externalWallet:
-            adminSigner = try container.decode(ExternalWalletSignerApiModel.self, forKey: .adminSigner)
+            recovery = try container.decode(ExternalWalletSignerApiModel.self, forKey: .recovery)
         }
 
-        delegatedSigners = try container.decodeIfPresent([WalletDelegatedSignerConfigApiModel].self, forKey: .delegatedSigners)
+        signers = try container.decodeIfPresent([WalletDelegatedSignerConfigApiModel].self, forKey: .signers)
     }
 
     private enum AdminSignerCodingKeys: String, CodingKey {
@@ -43,6 +43,6 @@ public struct WalletConfigApiModel: Decodable {
     }
 
     var toDomain: WalletConfig {
-        WalletConfig(adminSigner: adminSigner.toDomain)
+        WalletConfig(recovery: recovery.toDomain)
     }
 }

--- a/Sources/Wallet/Data/SmartWalletService.swift
+++ b/Sources/Wallet/Data/SmartWalletService.swift
@@ -59,7 +59,7 @@ public protocol SmartWalletService: AuthenticatedService, Sendable {
         chainType: ChainType
     ) async throws(SignatureError) -> any SignatureApiModel
 
-    func addDelegatedSigner(
+    func addSigner(
         _ entry: DelegatedSignerEntry,
         chainType: ChainType,
         chainName: String

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -310,7 +310,6 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
         for entry in signers {
             guard let locator = entry.locator, locator.hasPrefix("device:") else { continue }
             let b64 = String(locator.dropFirst("device:".count))
-            guard let data = Data(base64Encoded: b64), data.count == 65, data.first == 0x04 else { continue }
             if storage.hasKey(publicKeyBase64: b64) {
                 return b64
             }

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -281,7 +281,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
     ) async {
         let existingPublicKeyBase64 = await storage.getKey(address: walletApiModel.address)
         guard !isDeviceSignerRegistered(existingPublicKeyBase64, in: walletApiModel) else { return }
-        guard let deviceSignerPendingAssignment = await findMatchingDeviceSignerKey(in: walletApiModel, storage: storage) else { return }
+        guard let deviceSignerPendingAssignment = findMatchingDeviceSignerKey(in: walletApiModel, storage: storage) else { return }
 
         do {
             try await storage.mapAddressToKey(
@@ -305,13 +305,13 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
     private func findMatchingDeviceSignerKey(
         in wallet: WalletApiModel,
         storage: any DeviceSignerKeyStorage
-    ) async -> String? {
+    ) -> String? {
         guard let signers = wallet.config.signers else { return nil }
         for entry in signers {
             guard let locator = entry.locator, locator.hasPrefix("device:") else { continue }
             let b64 = String(locator.dropFirst("device:".count))
             guard let data = Data(base64Encoded: b64), data.count == 65, data.first == 0x04 else { continue }
-            if await storage.hasKey(publicKeyBase64: b64) {
+            if storage.hasKey(publicKeyBase64: b64) {
                 return b64
             }
         }

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -19,8 +19,20 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
         Logger.smartWallet.info(LogEvents.sdkInitialized)
     }
 
+    public func getOrCreateWallet<C: ChainWithSigners>(
+        chain: C,
+        recovery: C.SpecificSigner,
+        options: WalletOptions?
+    ) async throws(WalletError) -> Wallet {
+        try await getOrCreateWalletCore(
+            chain: Chain(chain.name),
+            signer: await recovery.signer,
+            options: options
+        )
+    }
+
     // swiftlint:disable:next function_body_length cyclomatic_complexity
-    public func getOrCreateWallet(
+    private func getOrCreateWalletCore(
         chain: Chain,
         signer: any Signer,
         options: WalletOptions? = nil
@@ -43,7 +55,7 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
         let walletApiModel: WalletApiModel
         do {
             walletApiModel = try await smartWalletService.getWallet(GetMeWalletRequest(chainType: chain.chainType))
-            let signers = walletApiModel.config.delegatedSigners?.compactMap(\.locator) ?? []
+            let signers = walletApiModel.config.signers?.compactMap(\.locator) ?? []
             let existingDelegatedLocators = signers.isEmpty ? "none" : signers.joined(separator: ", ")
             Logger.smartWallet.debug(LogEvents.walletGetOrCreateExisting, attributes: [
                 "chain": chain.name,
@@ -69,7 +81,7 @@ public final class DefaultCrossmintWallets: CrossmintWallets, Sendable {
                         }
                         publicKeyBase64 = key
                         let entry = try makeDelegatedSignerEntry(publicKeyBase64: key)
-                        let registration = try await smartWalletService.addDelegatedSigner(
+                        let registration = try await smartWalletService.addSigner(
                             entry, chainType: chain.chainType, chainName: chain.name
                         )
                         if let chainEntry = registration.chains?[chain.name],
@@ -267,7 +279,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
                 }
             }
 
-            let createSigners = walletApiModel.config.delegatedSigners?.compactMap(\.locator) ?? []
+            let createSigners = walletApiModel.config.signers?.compactMap(\.locator) ?? []
             let delegatedSignerLocators = createSigners.isEmpty ? "none" : createSigners.joined(separator: ", ")
             Logger.smartWallet.debug(LogEvents.walletCreateSuccess, attributes: [
                 "chainType": chainType.rawValue,
@@ -301,7 +313,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
         }
         let uncompressed = Data([0x04]) + rawKey
         let locator = "device:\(uncompressed.base64EncodedString())"
-        return wallet.config.delegatedSigners?.contains(where: { $0.locator == locator }) ?? false
+        return wallet.config.signers?.contains(where: { $0.locator == locator }) ?? false
     }
 
     private func makeDelegatedSignerEntry(publicKeyBase64: String) throws(WalletError) -> DelegatedSignerEntry {

--- a/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
+++ b/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
@@ -56,7 +56,7 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
                 value: "\(value ?? .zero)",
                 data: data ?? "0x",
                 chain: chain,
-                signer: self.config.adminSigner.locator
+                signer: self.config.recovery.locator
             )
         ) else {
             throw .transactionGeneric("Unknown error")
@@ -83,7 +83,7 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
                 value: value ?? "0",
                 data: data ?? "0x",
                 chain: chain ?? self.evmChain,
-                signer: self.config.adminSigner.locator
+                signer: self.config.recovery.locator
             )
         ) else {
             throw .transactionGeneric("Unknown error")
@@ -112,7 +112,7 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
     ) async throws(SignatureError) -> String {
         Logger.smartWallet.info(LogEvents.evmSignMessageStart)
 
-        let signer = signer ?? self.config.adminSigner
+        let signer = signer ?? self.config.recovery
 
         do {
             let signatureRequest = SignMessageRequest(
@@ -164,7 +164,7 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
     ) async throws(SignatureError) -> String {
         Logger.smartWallet.info(LogEvents.evmSignTypedDataStart)
 
-        let signer = signer ?? self.config.adminSigner
+        let signer = signer ?? self.config.recovery
 
         do {
             let signatureRequest = typedData.toSignTypedDataRequest(

--- a/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
+++ b/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
@@ -23,7 +23,7 @@ public final class SolanaWallet: Wallet, WalletOnChain, @unchecked Sendable {
     ) throws(WalletError) {
         var effectiveSigner = signer
 
-        switch baseModel.config.adminSigner.type {
+        switch baseModel.config.recovery.type {
         case .apiKey:
             effectiveSigner = ApiKeySigner()
         default:

--- a/Sources/Wallet/Model/Wallet/Stellar/StellarWallet.swift
+++ b/Sources/Wallet/Model/Wallet/Stellar/StellarWallet.swift
@@ -31,7 +31,7 @@ public final class StellarWallet: Wallet, WalletOnChain, @unchecked Sendable {
         var effectiveSigner = signer
 
         // Switch to API key signer if wallet uses API key admin
-        switch baseModel.config.adminSigner.type {
+        switch baseModel.config.recovery.type {
         case .apiKey:
             effectiveSigner = ApiKeySigner()
         default:

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -394,7 +394,7 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
 
     internal func updateSignerIfRequired() async -> any Signer {
         var updatedSigner: any Signer = signer
-        if let passkey = config.adminSigner as? PasskeySignerData {
+        if let passkey = config.recovery as? PasskeySignerData {
             if let passkeySigner = updatedSigner as? PasskeySigner {
                 updatedSigner = await passkeySigner.updateAdminSigner(
                     passkey

--- a/Sources/Wallet/Model/Wallet/WalletConfig.swift
+++ b/Sources/Wallet/Model/Wallet/WalletConfig.swift
@@ -2,5 +2,5 @@ import CrossmintCommonTypes
 import Foundation
 
 public struct WalletConfig {
-    public let adminSigner: AdminSignerData
+    public let recovery: AdminSignerData
 }

--- a/Tests/WalletTests/Data/Responses/WalletApiModelTest.swift
+++ b/Tests/WalletTests/Data/Responses/WalletApiModelTest.swift
@@ -14,7 +14,7 @@ struct WalletApiModelTest {
             bundle: Bundle.module
         )
 
-        #expect(wallet.config.adminSigner.type == .passkey)
+        #expect(wallet.config.recovery.type == .passkey)
     }
 
     @Test(
@@ -26,8 +26,8 @@ struct WalletApiModelTest {
             bundle: Bundle.module
         )
 
-        #expect(wallet.config.adminSigner.type == .externalWallet)
-        let locator = wallet.config.adminSigner.toDomain.locator
+        #expect(wallet.config.recovery.type == .externalWallet)
+        let locator = wallet.config.recovery.toDomain.locator
         let expectedLocator = "external-wallet:0x1234567890123456789012345678901234567890"
         #expect(locator == expectedLocator)
     }
@@ -41,8 +41,8 @@ struct WalletApiModelTest {
             bundle: Bundle.module
         )
 
-        #expect(wallet.config.adminSigner.type == .externalWallet)
-        let locator = wallet.config.adminSigner.toDomain.locator
+        #expect(wallet.config.recovery.type == .externalWallet)
+        let locator = wallet.config.recovery.toDomain.locator
         let expectedLocator = "external-wallet:EX2jMfAdfUKSqh7415jsTzGE1KMepXPeqM4vXyCpVXGc"
         #expect(locator == expectedLocator)
     }
@@ -56,8 +56,8 @@ struct WalletApiModelTest {
             bundle: Bundle.module
         )
 
-        #expect(wallet.config.adminSigner.type == .apiKey)
-        let locator = wallet.config.adminSigner.toDomain.locator
+        #expect(wallet.config.recovery.type == .apiKey)
+        let locator = wallet.config.recovery.toDomain.locator
         // New ApiKeySignerData uses fixed locatorId
         let expectedLocator = "api-key:api-key"
         #expect(locator == expectedLocator)
@@ -72,8 +72,8 @@ struct WalletApiModelTest {
             bundle: Bundle.module
         )
 
-        #expect(wallet.config.adminSigner.type == .email)
-        let locator = wallet.config.adminSigner.toDomain.locator
+        #expect(wallet.config.recovery.type == .email)
+        let locator = wallet.config.recovery.toDomain.locator
         let expectedLocator = "email:user@example.com"
         #expect(locator == expectedLocator)
     }
@@ -87,8 +87,8 @@ struct WalletApiModelTest {
             bundle: Bundle.module
         )
 
-        #expect(wallet.config.adminSigner.type == .email)
-        let locator = wallet.config.adminSigner.toDomain.locator
+        #expect(wallet.config.recovery.type == .email)
+        let locator = wallet.config.recovery.toDomain.locator
         let expectedLocator = "email:solana.user@example.com"
         #expect(locator == expectedLocator)
     }
@@ -102,8 +102,8 @@ struct WalletApiModelTest {
             bundle: Bundle.module
         )
 
-        #expect(wallet.config.adminSigner.type == .phone)
-        let locator = wallet.config.adminSigner.toDomain.locator
+        #expect(wallet.config.recovery.type == .phone)
+        let locator = wallet.config.recovery.toDomain.locator
         let expectedLocator = "phone:+14155552671"
         #expect(locator == expectedLocator)
     }


### PR DESCRIPTION
Public API parameter names have been updated to match the V1 release of the TS SDK:

- `adminSigner` renamed to `recovery`
- `delegatedSigners` renamed to `signers`
- `addDelegatedSigner` renamed to `addSigner`

`hasKey(publicKeyBase64:) async -> Bool` has been added to `DeviceSignerKeyStorage`. It returns `true` if a matching private key lives on this device, whether under a pending tag or mapped to a wallet address.

## Changes
- Rename `adminSigner` to `recovery` in `WalletConfig`, `WalletConfigApiModel`, and all wallet types; rename `delegatedSigners` to `signers` in `WalletConfigApiModel` and `DefaultCrossmintWallets`
- Rename `addDelegatedSigner` to `addSigner` in `SmartWalletService` and `DefaultSmartWalletService`
- Update `CrossmintWallets` protocol parameter `signer:` to `recovery:` and update call sites in both demo apps
- Add `hasKey(publicKeyBase64:) async -> Bool` to `DeviceSignerKeyStorage`
- Add `hasMatchingKey` and `allTags(prefix:)` to `DeviceSignerKeychainStorage`; extract tag prefix strings to `static let` constants
- Implement `hasKey` in `SecureEnclaveKeyStorage` and `SoftwareDeviceSignerKeyStorage`