### PR TITLE
Add local email validation before OTP request

### DIFF
--- a/Sources/CrossmintAuth/AuthManager.swift
+++ b/Sources/CrossmintAuth/AuthManager.swift
@@ -10,11 +10,14 @@ public protocol AuthManager: Sendable {
 public enum AuthManagerError: Swift.Error {
     case unknown(String)
     case serviceError(String)
+    case invalidEmail
 
     public var errorMessage: String {
         return switch self {
-            case .unknown(let message), .serviceError(let message):
-                message
+        case .unknown(let message), .serviceError(let message):
+            message
+        case .invalidEmail:
+            "Invalid email address"
         }
     }
 }

--- a/Sources/CrossmintAuth/DefaultAuthManager.swift
+++ b/Sources/CrossmintAuth/DefaultAuthManager.swift
@@ -1,6 +1,7 @@
 import Logger
 import CrossmintService
 import SecureStorage
+import Utils
 
 public actor CrossmintAuthManager: AuthManager {
     enum Errors: Error {
@@ -77,6 +78,9 @@ public actor CrossmintAuthManager: AuthManager {
         forceRefresh: Bool = false
     ) async throws(AuthManagerError) -> OTPAuthenticationStatus {
         let normalizedEmail = email.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isValidEmail(normalizedEmail) else {
+            throw AuthManagerError.invalidEmail
+        }
         do {
             if forceRefresh || !otpAuthenticationStatus.isAuthenticating {
                 otpAuthenticationStatus = try await startEmailValidation(

--- a/Tests/UtilsTests/EmailValidationTest.swift
+++ b/Tests/UtilsTests/EmailValidationTest.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import Utils
+
+@Suite("Email Validation Tests")
+struct EmailValidationTests {
+    @Test(
+        "Rejects invalid emails",
+        arguments: [
+            "",
+            "notanemail",
+            "foo~&(&)(@bar.com",
+            "a@b.com c@d.com"
+        ]
+    )
+    func rejectsInvalidEmails(email: String) {
+        #expect(!isValidEmail(email))
+    }
+
+    @Test(
+        "Accepts valid emails",
+        arguments: [
+            "user@example.com",
+            "user+tag@example.com",
+            "user.name@sub.domain.org"
+        ]
+    )
+    func acceptsValidEmails(email: String) {
+        #expect(isValidEmail(email))
+    }
+}


### PR DESCRIPTION
Passing an invalid email to \`otpAuthentication\` would silently proceed to the server, which would return a 400 and wrap it as a generic \`serviceError\`. The SDK now validates format upfront using the existing \`isValidEmail\` utility from \`Utils\`.

\`AuthManagerError\` gains an \`.invalidEmail\` case to distinguish client-side validation failures from errors that originated in the service.

## Changes

- \`AuthManagerError\`: added \`.invalidEmail\` case; \`errorMessage\` switch updated to cover it
- \`DefaultAuthManager\`: \`otpAuthentication\` throws \`.invalidEmail\` immediately after normalising the email if \`isValidEmail\` returns \`false\`, before any network call or state transition