### PR TITLE
Fix hardcoded api key signer locator

### DIFF
--- a/Sources/CrossmintCommonTypes/Blockchain/Models/Wallet/AdminSignerData.swift
+++ b/Sources/CrossmintCommonTypes/Blockchain/Models/Wallet/AdminSignerData.swift
@@ -59,23 +59,29 @@ public struct ExternalWalletSignerData: AdminSignerData {
 }
 
 public struct ApiKeySignerData: AdminSignerData {
+    public let address: String?
+
     public var type: AdminSignerDataType {
         .apiKey
     }
 
     public var locatorId: String {
-        "api-key"
+        address ?? type.rawValue
     }
 
-    public init() {}
+    public init(address: String? = nil) {
+        self.address = address
+    }
 
     private enum CodingKeys: String, CodingKey {
         case type
+        case address
     }
 
     public nonisolated func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(type.rawValue, forKey: .type)
+        try container.encodeIfPresent(address, forKey: .address)
     }
 
     public init(from decoder: Decoder) throws {
@@ -88,6 +94,7 @@ public struct ApiKeySignerData: AdminSignerData {
                 debugDescription: "Expected signer type to be \(AdminSignerDataType.apiKey.rawValue) but found \(type)"
             )
         }
+        self.address = try container.decodeIfPresent(String.self, forKey: .address)
     }
 }
 

--- a/Sources/Wallet/Data/CreateWallet/Signers/ApiKeySigner.swift
+++ b/Sources/Wallet/Data/CreateWallet/Signers/ApiKeySigner.swift
@@ -6,7 +6,7 @@ public class ApiKeySigner: Signer, @unchecked Sendable {
     public typealias AdminType = ApiKeySignerData
     nonisolated public let signerType: SignerType = .apiKey
 
-    public init(adminSigner: ApiKeySignerData = ApiKeySignerData()) {
+    public init(adminSigner: ApiKeySignerData) {
         self.adminSigner = adminSigner
     }
 

--- a/Sources/Wallet/Data/CreateWallet/Signers/ChainCompatibility.swift
+++ b/Sources/Wallet/Data/CreateWallet/Signers/ChainCompatibility.swift
@@ -1,3 +1,4 @@
+import CrossmintCommonTypes
 import Foundation
 import Web
 
@@ -14,7 +15,7 @@ public enum EVMSigners: Sendable, SignerProvider {
     public var signer: any Signer {
         switch self {
         case .apiKey:
-            ApiKeySigner()
+            ApiKeySigner(adminSigner: ApiKeySignerData())
         case let .email(email):
             EVMEmailSigner(email: email, crossmintTEE: CrossmintTEE.shared)
         case let .passkey(name, host):
@@ -31,7 +32,7 @@ public enum SolanaSigners: Sendable, SignerProvider {
     public var signer: any Signer {
         switch self {
         case .apiKey:
-            ApiKeySigner()
+            ApiKeySigner(adminSigner: ApiKeySignerData())
         case let .email(email):
             SolanaEmailSigner(email: email, crossmintTEE: CrossmintTEE.shared)
         }
@@ -46,7 +47,7 @@ public enum StellarSigners: Sendable, SignerProvider {
     public var signer: any Signer {
         switch self {
         case .apiKey:
-            ApiKeySigner()
+            ApiKeySigner(adminSigner: ApiKeySignerData())
         case let .email(email):
             StellarEmailSigner(email: email, crossmintTEE: CrossmintTEE.shared)
         }

--- a/Sources/Wallet/Data/CreateWallet/Signers/Signers.swift
+++ b/Sources/Wallet/Data/CreateWallet/Signers/Signers.swift
@@ -1,3 +1,4 @@
+import CrossmintCommonTypes
 import Web
 
 @available(*, deprecated, message: "Use EVMSigners or SolanaSigners for type-safe chain compatibility")
@@ -12,9 +13,9 @@ public enum Signers: Sendable {
     public var signer: any Signer {
         switch self {
         case .evmFireblocksSigner:
-            ApiKeySigner()
+            ApiKeySigner(adminSigner: ApiKeySignerData())
         case .solanaFireblocksSigner:
-            ApiKeySigner()
+            ApiKeySigner(adminSigner: ApiKeySignerData())
         case let .solanaEmailSigner(email):
             SolanaEmailSigner(email: email, crossmintTEE: CrossmintTEE.shared)
         case let .evmEmailSigner(email):

--- a/Sources/Wallet/Data/GetWallet/Response/ApiKeySignerApiModel.swift
+++ b/Sources/Wallet/Data/GetWallet/Response/ApiKeySignerApiModel.swift
@@ -6,6 +6,6 @@ public struct ApiKeySignerApiModel: AdminSignerApiModel {
     public let locator: String
 
     public var toDomain: any AdminSignerData {
-        ApiKeySignerData()
+        ApiKeySignerData(address: address)
     }
 }

--- a/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
+++ b/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
@@ -25,7 +25,9 @@ public final class SolanaWallet: Wallet, WalletOnChain, @unchecked Sendable {
 
         switch baseModel.config.recovery.type {
         case .apiKey:
-            effectiveSigner = ApiKeySigner()
+            if let apiKeyData = baseModel.config.recovery.toDomain as? ApiKeySignerData {
+                effectiveSigner = ApiKeySigner(adminSigner: apiKeyData)
+            }
         default:
             break
         }

--- a/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
+++ b/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
@@ -25,9 +25,10 @@ public final class SolanaWallet: Wallet, WalletOnChain, @unchecked Sendable {
 
         switch baseModel.config.recovery.type {
         case .apiKey:
-            if let apiKeyData = baseModel.config.recovery.toDomain as? ApiKeySignerData {
-                effectiveSigner = ApiKeySigner(adminSigner: apiKeyData)
+            guard let apiKeyData = baseModel.config.recovery.toDomain as? ApiKeySignerData else {
+                throw .walletGeneric("Recovery signer is not an ApiKeySignerData")
             }
+            effectiveSigner = ApiKeySigner(adminSigner: apiKeyData)
         default:
             break
         }

--- a/Sources/Wallet/Model/Wallet/Stellar/StellarWallet.swift
+++ b/Sources/Wallet/Model/Wallet/Stellar/StellarWallet.swift
@@ -33,9 +33,10 @@ public final class StellarWallet: Wallet, WalletOnChain, @unchecked Sendable {
         // Switch to API key signer if wallet uses API key admin
         switch baseModel.config.recovery.type {
         case .apiKey:
-            if let apiKeyData = baseModel.config.recovery.toDomain as? ApiKeySignerData {
-                effectiveSigner = ApiKeySigner(adminSigner: apiKeyData)
+            guard let apiKeyData = baseModel.config.recovery.toDomain as? ApiKeySignerData else {
+                throw .walletGeneric("Recovery signer is not an ApiKeySignerData")
             }
+            effectiveSigner = ApiKeySigner(adminSigner: apiKeyData)
         default:
             break
         }

--- a/Sources/Wallet/Model/Wallet/Stellar/StellarWallet.swift
+++ b/Sources/Wallet/Model/Wallet/Stellar/StellarWallet.swift
@@ -33,7 +33,9 @@ public final class StellarWallet: Wallet, WalletOnChain, @unchecked Sendable {
         // Switch to API key signer if wallet uses API key admin
         switch baseModel.config.recovery.type {
         case .apiKey:
-            effectiveSigner = ApiKeySigner()
+            if let apiKeyData = baseModel.config.recovery.toDomain as? ApiKeySignerData {
+                effectiveSigner = ApiKeySigner(adminSigner: apiKeyData)
+            }
         default:
             break
         }

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -101,9 +101,11 @@ extension Wallet {
         case .passkey(let name, let host):
             try await activatePasskeySigner(name: name, host: host)
         case .apiKey:
-            let locator = "api-key:api-key"
+            let locator = self.config.recovery.locator
             guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
-            selectedSigner = ApiKeySigner()
+            if let apiKeyData = self.config.recovery as? ApiKeySignerData {
+                selectedSigner = ApiKeySigner(adminSigner: apiKeyData)
+            }
             selectedSignerLocator = locator
         }
     }

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -103,9 +103,10 @@ extension Wallet {
         case .apiKey:
             let locator = self.config.recovery.locator
             guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
-            if let apiKeyData = self.config.recovery as? ApiKeySignerData {
-                selectedSigner = ApiKeySigner(adminSigner: apiKeyData)
+            guard let apiKeyData = self.config.recovery as? ApiKeySignerData else {
+                throw .walletGeneric("Recovery signer is not an ApiKeySignerData")
             }
+            selectedSigner = ApiKeySigner(adminSigner: apiKeyData)
             selectedSignerLocator = locator
         }
     }

--- a/Tests/CrossmintCommonTypesTests/Blockchain/Models/Wallet/AdminSignerDataTests.swift
+++ b/Tests/CrossmintCommonTypesTests/Blockchain/Models/Wallet/AdminSignerDataTests.swift
@@ -63,17 +63,27 @@ struct AdminSignerDataTests {
 
     // MARK: - ApiKeySignerData Tests
 
-    @Test("ApiKeySignerData initialization")
+    @Test("ApiKeySignerData initialization with address")
     func testApiKeySignerDataInit() {
+        let signer = ApiKeySignerData(address: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e")
+
+        #expect(signer.type == .apiKey)
+        #expect(signer.address == "0x742d35Cc6634C0532925a3b844Bc454e4438f44e")
+        #expect(signer.locatorId == "0x742d35Cc6634C0532925a3b844Bc454e4438f44e")
+    }
+
+    @Test("ApiKeySignerData initialization without address falls back to type rawValue")
+    func testApiKeySignerDataInitNoAddress() {
         let signer = ApiKeySignerData()
 
         #expect(signer.type == .apiKey)
+        #expect(signer.address == nil)
         #expect(signer.locatorId == "api-key")
     }
 
-    @Test("ApiKeySignerData JSON encoding")
+    @Test("ApiKeySignerData JSON encoding with address")
     func testApiKeySignerDataEncoding() throws {
-        let signer = ApiKeySignerData()
+        let signer = ApiKeySignerData(address: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e")
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys
@@ -81,14 +91,40 @@ struct AdminSignerDataTests {
         let json = String(data: data, encoding: .utf8)!
 
         let expectedJSON = """
-        {"type":"api-key"}
+        {"address":"0x742d35Cc6634C0532925a3b844Bc454e4438f44e","type":"api-key"}
         """
 
         #expect(json == expectedJSON)
     }
 
-    @Test("ApiKeySignerData JSON decoding")
+    @Test("ApiKeySignerData JSON encoding without address omits address field")
+    func testApiKeySignerDataEncodingNoAddress() throws {
+        let signer = ApiKeySignerData()
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let data = try encoder.encode(signer)
+        let json = String(data: data, encoding: .utf8)!
+
+        #expect(json == #"{"type":"api-key"}"#)
+    }
+
+    @Test("ApiKeySignerData JSON decoding with address")
     func testApiKeySignerDataDecoding() throws {
+        let json = """
+        {"type": "api-key", "address": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"}
+        """
+
+        let data = json.data(using: .utf8)!
+        let signer = try JSONDecoder().decode(ApiKeySignerData.self, from: data)
+
+        #expect(signer.type == .apiKey)
+        #expect(signer.address == "0x742d35Cc6634C0532925a3b844Bc454e4438f44e")
+        #expect(signer.locatorId == "0x742d35Cc6634C0532925a3b844Bc454e4438f44e")
+    }
+
+    @Test("ApiKeySignerData JSON decoding without address")
+    func testApiKeySignerDataDecodingNoAddress() throws {
         let json = """
         {"type": "api-key"}
         """
@@ -97,6 +133,7 @@ struct AdminSignerDataTests {
         let signer = try JSONDecoder().decode(ApiKeySignerData.self, from: data)
 
         #expect(signer.type == .apiKey)
+        #expect(signer.address == nil)
         #expect(signer.locatorId == "api-key")
     }
 
@@ -325,12 +362,25 @@ struct AdminSignerDataTests {
 
     @Test("ApiKeySignerData round-trip encoding/decoding")
     func testApiKeySignerDataRoundTrip() throws {
+        let original = ApiKeySignerData(address: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e")
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ApiKeySignerData.self, from: data)
+
+        #expect(decoded.type == original.type)
+        #expect(decoded.address == original.address)
+        #expect(decoded.locatorId == original.locatorId)
+    }
+
+    @Test("ApiKeySignerData round-trip encoding/decoding without address")
+    func testApiKeySignerDataRoundTripNoAddress() throws {
         let original = ApiKeySignerData()
 
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(ApiKeySignerData.self, from: data)
 
         #expect(decoded.type == original.type)
+        #expect(decoded.address == nil)
         #expect(decoded.locatorId == original.locatorId)
     }
 

--- a/Tests/WalletTests/Data/Responses/WalletApiModelTest.swift
+++ b/Tests/WalletTests/Data/Responses/WalletApiModelTest.swift
@@ -58,8 +58,7 @@ struct WalletApiModelTest {
 
         #expect(wallet.config.recovery.type == .apiKey)
         let locator = wallet.config.recovery.toDomain.locator
-        // New ApiKeySignerData uses fixed locatorId
-        let expectedLocator = "api-key:api-key"
+        let expectedLocator = "api-key:0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb"
         #expect(locator == expectedLocator)
     }
 


### PR DESCRIPTION
`ApiKeySignerData.locatorId` was hardcoded to `"api-key"` regardless of what the server returned, so any operation that matched on the locator would always fail.

The fix adds an `address` field to `ApiKeySignerData` decoded from the API response, used as `locatorId` when present, falling back to `"api-key"` otherwise.

## Changes

- `ApiKeySignerData`: added `address: String?`; `locatorId` returns `address ?? type.rawValue`; encodes/decodes address with `encodeIfPresent`/`decodeIfPresent`
- `ApiKeySignerApiModel`: `toDomain` now passes `address` through to `ApiKeySignerData`
- `ApiKeySigner`: removed default value from `adminSigner` init; all call sites updated to pass explicit `ApiKeySignerData()`
- `SolanaWallet`, `StellarWallet`, `Wallet+SignerManagement`: updated recovery signer setup to cast `toDomain` to `ApiKeySignerData` and pass it through
- `AdminSignerDataTests`: expanded to cover with-address and without-address cases for init, encoding, decoding, and round-trip