### PR TITLE
Fix device signer deletion failing

### DIFF
--- a/Sources/CrossmintService/DefaultRequestBuilder.swift
+++ b/Sources/CrossmintService/DefaultRequestBuilder.swift
@@ -17,7 +17,7 @@ public struct DefaultRequestBuilder: RequestBuilder {
         guard var components = URLComponents(url: baseUrl, resolvingAgainstBaseURL: true) else {
             throw .invalidURL
         }
-        components.path += endpoint.path
+        components.percentEncodedPath += endpoint.path
         components.queryItems = endpoint.queryItems
 
         components.percentEncodedQuery = components.percentEncodedQuery?

--- a/Tests/CrossmintServiceTests/DefaultRequestBuilderTest.swift
+++ b/Tests/CrossmintServiceTests/DefaultRequestBuilderTest.swift
@@ -99,4 +99,18 @@ struct DefaultRequestBuilderTest {
 
         #expect(request.httpMethod == "POST")
     }
+
+    @Test("Preserves percent-encoded characters in path")
+    func preservesPercentEncodedPathCharacters() throws {
+        let request = try requestBuilder.getRequest(
+            forEndpoint: .init(
+                path: "/2025-06-09/wallets/me:evm-smart-wallet/signers/device%2Bkey%3Dvalue%2Fextra",
+                method: .delete
+            ),
+            withKey: apiKey,
+            andAppIdentifier: "App-Identifier"
+        )
+
+        #expect(request.url?.absoluteString.contains("device%2Bkey%3Dvalue%2Fextra") == true)
+    }
 }


### PR DESCRIPTION
This pull request fixes a bug which would prevent device signers from an existing wallet to be removed. The issue was that `URLComponents.path` re-encodes any percent-encoded characters in the path, so special characters like `+`, `=`, and `/` already encoded in the signer locator were being double-encoded before reaching the API.

To fix this, the SDK will now pass `URLComponents.percentEncodedPath` instead of `URLComponents.path`, so pre-encoded path segments are passed through as-is instead of being double-encoded