### PR TITLE
WAL-9410: Add useSigner, addSigner, needsRecovery, recover to Wallet

### DIFF
--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -327,22 +327,17 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
     }
 
     private func isDeviceSignerRegistered(_ publicKeyBase64: String?, in wallet: WalletApiModel) -> Bool {
-        guard let keyBase64 = publicKeyBase64,
-              let rawKey = Data(base64Encoded: keyBase64), rawKey.count == 64 else {
-            return false
-        }
-        let uncompressed = Data([0x04]) + rawKey
-        let locator = "device:\(uncompressed.base64EncodedString())"
+        guard let keyBase64 = publicKeyBase64 else { return false }
+        let locator = "device:\(keyBase64)"
         return wallet.config.signers?.contains(where: { $0.locator == locator }) ?? false
     }
 
     private func makeDelegatedSignerEntry(publicKeyBase64: String) throws(WalletError) -> DelegatedSignerEntry {
-        guard let rawPublicKey = Data(base64Encoded: publicKeyBase64), rawPublicKey.count == 64 else {
+        guard let rawPublicKey = Data(base64Encoded: publicKeyBase64),
+              rawPublicKey.count == 65, rawPublicKey.first == 0x04 else {
             throw WalletError.walletCreationFailed("Invalid device signer public key")
         }
-        // Build uncompressed P256 point: 0x04 || x (32 bytes) || y (32 bytes)
-        let uncompressed = Data([0x04]) + rawPublicKey
-        return DelegatedSignerEntry(signer: "device:\(uncompressed.base64EncodedString())")
+        return DelegatedSignerEntry(signer: "device:\(publicKeyBase64)")
     }
 
     private func approveDelegatedSignerRegistration(

--- a/Sources/Wallet/Model/Wallet/SignerConfig.swift
+++ b/Sources/Wallet/Model/Wallet/SignerConfig.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Identifies a signing key that can be attached to a wallet.
+///
+/// Pass a `SignerConfig` to ``Wallet/useSigner(_:)``, ``Wallet/addSigner(_:)``, or
+/// ``Wallet/recover()`` to configure how the wallet signs transactions on this device.
+public enum SignerConfig {
+    /// A hardware-backed P-256 key stored in the Secure Enclave (or a Keychain fallback
+    /// when Secure Enclave is unavailable). The SDK generates and manages the key automatically.
+    case device
+
+    /// An email address registered as a delegated signer.
+    case email(String)
+
+    /// A phone number registered as a delegated signer.
+    case phone(String)
+
+    /// An external wallet address (EVM, Solana, or Stellar) registered as a delegated signer.
+    case externalWallet(address: String)
+}

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -1,5 +1,6 @@
 // swiftlint:disable file_length
 import CrossmintCommonTypes
+import CryptoKit
 import DeviceSigner
 import Foundation
 import Logger
@@ -16,6 +17,8 @@ open class Wallet: @unchecked Sendable {
     internal let signer: any Signer
     internal let chain: Chain
     var deviceSignerKeyStorage: (any DeviceSignerKeyStorage)?
+    private var delegatedSignerLocators: [String]
+    private var isDeviceSignerReady = false
 
     private let owner: Owner?
     private let createdAt: Date
@@ -40,6 +43,7 @@ open class Wallet: @unchecked Sendable {
         self.blockchainAddress = address
         self.createdAt = baseModel.createdAt
         self.config = baseModel.config.toDomain
+        self.delegatedSignerLocators = baseModel.config.signers?.compactMap(\.locator) ?? []
         self.signer = signer
         self.chain = chain
         self.onTransactionStart = onTransactionStart
@@ -325,52 +329,157 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
         }
     }
 
-    /// Lazily registers a new device signer if one is configured but no key exists for this wallet address.
+    // MARK: - Public signer management
+
+    /// Sets the active signer for this wallet on the current device.
     ///
-    /// Called before the first transfer transaction so the device signer is in place when the
-    /// backend routes the transaction through it. Best-effort: any error is logged and the
-    /// wallet continues without a device signer.
+    /// For `.device`, the key is provisioned lazily on the first transaction if it does not
+    /// already exist, so this method never throws. Call ``addSigner(_:)`` or ``recover()``
+    /// to register the key eagerly.
+    public func useSigner(_ signer: SignerConfig) {
+        switch signer {
+        case .device:
+            ensureDeviceSignerStorage()
+        case .email, .phone, .externalWallet:
+            break
+        }
+    }
+
+    /// Registers a new signer on this wallet.
+    ///
+    /// For `.device`, generates a hardware-backed P-256 key and registers it as a delegated
+    /// signer via the approval flow. Does nothing if this device already has a key for the wallet.
+    /// For `.email`, `.phone`, and `.externalWallet`, registers the locator via the API and
+    /// approves using the recovery signer.
+    public func addSigner(_ signer: SignerConfig) async throws(WalletError) {
+        switch signer {
+        case .device:
+            ensureDeviceSignerStorage()
+            try await performDeviceSignerRegistration()
+        case .email(let email):
+            try await registerDelegatedSigner(locator: "email:\(email)")
+        case .phone(let phone):
+            try await registerDelegatedSigner(locator: "phone:\(phone)")
+        case .externalWallet(let address):
+            try await registerDelegatedSigner(locator: "external-wallet:\(address)")
+        }
+    }
+
+    /// Returns `true` when the wallet has a device signer registered on the backend but
+    /// the current device does not hold a matching key.
+    ///
+    /// Call ``recover()`` to generate a new key and re-register on this device.
+    public func needsRecovery() async -> Bool {
+        guard delegatedSignerLocators.contains(where: { $0.hasPrefix("device:") }) else {
+            return false
+        }
+        guard let storage = deviceSignerKeyStorage else { return true }
+        return await storage.getKey(address: address) == nil
+    }
+
+    /// Generates a new device key and registers it on the wallet using the recovery signer.
+    ///
+    /// Use this when ``needsRecovery()`` returns `true` (e.g., the wallet was set up on another
+    /// device). Called automatically before the first transaction when recovery is needed.
+    public func recover() async throws(WalletError) {
+        ensureDeviceSignerStorage()
+        try await performDeviceSignerRegistration()
+    }
+
+    /// Returns `true` if the given signer locator is registered on this wallet.
+    public func signerIsRegistered(_ locator: String) -> Bool {
+        delegatedSignerLocators.contains(locator)
+    }
+
+    // MARK: - Internal helpers
+
+    /// Lazily registers a device signer before the first transaction. Best-effort — errors are logged and the wallet proceeds without one.
     internal func ensureDeviceSignerRegistered() async {
-        guard let storage = deviceSignerKeyStorage,
-              await storage.getKey(address: address) == nil else { return }
+        guard deviceSignerKeyStorage != nil, !isDeviceSignerReady else { return }
+        do {
+            try await performDeviceSignerRegistration()
+        } catch {
+            Logger.smartWallet.warn(LogEvents.walletAddDelegatedSignerError, attributes: [
+                "error": "\(error)"
+            ])
+        }
+    }
+
+    private func registerDelegatedSigner(locator: String) async throws(WalletError) {
+        guard !delegatedSignerLocators.contains(locator) else { return }
+
+        let registration: AddDelegatedSignerResponse
+        do {
+            registration = try await smartWalletService.addSigner(
+                DelegatedSignerEntry(signer: locator),
+                chainType: chain.chainType,
+                chainName: chain.name
+            )
+        } catch {
+            throw .signerRegistrationFailed(error)
+        }
+
+        do {
+            try await approveAddDelegatedSigner(registration: registration)
+            delegatedSignerLocators.append(locator)
+        } catch {
+            throw .signerRegistrationFailed(error)
+        }
+    }
+
+    private func performDeviceSignerRegistration() async throws(WalletError) {
+        guard let storage = deviceSignerKeyStorage else { return }
+
+        guard await storage.getKey(address: address) == nil else {
+            isDeviceSignerReady = true
+            return
+        }
 
         Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerStart, attributes: [
             "address": address
         ])
 
-        var publicKeyBase64: String?
-        var registeredOnBackend = false
+        let pubKey: String
         do {
-            let pubKey = try await storage.generateKey(address: nil)
-            publicKeyBase64 = pubKey
+            pubKey = try await storage.generateKey(address: nil)
+        } catch {
+            throw .signerRegistrationFailed(error)
+        }
 
-            guard let rawPublicKey = Data(base64Encoded: pubKey), rawPublicKey.count == 64 else {
-                throw DeviceSignerError.keyGenerationFailed
-            }
-            let uncompressed = Data([0x04]) + rawPublicKey
-            let entry = DelegatedSignerEntry(signer: "device:\(uncompressed.base64EncodedString())")
-
-            let registration = try await smartWalletService.addSigner(
-                entry,
+        let locator = "device:\(pubKey)"
+        let registration: AddDelegatedSignerResponse
+        do {
+            registration = try await smartWalletService.addSigner(
+                DelegatedSignerEntry(signer: locator),
                 chainType: chain.chainType,
                 chainName: chain.name
             )
-            registeredOnBackend = true
+        } catch {
+            try? await storage.deletePendingKey(publicKeyBase64: pubKey)
+            throw .signerRegistrationFailed(error)
+        }
 
+        do {
             try await approveAddDelegatedSigner(registration: registration)
-
             try await storage.mapAddressToKey(address: address, publicKeyBase64: pubKey)
+            delegatedSignerLocators.append(locator)
+            isDeviceSignerReady = true
             Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerSuccess, attributes: [
                 "address": address
             ])
         } catch {
-            if let pubKey = publicKeyBase64, !registeredOnBackend {
-                try? await storage.deletePendingKey(publicKeyBase64: pubKey)
-            }
-            Logger.smartWallet.warn(LogEvents.walletAddDelegatedSignerError, attributes: [
-                "error": "\(error)"
-            ])
+            throw .signerRegistrationFailed(error)
         }
+    }
+
+    private func ensureDeviceSignerStorage() {
+        if deviceSignerKeyStorage == nil {
+            deviceSignerKeyStorage = makeDeviceSignerKeyStorage()
+        }
+    }
+
+    private func makeDeviceSignerKeyStorage() -> any DeviceSignerKeyStorage {
+        SecureEnclave.isAvailable ? SecureEnclaveKeyStorage() : KeychainKeyStorage()
     }
 
     private func approveAddDelegatedSigner(registration: AddDelegatedSignerResponse) async throws {
@@ -395,11 +504,8 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
 
     private func deviceSignerLocator() async -> String? {
         guard let storage = deviceSignerKeyStorage,
-              let publicKeyBase64 = await storage.getKey(address: address),
-              let rawKey = Data(base64Encoded: publicKeyBase64),
-              rawKey.count == 64 else { return nil }
-        let uncompressed = Data([0x04]) + rawKey
-        return "device:\(uncompressed.base64EncodedString())"
+              let publicKeyBase64 = await storage.getKey(address: address) else { return nil }
+        return "device:\(publicKeyBase64)"
     }
 
     internal func transferTokenAndPollWhilePending(

--- a/Sources/Wallet/Model/Wallet/WalletError.swift
+++ b/Sources/Wallet/Model/Wallet/WalletError.swift
@@ -15,6 +15,7 @@ public enum WalletError: ServiceError {
     case transactionNotFound
     case invalidChain(chain: Chain)
     case invalidToken(token: CryptoCurrency)
+    case signerRegistrationFailed(Error)
 
     public var errorMessage: String {
         switch self {
@@ -39,6 +40,8 @@ public enum WalletError: ServiceError {
             return "Invalid chain: \(chain.name)"
         case .invalidToken(let token):
             return "Invalid token: \(token.name)"
+        case .signerRegistrationFailed(let error):
+            return "Signer registration failed: \(error.localizedDescription)"
         }
     }
 


### PR DESCRIPTION
This pull request adds the signer management API to the `Wallet` base class, aligning the iOS SDK with the `wallets-v1` release of the TS SDK.

`useSigner(_:)` sets the active signer for this device without making any API calls. `addSigner(_:)` registers a new delegated signer on the wallet via the API and approves it using the recovery signer. `needsRecovery()` returns `true` when the wallet has a device signer on the backend but the current device does not hold a matching key. `recover()` generates a new key and re-registers it. `signerIsRegistered(_:)` provides a synchronous check against the locally cached list of signer locators.

`SignerConfig` is expanded beyond `.device` to cover all delegated signer types the backend supports: `.email`, `.phone`, and `.externalWallet`. A shared `registerDelegatedSigner(locator:)` helper handles the add + approve flow for all non-device types, keeping `addSigner` clean.

A bug in device signer locator construction is also fixed: the public key stored by `DeviceSignerKeyStorage` is the 65-byte uncompressed representation (`0x04 || x || y`), but several call sites were treating it as a 64-byte raw key and manually prepending `0x04`. This caused silent mismatches when comparing locators.

## Changes

- **`SignerConfig`**: add `.email(String)`, `.phone(String)`, and `.externalWallet(address: String)` cases
- **`Wallet`**: add `useSigner(_:)`, `addSigner(_:)`, `needsRecovery()`, `recover()`, and `signerIsRegistered(_:)`; add private `registerDelegatedSigner(locator:)` helper; add `isDeviceSignerReady` flag to skip redundant keychain reads; extract `ensureDeviceSignerStorage()` and `makeDeviceSignerKeyStorage()`
- **`WalletError`**: add `signerRegistrationFailed(Error)` case
- **`DefaultCrossmintWallets`**: fix `makeDelegatedSignerEntry` and `isDeviceSignerRegistered` to use the 65-byte uncompressed public key directly instead of expecting 64 bytes and prepending `0x04`