### PR TITLE
Test restructure: add test tagging infrastructure (PR-2)

### DIFF
--- a/CrossmintSDK.xctestplan
+++ b/CrossmintSDK.xctestplan
@@ -4,7 +4,11 @@
       "id" : "D5674AFA-547D-4078-84D6-493CEEF5A2DD",
       "name" : "Configuration 1",
       "options" : {
-
+        "tags" : {
+          "skippedTagIDs" : [
+            "staging"
+          ]
+        }
       }
     }
   ],

--- a/Tests/CrossmintCommonTypesTests/Blockchain/Address/Models/SolanaPublicKeyAddressTests.swift
+++ b/Tests/CrossmintCommonTypesTests/Blockchain/Address/Models/SolanaPublicKeyAddressTests.swift
@@ -2,7 +2,7 @@ import Testing
 
 @testable import CrossmintCommonTypes
 
-@Suite("Solana Address and PublicKey tests")
+@Suite("Solana Address and PublicKey tests", .tags(.unit))
 struct SolanaPublicKeyAddressTests {
     @Test("Should parse a valid Solana public address")
     func shouldParseValidSolanaPublicAddress() throws {

--- a/Tests/CrossmintCommonTypesTests/Tags.swift
+++ b/Tests/CrossmintCommonTypesTests/Tags.swift
@@ -1,0 +1,8 @@
+import Testing
+
+extension Tag {
+    @Tag static var unit: Self
+    @Tag static var staging: Self
+    @Tag static var critical: Self
+    @Tag static var flaky: Self
+}

--- a/Tests/CrossmintServiceTests/Tags.swift
+++ b/Tests/CrossmintServiceTests/Tags.swift
@@ -1,0 +1,8 @@
+import Testing
+
+extension Tag {
+    @Tag static var unit: Self
+    @Tag static var staging: Self
+    @Tag static var critical: Self
+    @Tag static var flaky: Self
+}

--- a/Tests/PaymentTests/Tags.swift
+++ b/Tests/PaymentTests/Tags.swift
@@ -1,0 +1,8 @@
+import Testing
+
+extension Tag {
+    @Tag static var unit: Self
+    @Tag static var staging: Self
+    @Tag static var critical: Self
+    @Tag static var flaky: Self
+}

--- a/Tests/UtilsTests/Base58Tests.swift
+++ b/Tests/UtilsTests/Base58Tests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import Utils
 
-@Suite("Base58 Tests")
+@Suite("Base58 Tests", .tags(.unit))
 struct Base58Tests {
 
     @Test("Decode valid address")

--- a/Tests/UtilsTests/EmailValidationTest.swift
+++ b/Tests/UtilsTests/EmailValidationTest.swift
@@ -1,7 +1,7 @@
 import Testing
 @testable import Utils
 
-@Suite("Email Validation Tests")
+@Suite("Email Validation Tests", .tags(.unit))
 struct EmailValidationTests {
     @Test(
         "Rejects invalid emails",

--- a/Tests/UtilsTests/HexUtilTest.swift
+++ b/Tests/UtilsTests/HexUtilTest.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import Utils
 
-@Suite("HexUtil Tests")
+@Suite("HexUtil Tests", .tags(.unit))
 struct HexUtilTests {
 
     @Test("Convert valid hex digits")

--- a/Tests/UtilsTests/Tags.swift
+++ b/Tests/UtilsTests/Tags.swift
@@ -1,0 +1,8 @@
+import Testing
+
+extension Tag {
+    @Tag static var unit: Self
+    @Tag static var staging: Self
+    @Tag static var critical: Self
+    @Tag static var flaky: Self
+}

--- a/Tests/WalletTests/Tags.swift
+++ b/Tests/WalletTests/Tags.swift
@@ -1,0 +1,8 @@
+import Testing
+
+extension Tag {
+    @Tag static var unit: Self
+    @Tag static var staging: Self
+    @Tag static var critical: Self
+    @Tag static var flaky: Self
+}

--- a/Tests/WebTests/CrossmintTEETests.swift
+++ b/Tests/WebTests/CrossmintTEETests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import Web
 
-@Suite("CrossmintTEE Tests")
+@Suite("CrossmintTEE Tests", .tags(.unit))
 @MainActor
 struct CrossmintTEETests {
     @MainActor

--- a/Tests/WebTests/GetStatusResponseTests.swift
+++ b/Tests/WebTests/GetStatusResponseTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import Web
 
-@Suite("GetStatusResponse Tests")
+@Suite("GetStatusResponse Tests", .tags(.unit))
 struct GetStatusResponseTests {
 
     @Test("Decode new device response with signerStatus")

--- a/Tests/WebTests/NonCustodialSignResponseTests.swift
+++ b/Tests/WebTests/NonCustodialSignResponseTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import Web
 
-@Suite("NonCustodialSignResponse Tests")
+@Suite("NonCustodialSignResponse Tests", .tags(.unit))
 struct NonCustodialSignResponseTests {
 
     @Test("Decode successful sign response with signature and publicKey")

--- a/Tests/WebTests/Tags.swift
+++ b/Tests/WebTests/Tags.swift
@@ -1,0 +1,8 @@
+import Testing
+
+extension Tag {
+    @Tag static var unit: Self
+    @Tag static var staging: Self
+    @Tag static var critical: Self
+    @Tag static var flaky: Self
+}

--- a/Tests/WebTests/WebViewMessageHandlerTests.swift
+++ b/Tests/WebTests/WebViewMessageHandlerTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import Web
 @testable import Logger
 
-@Suite("WebViewMessageHandler Tests")
+@Suite("WebViewMessageHandler Tests", .tags(.unit))
 @MainActor
 struct WebViewMessageHandlerTests {
     final class MockWebViewMessageHandlerDelegate: WebViewMessageHandlerDelegate {


### PR DESCRIPTION
## Summary

- Adds \`Tags.swift\` to all 6 test targets, defining \`unit\`, \`staging\`, \`critical\`, and \`flaky\` Swift Testing tags
- Applies \`.tags(.unit)\` at the \`@Suite\` level across all test suites that already have \`@Suite\` on \`main\` (WebTests, UtilsTests, CrossmintCommonTypesTests)
- Updates \`CrossmintSDK.xctestplan\` to skip tests tagged \`.staging\` in the default run configuration

Resolves WAL-10122, WAL-10123

**Stream B — independent, can merge any time.**

## Test plan

- [ ] \`make test\` passes (unit tests only — staging tests excluded by the \`skippedTagIDs\` configuration)
