### PR TITLE
Fix invalid chain passing validation

### DIFF
--- a/Sources/CrossmintCommonTypes/Blockchain/Models/Chain/Chain.swift
+++ b/Sources/CrossmintCommonTypes/Blockchain/Models/Chain/Chain.swift
@@ -207,7 +207,7 @@ public enum Chain: AnyChain, Equatable, Sendable, Hashable {
         case .solana:
             SolanaChain.solana
         case .unknown(name: let name):
-            UnknownChain.unknown(name: name, isTest: true)
+            UnknownChain.unknown(name: name)
         }
     }
 

--- a/Sources/CrossmintCommonTypes/Blockchain/Models/Chain/UnknownChain.swift
+++ b/Sources/CrossmintCommonTypes/Blockchain/Models/Chain/UnknownChain.swift
@@ -9,18 +9,18 @@ public enum UnknownChain: SpecificChain {
 
     public var name: String {
         switch self {
-        case .unknown(let name, _):
+        case .unknown(let name):
             name
         }
     }
 
     public func isValid(isProductionEnvironment: Bool) -> Bool {
-        true
+        false
     }
 
     public init?(_ from: String) {
-        self = .unknown(name: from, isTest: true)
+        self = .unknown(name: from)
     }
 
-    case unknown(name: String, isTest: Bool)
+    case unknown(name: String)
 }

--- a/Tests/WalletTests/Model/ChainTest.swift
+++ b/Tests/WalletTests/Model/ChainTest.swift
@@ -158,14 +158,18 @@ struct ChainTest {
     }
 
     @Test(
-        "Unknown chains should be valid in both environments"
+        "Unknown chains should be invalid in both environments"
     )
-    func unknownChainsValidInBothEnvironments() async {
+    func unknownChainsInvalidInBothEnvironments() async {
         let unknownChain = Chain.unknown(name: "custom_chain")
 
         #expect(
-            unknownChain.isValid(isProductionEnvironment: true),
-            "Unknown chain should be valid in production environment"
+            !unknownChain.isValid(isProductionEnvironment: true),
+            "Unknown chain should be invalid in production environment"
+        )
+        #expect(
+            !unknownChain.isValid(isProductionEnvironment: false),
+            "Unknown chain should be invalid in test environment"
         )
     }
 


### PR DESCRIPTION
`UnknownChain.isValid` was returning `true`, so passing any unrecognised string to `Chain(_:)` would silently pass `assertValid()` and only fail later during wallet creation with a `walletInvalidType` error. It now returns `false`, throwing `invalidChain` immediately.

## Changes

- `UnknownChain`: `isValid` now returns `false`; removed unused `isTest: Bool` associated value
- `Chain`: updated `specificChain` to call `UnknownChain.unknown(name:)` without the dropped argument
- `ChainTest`: updated test to assert unknown chains are invalid in both environments