### PR TITLE
Split otpAuthentication into sendEmailOtp and confirmEmailOtp

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/SignInView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/SignInView.swift
@@ -8,11 +8,9 @@ struct SignInView: View {
 
     @State private var email: String = ""
     @State private var isSigningIn: Bool = false
-    @State private var otpAuthenticationStatus: OTPAuthenticationStatus?
     @State private var showAlert: Bool = false
     @State private var alertMessage: String = ""
     @State private var showOTPVerification: Bool = false
-    @State private var emailId: String = ""
     @State private var opacity: Double = 0
 
     private var authManager: AuthManager {
@@ -85,8 +83,7 @@ struct SignInView: View {
                         }
                     }
                 }),
-                email: email,
-                emailId: emailId
+                email: email
             )
             .presentationDetents([.medium])
         }
@@ -98,18 +95,9 @@ struct SignInView: View {
         isSigningIn = true
         Task {
             do {
-                let status = try await crossmintAuthManager.otpAuthentication(
-                    email: email,
-                    code: nil,
-                    forceRefresh: false
-                )
-                otpAuthenticationStatus = status
+                try await crossmintAuthManager.sendEmailOtp(email: email)
                 isSigningIn = false
-
-                if case let .emailSent(_, id) = status {
-                    self.emailId = id
-                    self.showOTPVerification = true
-                }
+                showOTPVerification = true
             } catch let authError as AuthManagerError {
                 isSigningIn = false
                 showAlert(with: "\(authError.errorMessage)")

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/VerificationView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/VerificationView.swift
@@ -17,7 +17,6 @@ struct VerificationView: View {
     }
 
     let email: String
-    let emailId: String
 
     var body: some View {
         VStack(spacing: 20) {
@@ -83,26 +82,18 @@ struct VerificationView: View {
         isVerifying = true
         Task {
             do {
-                let status = try await crossmintAuthManager.otpAuthentication(
-                    email: email,
-                    code: verificationCode,
-                    forceRefresh: false
-                )
+                let status = try await crossmintAuthManager.confirmEmailOtp(email: email, code: verificationCode)
 
                 isVerifying = false
 
-                if case let .authenticationStatus(authStatus) = status {
-                    if case .authenticated = authStatus {
-                        withAnimation(AnimationConstants.easeOut()) {
-                            opacity = 0
-                        }
-
-                        DispatchQueue.main.asyncAfter(deadline: .now() + AnimationConstants.duration) {
-                            authenticationStatus = authStatus
-                        }
+                if case let .authenticationStatus(authStatus) = status, case .authenticated = authStatus {
+                    withAnimation(AnimationConstants.easeOut()) {
+                        opacity = 0
                     }
-                } else {
-                    showAlert(with: "Invalid verification code. Please try again.")
+
+                    DispatchQueue.main.asyncAfter(deadline: .now() + AnimationConstants.duration) {
+                        authenticationStatus = authStatus
+                    }
                 }
             } catch {
                 isVerifying = false
@@ -115,15 +106,8 @@ struct VerificationView: View {
     private func resendCode() {
         Task {
             do {
-                let status = try await crossmintAuthManager.otpAuthentication(
-                    email: email,
-                    code: nil,
-                    forceRefresh: true
-                )
-
-                if case .emailSent = status {
-                    showAlert(with: "A new verification code has been sent to your email.")
-                }
+                try await crossmintAuthManager.sendEmailOtp(email: email)
+                showAlert(with: "A new verification code has been sent to your email.")
             } catch {
                 showAlert(with: "Error sending new code: \(error.localizedDescription)")
                 print("Error resending code: \(error)")
@@ -153,7 +137,6 @@ struct VerificationView: View {
 #Preview {
     VerificationView(
         authenticationStatus: .constant(nil),
-        email: "example@email.com",
-        emailId: "sample-id"
+        email: "example@email.com"
     )
 }

--- a/Sources/CrossmintAuth/AuthManager.swift
+++ b/Sources/CrossmintAuth/AuthManager.swift
@@ -11,6 +11,7 @@ public enum AuthManagerError: Swift.Error {
     case unknown(String)
     case serviceError(String)
     case invalidEmail
+    case noPendingOTP
 
     public var errorMessage: String {
         return switch self {
@@ -18,6 +19,8 @@ public enum AuthManagerError: Swift.Error {
             message
         case .invalidEmail:
             "Invalid email address"
+        case .noPendingOTP:
+            "No OTP email has been sent. Call sendEmailOtp first."
         }
     }
 }

--- a/Sources/CrossmintAuth/DefaultAuthManager.swift
+++ b/Sources/CrossmintAuth/DefaultAuthManager.swift
@@ -78,8 +78,9 @@ public actor CrossmintAuthManager: AuthManager {
             throw AuthManagerError.invalidEmail
         }
         do {
+            let newStatus = try await startEmailValidation(email: normalizedEmail)
             jwtRefreshTimer?.invalidate()
-            otpAuthenticationStatus = try await startEmailValidation(email: normalizedEmail)
+            otpAuthenticationStatus = newStatus
         } catch {
             throw AuthManagerError.serviceError(error.errorMessage)
         }

--- a/Sources/CrossmintAuth/DefaultAuthManager.swift
+++ b/Sources/CrossmintAuth/DefaultAuthManager.swift
@@ -72,58 +72,31 @@ public actor CrossmintAuthManager: AuthManager {
     }
 #endif
 
-    public func otpAuthentication(
-        email: String,
-        code: String? = nil,
-        forceRefresh: Bool = false
-    ) async throws(AuthManagerError) -> OTPAuthenticationStatus {
-        let normalizedEmail = email.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    public func sendEmailOtp(email: String) async throws(AuthManagerError) {
+        let normalizedEmail = normalizeEmail(email)
         guard isValidEmail(normalizedEmail) else {
             throw AuthManagerError.invalidEmail
         }
         do {
-            if forceRefresh || !otpAuthenticationStatus.isAuthenticating {
-                otpAuthenticationStatus = try await startEmailValidation(
-                    email: normalizedEmail
-                )
-            } else {
-                switch otpAuthenticationStatus {
-                case .authenticationStatus(let authenticationStatus):
-                    switch authenticationStatus {
-                    case .nonAuthenticated:
-                        otpAuthenticationStatus = try await startEmailValidation(email: normalizedEmail)
-                        jwtRefreshTimer?.invalidate()
-                    case .authenticated(let authenticatedEmail, _, _):
-                        if authenticatedEmail != normalizedEmail {
-                            // swiftlint:disable:next line_length
-                            Logger.auth.debug("Starting authentication again. \(email) is different from \(authenticatedEmail)")
-                            otpAuthenticationStatus = try await startEmailValidation(email: normalizedEmail)
-                            jwtRefreshTimer?.invalidate()
-                        } else {
-                            Logger.auth.debug("Already authenticated. Use force refresh to authenticate again")
-                        }
-                    case .authenticating:
-                        break
-                    }
-                case .emailSent(let verifiedEmail, let emailId):
-                    if let code {
-                        if verifiedEmail == normalizedEmail {
-                            try await refreshJWT(
-                                try await authService.validateToken(
-                                    ValidateTokenRequest(email: verifiedEmail, token: code, emailID: emailId)
-                                ).oneTimeSecret
-                            )
-                        } else {
-                            Logger.auth.debug("Email mismatch. Using \(normalizedEmail) to start authentication again")
-                            otpAuthenticationStatus = try await startEmailValidation(email: normalizedEmail)
-                        }
-                    } else {
-                        // swiftlint:disable:next line_length
-                        Logger.auth.debug("No code received while expecting it. Authentication won't proceed until a code is provided")
-                    }
+            jwtRefreshTimer?.invalidate()
+            otpAuthenticationStatus = try await startEmailValidation(email: normalizedEmail)
+        } catch {
+            throw AuthManagerError.serviceError(error.errorMessage)
+        }
+    }
 
-                }
-            }
+    public func confirmEmailOtp(email: String, code: String) async throws(AuthManagerError) -> OTPAuthenticationStatus {
+        let normalizedEmail = normalizeEmail(email)
+        guard case let .emailSent(verifiedEmail, emailId) = otpAuthenticationStatus,
+              verifiedEmail == normalizedEmail else {
+            throw AuthManagerError.noPendingOTP
+        }
+        do {
+            try await refreshJWT(
+                try await authService.validateToken(
+                    ValidateTokenRequest(email: verifiedEmail, token: code, emailID: emailId)
+                ).oneTimeSecret
+            )
             return otpAuthenticationStatus
         } catch {
             throw AuthManagerError.serviceError(error.errorMessage)
@@ -164,6 +137,10 @@ public actor CrossmintAuthManager: AuthManager {
         )
         otpAuthenticationStatus = .authenticationStatus(authStatus)
         _authenticationStatus = authStatus
+    }
+
+    private func normalizeEmail(_ email: String) -> String {
+        email.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func startEmailValidation(email: String) async throws(AuthError) -> OTPAuthenticationStatus {


### PR DESCRIPTION
Splits `otpAuthentication(email:code:forceRefresh:)` into `sendEmailOtp(email:)` and `confirmEmailOtp(email:code:)`.

```swift
// Before
let status = try await authManager.otpAuthentication(email: email, code: nil, forceRefresh: false)
let status = try await authManager.otpAuthentication(email: email, code: verificationCode, forceRefresh: false)

// After
try await authManager.sendEmailOtp(email: email)
let status = try await authManager.confirmEmailOtp(email: email, code: verificationCode)
```

## Changes

- **`sendEmailOtp(email:)`** — sends the OTP email; validates the email address and resets any active JWT refresh timer before dispatching
- **`confirmEmailOtp(email:code:)`** — validates the OTP code; throws `AuthManagerError.noPendingOTP` (new typed error case) if called before `sendEmailOtp` or with a mismatched email
- **`AuthManagerError.noPendingOTP`** — new error case replacing the previous stringly-typed `serviceError` for the missing-session precondition
- **`normalizeEmail(_:)`** — private helper extracted to avoid duplicating `lowercased().trimmingCharacters(...)` across both methods
- **SmartWalletsDemo** updated to use the new API; removed now-unnecessary `emailId` and `otpAuthenticationStatus` state from `SignInView`, removed `emailId` parameter from `VerificationView`