### PR TITLE
Add removeSigner to Wallet

### DIFF
--- a/Sources/Http/Endpoint.swift
+++ b/Sources/Http/Endpoint.swift
@@ -6,6 +6,7 @@ public struct Endpoint: Hashable {
         case post = "POST"
         case put = "PUT"
         case patch = "PATCH"
+        case delete = "DELETE"
     }
 
     public let path: String

--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -344,6 +344,17 @@ public enum LogEvents {
     /// Delegated signers retrieved
     public static let walletDelegatedSignersSuccess = "wallet.delegatedSigners.success"
 
+    // MARK: - Remove Signer Events
+
+    /// Starting remove signer
+    public static let walletRemoveSignerStart = "wallet.removeSigner.start"
+
+    /// Remove signer succeeded
+    public static let walletRemoveSignerSuccess = "wallet.removeSigner.success"
+
+    /// Remove signer failed
+    public static let walletRemoveSignerError = "wallet.removeSigner.error"
+
     // MARK: - Device Signer Events
 
     /// Device signer key prepared for new wallet creation

--- a/Sources/Wallet/Data/DefaultSmartWalletService.swift
+++ b/Sources/Wallet/Data/DefaultSmartWalletService.swift
@@ -402,6 +402,28 @@ public final class DefaultSmartWalletService: SmartWalletService {
         }
     }
 
+    public func removeSigner(
+        _ signerLocator: String,
+        chainType: ChainType,
+        chainName: String
+    ) async throws(TransactionError) -> any TransactionApiModel {
+        let allowedChars = CharacterSet.alphanumerics.union(.init(charactersIn: "-._~:"))
+        let encodedLocator = signerLocator.addingPercentEncoding(withAllowedCharacters: allowedChars) ?? signerLocator
+
+        var queryItems: [URLQueryItem] = []
+        if chainType != .solana && chainType != .stellar {
+            queryItems = [URLQueryItem(name: "chain", value: chainName)]
+        }
+
+        let endpoint = Endpoint(
+            path: "/2025-06-09/wallets/me:\(chainType.rawValue)/signers/\(encodedLocator)",
+            method: .delete,
+            headers: await authHeaders,
+            queryItems: queryItems
+        )
+        return try await executeTransactionRequest(endpoint: endpoint, mapping: chainType.mappingType)
+    }
+
     public func listTransfers(
         _ params: ListTransfersQueryParams
     ) async throws(WalletError) -> TransferListResult {

--- a/Sources/Wallet/Data/SmartWalletService.swift
+++ b/Sources/Wallet/Data/SmartWalletService.swift
@@ -65,6 +65,12 @@ public protocol SmartWalletService: AuthenticatedService, Sendable {
         chainName: String
     ) async throws(WalletError) -> AddDelegatedSignerResponse
 
+    func removeSigner(
+        _ signerLocator: String,
+        chainType: ChainType,
+        chainName: String
+    ) async throws(TransactionError) -> any TransactionApiModel
+
     /// Fetches the transfer history for a wallet.
     ///
     /// - Note: This endpoint uses the `/unstable/` API prefix, meaning the API may change

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -119,6 +119,36 @@ open class Wallet: @unchecked Sendable {
         }
     }
 
+    public func removeSigner(locator: String) async throws(TransactionError) -> Transaction {
+        Logger.smartWallet.info(LogEvents.walletRemoveSignerStart, attributes: [
+            "locator": locator
+        ])
+
+        do {
+            let transactionModel = try await smartWalletService.removeSigner(
+                locator,
+                chainType: chain.chainType,
+                chainName: chain.name
+            )
+            guard let transaction = transactionModel.toDomain(withService: smartWalletService) else {
+                throw TransactionError.transactionGeneric("Failed to parse remove signer response")
+            }
+            guard let result = try await signAndPollWhilePending(transaction) else {
+                throw TransactionError.transactionGeneric("Unknown error")
+            }
+            Logger.smartWallet.info(LogEvents.walletRemoveSignerSuccess, attributes: [
+                "locator": locator
+            ])
+            return result
+        } catch {
+            Logger.smartWallet.error(LogEvents.walletRemoveSignerError, attributes: [
+                "locator": locator,
+                "error": "\(error)"
+            ])
+            throw error as? TransactionError ?? .transactionGeneric("Unknown error")
+        }
+    }
+
     @available(*, deprecated, renamed: "balances", message: "Use the balances(tokens) instead")
     public func balance(
         of tokens: [CryptoCurrency] = []

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -134,6 +134,7 @@ open class Wallet: @unchecked Sendable {
         ])
 
         do {
+            onTransactionStart?()
             let transactionModel = try await smartWalletService.removeSigner(
                 locator,
                 chainType: chain.chainType,

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -119,6 +119,15 @@ open class Wallet: @unchecked Sendable {
         }
     }
 
+    /// Removes an assigned signer from this wallet.
+    ///
+    /// Submits a remove-signer transaction on-chain. If the transaction requires approval,
+    /// the current signer signs it automatically before polling for completion.
+    ///
+    /// - Parameter locator: The signer locator string identifying the signer to remove
+    ///   (e.g. `"device:ABC123..."`, `"external-wallet:0x456..."`).
+    /// - Returns: The completed ``Transaction`` once the signer has been removed on-chain.
+    /// - Throws: ``TransactionError`` if the request fails or the transaction is rejected.
     public func removeSigner(locator: String) async throws(TransactionError) -> Transaction {
         Logger.smartWallet.info(LogEvents.walletRemoveSignerStart, attributes: [
             "locator": locator


### PR DESCRIPTION
This pull request adds a new `removeSigner(locator:)` method to wallet, allowing users to remove a currently assigned signer from a wallet

The new method returns a transaction. If the transaction requires approval, it runs the existing sign and poll flow via `signAndPollWhilePending`, just like in the existing  `approve(transactionId:)` method

```swift
let transaction = try await wallet.removeSigner(locator: "device:ABC123...")
// transaction.status == .success
```

## Changes

- `Endpoint.Method`: added new `.delete` case to perform DELETE HTTP requests
- `SmartWalletService`: new `removeSigner(_:chainType:chainName:)` protocol method returning `any TransactionApiModel`
- `DefaultSmartWalletService`: implements `removeSigner` — URL-encodes the signer locator, appends `?chain=` for EVM (omitted for Solana/Stellar), delegates to `executeTransactionRequest`
- `Wallet`: new `public func removeSigner(locator: String) async throws(TransactionError) -> Transaction`
- `LogEvents`: three new constants for remove signer start/success/error
