### PR TITLE
Test restructure: add @Suite decorators and BDD function naming (PR-4)

### DIFF
--- a/Tests/CrossmintCommonTypesTests/Address/PublicKeyAddressTests.swift
+++ b/Tests/CrossmintCommonTypesTests/Address/PublicKeyAddressTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import CrossmintCommonTypes
 
+@Suite("Public Key Address Tests")
 struct PublicAddressTest {
     @Test("Should parse a valid EVM public address")
     func shouldParseValidEVMPublicAddress() throws {

--- a/Tests/CrossmintCommonTypesTests/Address/PublicKeyAddressTests.swift
+++ b/Tests/CrossmintCommonTypesTests/Address/PublicKeyAddressTests.swift
@@ -2,7 +2,7 @@ import Testing
 
 @testable import CrossmintCommonTypes
 
-@Suite("Public Key Address Tests")
+@Suite("Public Key Address Tests", .tags(.unit))
 struct PublicAddressTest {
     @Test("Should parse a valid EVM public address")
     func shouldParseValidEVMPublicAddress() throws {

--- a/Tests/CrossmintCommonTypesTests/Wallet/AdminSignerDataTests.swift
+++ b/Tests/CrossmintCommonTypesTests/Wallet/AdminSignerDataTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import CrossmintCommonTypes
 
+@Suite("Admin Signer Data Tests")
 struct AdminSignerDataTests {
 
     // MARK: - ExternalWalletSignerData

--- a/Tests/CrossmintCommonTypesTests/Wallet/AdminSignerDataTests.swift
+++ b/Tests/CrossmintCommonTypesTests/Wallet/AdminSignerDataTests.swift
@@ -2,7 +2,7 @@ import Testing
 
 @testable import CrossmintCommonTypes
 
-@Suite("Admin Signer Data Tests")
+@Suite("Admin Signer Data Tests", .tags(.unit))
 struct AdminSignerDataTests {
 
     // MARK: - ExternalWalletSignerData

--- a/Tests/CrossmintServiceTests/ApiKeyTests.swift
+++ b/Tests/CrossmintServiceTests/ApiKeyTests.swift
@@ -1,22 +1,23 @@
 import Testing
 @testable import CrossmintService
 
+@Suite("API Key Tests")
 struct ApiKeyTest {
     @Test(
-        "Will throw for every environment when the API key is old",
+        "Rejects old API key format for all environments",
         arguments: ["sk_live", "sk_test"]
     )
-    func willThrowWhenTheApiKeyIsOld(key: String) async throws {
+    func rejectsOldApiKeyFormat(key: String) async throws {
         #expect(throws: ApiKey.Error.oldKey) {
             try ApiKey(key: key)
         }
     }
 
     @Test(
-        "Will throw if the API key does not start with the correct prefix",
+        "Rejects API key that does not start with the correct prefix",
         arguments: ApiKeyUsageOriginPrefix.allCases
     )
-    func willThrowIfTheApiKeyDoesNotStartWithTheCorrectPrefix(prefix: ApiKeyUsageOriginPrefix) async throws {
+    func rejectsApiKeyWithWrongPrefix(prefix: ApiKeyUsageOriginPrefix) async throws {
         let expectedError = ApiKey.Error.malformedKey(
             // swiftlint:disable:next line_length
             "Malformed API key. Must starts with \(ApiKeyUsageOriginPrefix.client.rawValue) or \(ApiKeyUsageOriginPrefix.server.rawValue)"
@@ -28,10 +29,10 @@ struct ApiKeyTest {
     }
 
     @Test(
-        "Will extract the expected environment from the API key",
+        "Extracts the expected environment from the API key",
         arguments: ApiKeyEnvironmentPrefix.allCases
     )
-    func willExtractTheExpectedEnvironmentFromTheApiKey(prefix: ApiKeyEnvironmentPrefix) async throws {
+    func extractsEnvironmentFromApiKey(prefix: ApiKeyEnvironmentPrefix) async throws {
         let key = "\(ApiKeyUsageOriginPrefix.client.rawValue)_\(prefix.rawValue)"
         let apiKey = try ApiKey(key: key)
         #expect(apiKey.environment == prefix.expectedEnvironment)

--- a/Tests/CrossmintServiceTests/ApiKeyTests.swift
+++ b/Tests/CrossmintServiceTests/ApiKeyTests.swift
@@ -1,7 +1,7 @@
 import Testing
 @testable import CrossmintService
 
-@Suite("API Key Tests")
+@Suite("API Key Tests", .tags(.unit))
 struct ApiKeyTest {
     @Test(
         "Rejects old API key format for all environments",

--- a/Tests/CrossmintServiceTests/DefaultJSONCoderTests.swift
+++ b/Tests/CrossmintServiceTests/DefaultJSONCoderTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import CrossmintService
 
-@Suite("DefaultJSONCoder Tests")
+@Suite("DefaultJSONCoder Tests", .tags(.unit))
 struct DefaultJSONCoderTest {
 
     private struct TestModel: Codable {

--- a/Tests/CrossmintServiceTests/DefaultJSONCoderTests.swift
+++ b/Tests/CrossmintServiceTests/DefaultJSONCoderTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import CrossmintService
 
+@Suite("DefaultJSONCoder Tests")
 struct DefaultJSONCoderTest {
 
     private struct TestModel: Codable {

--- a/Tests/CrossmintServiceTests/DefaultRequestBuilderTests.swift
+++ b/Tests/CrossmintServiceTests/DefaultRequestBuilderTests.swift
@@ -1,7 +1,7 @@
 import Testing
 @testable import CrossmintService
 
-@Suite("DefaultRequestBuilder Tests")
+@Suite("DefaultRequestBuilder Tests", .tags(.unit))
 struct DefaultRequestBuilderTest {
 
     // swiftlint:disable:next force_try

--- a/Tests/CrossmintServiceTests/DefaultRequestBuilderTests.swift
+++ b/Tests/CrossmintServiceTests/DefaultRequestBuilderTests.swift
@@ -1,6 +1,7 @@
 import Testing
 @testable import CrossmintService
 
+@Suite("DefaultRequestBuilder Tests")
 struct DefaultRequestBuilderTest {
 
     // swiftlint:disable:next force_try

--- a/Tests/CrossmintServiceTests/RequestEncodingUtilityTests.swift
+++ b/Tests/CrossmintServiceTests/RequestEncodingUtilityTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import CrossmintService
 
-@Suite("RequestEncodingUtility Tests")
+@Suite("RequestEncodingUtility Tests", .tags(.unit))
 struct RequestEncodingUtilityTest {
 
     struct TestRequest: Encodable {

--- a/Tests/CrossmintServiceTests/RequestEncodingUtilityTests.swift
+++ b/Tests/CrossmintServiceTests/RequestEncodingUtilityTests.swift
@@ -4,6 +4,7 @@ import Testing
 
 @testable import CrossmintService
 
+@Suite("RequestEncodingUtility Tests")
 struct RequestEncodingUtilityTest {
 
     struct TestRequest: Encodable {

--- a/Tests/PaymentTests/Locators/TokenLocatorTests.swift
+++ b/Tests/PaymentTests/Locators/TokenLocatorTests.swift
@@ -1,7 +1,7 @@
 import Testing
 @testable import Payments
 
-@Suite("Token Locator Tests")
+@Suite("Token Locator Tests", .tags(.unit))
 struct TokenLocatorTests {
     @Test(
         "Returns the correct token locator for the given type",

--- a/Tests/PaymentTests/Locators/TokenLocatorTests.swift
+++ b/Tests/PaymentTests/Locators/TokenLocatorTests.swift
@@ -1,9 +1,10 @@
 import Testing
 @testable import Payments
 
+@Suite("Token Locator Tests")
 struct TokenLocatorTests {
     @Test(
-        "Will return the correct token locator for the given type",
+        "Returns the correct token locator for the given type",
         arguments: [
             (
                 "solana:6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN",
@@ -25,7 +26,7 @@ struct TokenLocatorTests {
             )
         ]
     )
-    func willReturnTheCorrectTokenLocatorForTheGivenType(expectAndActual: (String, TokenLocator)) async {
+    func returnsCorrectTokenLocatorForGivenType(expectAndActual: (String, TokenLocator)) async {
         do {
             let tokenLocator = try TokenLocator(string: expectAndActual.0)
             #expect(tokenLocator.description == expectAndActual.1.description)

--- a/Tests/PaymentTests/Order/OrderTests.swift
+++ b/Tests/PaymentTests/Order/OrderTests.swift
@@ -4,7 +4,7 @@ import TestsUtils
 
 @testable import Payments
 
-@Suite("Order Tests")
+@Suite("Order Tests", .tags(.unit))
 struct OrderTests {
     @Test("Parses a LineItemDeliveryToken")
     func parsesLineItemDeliveryToken() async throws {

--- a/Tests/PaymentTests/Order/OrderTests.swift
+++ b/Tests/PaymentTests/Order/OrderTests.swift
@@ -4,9 +4,10 @@ import TestsUtils
 
 @testable import Payments
 
+@Suite("Order Tests")
 struct OrderTests {
-    @Test("Will parse a LineItemDeliveryToken")
-    func willParseALineItemDeliveryToken() async throws {
+    @Test("Parses a LineItemDeliveryToken")
+    func parsesLineItemDeliveryToken() async throws {
         let lineItemDeliveryToken: LineItemDeliveryToken = try GetFromFile.getModelFrom(
             fileName: "GetLineItemDeliveryToken",
             bundle: Bundle.module
@@ -26,8 +27,8 @@ struct OrderTests {
         }
     }
 
-    @Test("Will parse a SolanaLineItemDeliveryToken of exact out type")
-    func willParseALineOutItemDeliveryToken() async throws {
+    @Test("Parses a SolanaLineItemDeliveryToken of exact out type")
+    func parsesSolanaLineItemDeliveryTokenExactOut() async throws {
         let lineItemDeliveryToken: LineItemDeliveryToken = try GetFromFile.getModelFrom(
             fileName: "SolanaLineItemDeliveryTokenOut",
             bundle: Bundle.module

--- a/Tests/WalletTests/Data/Config/SmartWalletConfigResponseTests.swift
+++ b/Tests/WalletTests/Data/Config/SmartWalletConfigResponseTests.swift
@@ -4,7 +4,7 @@ import TestsUtils
 
 @testable import Wallet
 
-@Suite("SmartWalletConfigResponse Tests")
+@Suite("SmartWalletConfigResponse Tests", .tags(.unit))
 struct SmartWalletConfigResponseTest {
     @Test("EOA wallet")
     func parsesEOAWallet() async throws {

--- a/Tests/WalletTests/Data/Config/SmartWalletConfigResponseTests.swift
+++ b/Tests/WalletTests/Data/Config/SmartWalletConfigResponseTests.swift
@@ -4,9 +4,10 @@ import TestsUtils
 
 @testable import Wallet
 
+@Suite("SmartWalletConfigResponse Tests")
 struct SmartWalletConfigResponseTest {
     @Test("EOA wallet")
-    func willParseEOAWallet() async throws {
+    func parsesEOAWallet() async throws {
         let response: SmartWalletConfigResponse = try GetFromFile.getModelFrom(
             fileName: "SmartWalletConfigResponseEOA",
             bundle: Bundle.module
@@ -16,7 +17,7 @@ struct SmartWalletConfigResponseTest {
     }
 
     @Test("Passkeys wallet")
-    func willParsePasskeysWallet() async throws {
+    func parsesPasskeysWallet() async throws {
         let response: SmartWalletConfigResponse = try GetFromFile.getModelFrom(
             fileName: "SmartWalletConfigResponsePasskeys",
             bundle: Bundle.module

--- a/Tests/WalletTests/Data/Responses/WalletApiModelTests.swift
+++ b/Tests/WalletTests/Data/Responses/WalletApiModelTests.swift
@@ -4,7 +4,7 @@ import TestsUtils
 
 @testable import Wallet
 
-@Suite("WalletApiModel Tests")
+@Suite("WalletApiModel Tests", .tags(.unit))
 struct WalletApiModelTest {
     @Test(
         "Parses an EVM Passkey Wallet"

--- a/Tests/WalletTests/Data/Responses/WalletApiModelTests.swift
+++ b/Tests/WalletTests/Data/Responses/WalletApiModelTests.swift
@@ -4,11 +4,12 @@ import TestsUtils
 
 @testable import Wallet
 
+@Suite("WalletApiModel Tests")
 struct WalletApiModelTest {
     @Test(
-        "Will parse an EVM Passkey Wallet"
+        "Parses an EVM Passkey Wallet"
     )
-    func willParseEVMPasskeyWallet() async throws {
+    func parsesEVMPasskeyWallet() async throws {
         let wallet: WalletApiModel = try GetFromFile.getModelFrom(
             fileName: "WalletPasskey",
             bundle: Bundle.module
@@ -18,9 +19,9 @@ struct WalletApiModelTest {
     }
 
     @Test(
-        "Will parse an EVM keypair Wallet"
+        "Parses an EVM keypair Wallet"
     )
-    func willParseEVMKeypairWallet() async throws {
+    func parsesEVMKeypairWallet() async throws {
         let wallet: WalletApiModel = try GetFromFile.getModelFrom(
             fileName: "WalletEVMKeypair",
             bundle: Bundle.module
@@ -33,9 +34,9 @@ struct WalletApiModelTest {
     }
 
     @Test(
-        "Will parse a Solana keypair Wallet"
+        "Parses a Solana keypair Wallet"
     )
-    func willParseSolanaKeypairWallet() async throws {
+    func parsesSolanaKeypairWallet() async throws {
         let wallet: WalletApiModel = try GetFromFile.getModelFrom(
             fileName: "WalletSolanaKeypair",
             bundle: Bundle.module
@@ -48,9 +49,9 @@ struct WalletApiModelTest {
     }
 
     @Test(
-        "Will parse an EVM API key Wallet"
+        "Parses an EVM API key Wallet"
     )
-    func willParseEVMApiKeyWallet() async throws {
+    func parsesEVMApiKeyWallet() async throws {
         let wallet: WalletApiModel = try GetFromFile.getModelFrom(
             fileName: "WalletEVMApiKey",
             bundle: Bundle.module
@@ -63,9 +64,9 @@ struct WalletApiModelTest {
     }
 
     @Test(
-        "Will parse an EVM email Wallet"
+        "Parses an EVM email Wallet"
     )
-    func willParseEVMEmailWallet() async throws {
+    func parsesEVMEmailWallet() async throws {
         let wallet: WalletApiModel = try GetFromFile.getModelFrom(
             fileName: "WalletEVMEmail",
             bundle: Bundle.module
@@ -78,9 +79,9 @@ struct WalletApiModelTest {
     }
 
     @Test(
-        "Will parse a Solana email Wallet"
+        "Parses a Solana email Wallet"
     )
-    func willParseSolanaEmailWallet() async throws {
+    func parsesSolanaEmailWallet() async throws {
         let wallet: WalletApiModel = try GetFromFile.getModelFrom(
             fileName: "WalletSolanaEmail",
             bundle: Bundle.module
@@ -93,9 +94,9 @@ struct WalletApiModelTest {
     }
 
     @Test(
-        "Will parse an EVM phone Wallet"
+        "Parses an EVM phone Wallet"
     )
-    func willParseEVMPhoneWallet() async throws {
+    func parsesEVMPhoneWallet() async throws {
         let wallet: WalletApiModel = try GetFromFile.getModelFrom(
             fileName: "WalletEVMPhone",
             bundle: Bundle.module

--- a/Tests/WalletTests/Data/Transaction/CreateTransactionResponseTests.swift
+++ b/Tests/WalletTests/Data/Transaction/CreateTransactionResponseTests.swift
@@ -4,9 +4,10 @@ import TestsUtils
 
 @testable import Wallet
 
+@Suite("CreateTransactionResponse Tests")
 struct CreateTransactionResponseTest {
     @Test("Parse awaiting approval state")
-    func willParseAwaitingApprovalState() async throws {
+    func parsesAwaitingApprovalState() async throws {
         let response: EVMTransactionApiModel = try GetFromFile.getModelFrom(
             fileName: "CreateTransactionAwaitingApproval",
             bundle: Bundle.module
@@ -17,7 +18,7 @@ struct CreateTransactionResponseTest {
     }
 
     @Test("Parse Solana transaction state")
-    func willParseSolanaTransactionResponse() async throws {
+    func parsesSolanaTransactionResponse() async throws {
         let response: SolanaTransactionApiModel = try GetFromFile.getModelFrom(
             fileName: "CreateSolanaTransactionResponse",
             bundle: Bundle.module

--- a/Tests/WalletTests/Data/Transaction/CreateTransactionResponseTests.swift
+++ b/Tests/WalletTests/Data/Transaction/CreateTransactionResponseTests.swift
@@ -4,7 +4,7 @@ import TestsUtils
 
 @testable import Wallet
 
-@Suite("CreateTransactionResponse Tests")
+@Suite("CreateTransactionResponse Tests", .tags(.unit))
 struct CreateTransactionResponseTest {
     @Test("Parse awaiting approval state")
     func parsesAwaitingApprovalState() async throws {

--- a/Tests/WalletTests/Data/Transaction/FetchTransactionResponseTests.swift
+++ b/Tests/WalletTests/Data/Transaction/FetchTransactionResponseTests.swift
@@ -4,7 +4,7 @@ import TestsUtils
 
 @testable import Wallet
 
-@Suite("FetchTransactionResponse Tests")
+@Suite("FetchTransactionResponse Tests", .tags(.unit))
 struct FetchTransactionResponseTest {
     @Test("Parse failed transactions")
     func parsesFailedTransactionState() async throws {

--- a/Tests/WalletTests/Data/Transaction/FetchTransactionResponseTests.swift
+++ b/Tests/WalletTests/Data/Transaction/FetchTransactionResponseTests.swift
@@ -4,9 +4,10 @@ import TestsUtils
 
 @testable import Wallet
 
+@Suite("FetchTransactionResponse Tests")
 struct FetchTransactionResponseTest {
     @Test("Parse failed transactions")
-    func willParseAwaitingApprovalState() async throws {
+    func parsesFailedTransactionState() async throws {
         let response: EVMTransactionApiModel = try GetFromFile.getModelFrom(
             fileName: "FailedTransactionResponse",
             bundle: Bundle.module

--- a/Tests/WalletTests/Data/Transaction/SignTransactionResponseTests.swift
+++ b/Tests/WalletTests/Data/Transaction/SignTransactionResponseTests.swift
@@ -4,7 +4,7 @@ import TestsUtils
 
 @testable import Wallet
 
-@Suite("SignTransactionResponse Tests")
+@Suite("SignTransactionResponse Tests", .tags(.unit))
 struct SignTransactionResponseTest {
     @Test("Parses transaction when signed")
     func parsesTransactionWhenSigned() async throws {

--- a/Tests/WalletTests/Data/Transaction/SignTransactionResponseTests.swift
+++ b/Tests/WalletTests/Data/Transaction/SignTransactionResponseTests.swift
@@ -4,9 +4,10 @@ import TestsUtils
 
 @testable import Wallet
 
+@Suite("SignTransactionResponse Tests")
 struct SignTransactionResponseTest {
-    @Test("Will parse transaction when signed")
-    func willParseTransactionWhenSigned() async throws {
+    @Test("Parses transaction when signed")
+    func parsesTransactionWhenSigned() async throws {
         let response: EVMTransactionApiModel = try GetFromFile.getModelFrom(
             fileName: "SignTransactionResponse",
             bundle: Bundle.module

--- a/Tests/WalletTests/Data/TransferToken/TransferTokenLocatorTests.swift
+++ b/Tests/WalletTests/Data/TransferToken/TransferTokenLocatorTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import Wallet
 
-@Suite("TransferTokenLocator Tests")
+@Suite("TransferTokenLocator Tests", .tags(.unit))
 struct TransferTokenLocatorTest {
     // swiftlint:disable:next force_try
     private let someSolanaAddress = try! SolanaAddress(

--- a/Tests/WalletTests/Data/TransferToken/TransferTokenLocatorTests.swift
+++ b/Tests/WalletTests/Data/TransferToken/TransferTokenLocatorTests.swift
@@ -4,6 +4,7 @@ import Testing
 
 @testable import Wallet
 
+@Suite("TransferTokenLocator Tests")
 struct TransferTokenLocatorTest {
     // swiftlint:disable:next force_try
     private let someSolanaAddress = try! SolanaAddress(

--- a/Tests/WalletTests/Data/TransferToken/TransferTokenRecipientTests.swift
+++ b/Tests/WalletTests/Data/TransferToken/TransferTokenRecipientTests.swift
@@ -5,6 +5,7 @@ import Utils
 
 @testable import Wallet
 
+@Suite("TransferTokenRecipient Tests")
 struct TransferTokenRecipientTest {
     // swiftlint:disable:next force_try
     private let someEVMAddress = try! EVMAddress(

--- a/Tests/WalletTests/Data/TransferToken/TransferTokenRecipientTests.swift
+++ b/Tests/WalletTests/Data/TransferToken/TransferTokenRecipientTests.swift
@@ -5,7 +5,7 @@ import Utils
 
 @testable import Wallet
 
-@Suite("TransferTokenRecipient Tests")
+@Suite("TransferTokenRecipient Tests", .tags(.unit))
 struct TransferTokenRecipientTest {
     // swiftlint:disable:next force_try
     private let someEVMAddress = try! EVMAddress(

--- a/Tests/WalletTests/Generator/ExternalSignerTests.swift
+++ b/Tests/WalletTests/Generator/ExternalSignerTests.swift
@@ -2,14 +2,15 @@ import Foundation
 import Testing
 @testable import Wallet
 
+@Suite("EVMKeyPairSigner Tests")
 struct ExternalSignerTest {
     private let invalidPrivateKey = "invalid key."
     private let validPrivateKey = "133185142a89f6fe2be363c0dcbc1d2e701cbe8c0de5440aeae17c4d3fd28fbd"
 
     @Test(
-        "Will create a new address from a valid private key"
+        "Creates a new address from a valid private key"
     )
-    func willCreateANewAddressFromAValidPrivateKey() async throws {
+    func createsAddressFromValidPrivateKey() async throws {
         let signer = try EVMKeyPairSigner(
             privateKeyData: validPrivateKey.bytes
         )
@@ -22,9 +23,9 @@ struct ExternalSignerTest {
     }
 
     @Test(
-        "Will fail when the private key data provided is empty"
+        "Rejects empty private key data"
     )
-    func willFailWhenEmptyDataIsUsedAsPrivateKey() async throws {
+    func rejectsEmptyPrivateKeyData() async throws {
         #expect(throws: SignerError.invalidPrivateKey) {
             try EVMKeyPairSigner(
                 privateKeyData: []
@@ -32,8 +33,8 @@ struct ExternalSignerTest {
         }
     }
 
-    @Test("Will fail when private key is not valid")
-    func willFailWhenPrivateKeyIsNotValid() async throws {
+    @Test("Rejects invalid private key")
+    func rejectsInvalidPrivateKey() async throws {
         await #expect(throws: SignerError.invalidPrivateKey) {
             let signer = try EVMKeyPairSigner(privateKey: invalidPrivateKey)
             try await signer.initialize()
@@ -41,8 +42,8 @@ struct ExternalSignerTest {
         }
     }
 
-    @Test("Will get signature when private key is valid")
-    func willGetSignatureWhenPrivateKeyIsValid() async throws {
+    @Test("Returns signature for valid private key")
+    func returnsSignatureForValidPrivateKey() async throws {
         let message = "0x52769994aa43c041dad4d211d584bef75e03b318dc8d34a449f815aeb50b99c8"
         let privateKey = "e9b363f475d641078ffd02b477054f8b4c0d3442941bc3d69d15d151ce07be8f"
         // swiftlint:disable:next line_length

--- a/Tests/WalletTests/Generator/ExternalSignerTests.swift
+++ b/Tests/WalletTests/Generator/ExternalSignerTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import Wallet
 
-@Suite("EVMKeyPairSigner Tests")
+@Suite("EVMKeyPairSigner Tests", .tags(.unit))
 struct ExternalSignerTest {
     private let invalidPrivateKey = "invalid key."
     private let validPrivateKey = "133185142a89f6fe2be363c0dcbc1d2e701cbe8c0de5440aeae17c4d3fd28fbd"

--- a/Tests/WalletTests/Model/AdminSignerRequestApiModelTests.swift
+++ b/Tests/WalletTests/Model/AdminSignerRequestApiModelTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 @testable import Wallet
 
+@Suite("AdminSignerRequestApiModel Tests")
 struct AdminSignerRequestApiModelTests {
     private let encoder: JSONEncoder = {
         let e = JSONEncoder()

--- a/Tests/WalletTests/Model/AdminSignerRequestApiModelTests.swift
+++ b/Tests/WalletTests/Model/AdminSignerRequestApiModelTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import Wallet
 
-@Suite("AdminSignerRequestApiModel Tests")
+@Suite("AdminSignerRequestApiModel Tests", .tags(.unit))
 struct AdminSignerRequestApiModelTests {
     private let encoder: JSONEncoder = {
         let e = JSONEncoder()

--- a/Tests/WalletTests/Model/BalanceTransformerTests.swift
+++ b/Tests/WalletTests/Model/BalanceTransformerTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import Wallet
 
-@Suite("BalanceTransformer Tests")
+@Suite("BalanceTransformer Tests", .tags(.unit))
 struct BalanceTransformerTest {
 
     // MARK: - Helper Methods

--- a/Tests/WalletTests/Model/BalanceTransformerTests.swift
+++ b/Tests/WalletTests/Model/BalanceTransformerTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 @testable import Wallet
 
+@Suite("BalanceTransformer Tests")
 struct BalanceTransformerTest {
 
     // MARK: - Helper Methods

--- a/Tests/WalletTests/Model/BalancesTests.swift
+++ b/Tests/WalletTests/Model/BalancesTests.swift
@@ -3,11 +3,12 @@ import Foundation
 import Testing
 @testable import Wallet
 
+@Suite("Balances Tests")
 struct BalancesTest {
     @Test(
-        "Will handle Balance if the currency is not known"
+        "Handles Balance if the currency is not known"
     )
-    func willHandleBalanceIfTheCurrencyIsNotKnown() async {
+    func handlesUnknownCurrencyInBalance() async {
         let balances = getBalances("""
                 [
                   {
@@ -35,8 +36,8 @@ struct BalancesTest {
         #expect(balances[.unknown("new_currency")]?.total == 242)
     }
 
-    @Test("Will get the right values for each chain for a given currency")
-    func willGetTheRightValuesForEachChainForAGivenCurrency() async {
+    @Test("Returns the right values for each chain for a given currency")
+    func returnsCorrectValuesPerChainForCurrency() async {
         let balances = getBalances("""
                 [
                   {
@@ -77,8 +78,8 @@ struct BalancesTest {
         #expect(balance.chainBalances[.unknown(name: "unknown-chain")] == 123)
     }
 
-    @Test("Will get all balances for the same currency together.")
-    func willGetAllBalancesForTheSameCurrencyTogether() async {
+    @Test("Aggregates balances for the same currency")
+    func aggregatesBalancesForSameCurrency() async {
         let balances = getBalances("""
                 [
                   {
@@ -121,9 +122,9 @@ struct BalancesTest {
         #expect(usdc[.bsc] == 200)
     }
 
-    @Test("Will parse different balances")
+    @Test("Parses different balances")
     // swiftlint:disable:next function_body_length
-    func willGetDifferentTokensFromTheBalanceResponse() async {
+    func parsesDifferentBalanceTokens() async {
         let balances = getBalances("""
                 [
                   {

--- a/Tests/WalletTests/Model/BalancesTests.swift
+++ b/Tests/WalletTests/Model/BalancesTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import Wallet
 
-@Suite("Balances Tests")
+@Suite("Balances Tests", .tags(.unit))
 struct BalancesTest {
     @Test(
         "Handles Balance if the currency is not known"

--- a/Tests/WalletTests/Model/ChainBalanceTests.swift
+++ b/Tests/WalletTests/Model/ChainBalanceTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import Wallet
 
-@Suite("ChainBalance Tests")
+@Suite("ChainBalance Tests", .tags(.unit))
 struct ChainBalanceTest {
     @Test(
         "Normalizes decimal strings to match the number of decimals",

--- a/Tests/WalletTests/Model/ChainBalanceTests.swift
+++ b/Tests/WalletTests/Model/ChainBalanceTests.swift
@@ -3,9 +3,10 @@ import Foundation
 import Testing
 @testable import Wallet
 
+@Suite("ChainBalance Tests")
 struct ChainBalanceTest {
     @Test(
-        "Will normalize decimal strings to match the number of decimals",
+        "Normalizes decimal strings to match the number of decimals",
         arguments: [
             (18, "0.1", "100000000000000000"),
             (6, "1", "1000000"),
@@ -17,7 +18,7 @@ struct ChainBalanceTest {
         ]
     )
     // swiftlint:disable:next large_tuple
-    func willNormalizeDecimalStrings(values: (Int, String, String?)) async {
+    func normalizesDecimalStringsToMatchDecimals(values: (Int, String, String?)) async {
         let balance = ChainBalances(total: .zero, decimals: values.0, chainBalances: [:])
         #expect(balance.convertToBaseUnits(values.1) == values.2)
     }

--- a/Tests/WalletTests/Model/ChainTests.swift
+++ b/Tests/WalletTests/Model/ChainTests.swift
@@ -4,11 +4,12 @@ import Testing
 
 @testable import Wallet
 
+@Suite("Chain Tests")
 struct ChainTest {
     @Test(
-        "Will set unknown chain if the name is not known"
+        "Sets unknown chain when the name is not known"
     )
-    func willParseUnknownChains() async {
+    func parsesUnknownChains() async {
         let chain = getChain(
             """
             {
@@ -21,9 +22,9 @@ struct ChainTest {
     }
 
     @Test(
-        "Will use the expected type when the name is known"
+        "Uses expected type when the chain name is known"
     )
-    func willParseKnownChains() async {
+    func parsesKnownChains() async {
         let chain = getChain(
             """
             {
@@ -36,9 +37,9 @@ struct ChainTest {
     }
 
     @Test(
-        "Will parse solana chain"
+        "Parses Solana chain"
     )
-    func willParseSolanaChain() async {
+    func parsesSolanaChain() async {
         let chain = getChain(
             """
             {

--- a/Tests/WalletTests/Model/ChainTests.swift
+++ b/Tests/WalletTests/Model/ChainTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import Wallet
 
-@Suite("Chain Tests")
+@Suite("Chain Tests", .tags(.unit))
 struct ChainTest {
     @Test(
         "Sets unknown chain when the name is not known"

--- a/Tests/WalletTests/Model/EIP712/EIP712Tests.swift
+++ b/Tests/WalletTests/Model/EIP712/EIP712Tests.swift
@@ -5,6 +5,7 @@ import TestsUtils
 import Utils
 @testable import Wallet
 
+@Suite("EIP712 Tests")
 // swiftlint:disable:next type_body_length
 struct EIP712Tests {
 

--- a/Tests/WalletTests/Model/EIP712/EIP712Tests.swift
+++ b/Tests/WalletTests/Model/EIP712/EIP712Tests.swift
@@ -5,7 +5,7 @@ import TestsUtils
 import Utils
 @testable import Wallet
 
-@Suite("EIP712 Tests")
+@Suite("EIP712 Tests", .tags(.unit))
 // swiftlint:disable:next type_body_length
 struct EIP712Tests {
 

--- a/Tests/WalletTests/Model/ERC20EncoderTests.swift
+++ b/Tests/WalletTests/Model/ERC20EncoderTests.swift
@@ -1,7 +1,7 @@
 import Testing
 @testable import Wallet
 
-@Suite("ERC20Encoder Tests")
+@Suite("ERC20Encoder Tests", .tags(.unit))
 struct ERC20EncoderTest {
     @Test("Valid input")
     func testValidInput() async throws {

--- a/Tests/WalletTests/Model/ERC20EncoderTests.swift
+++ b/Tests/WalletTests/Model/ERC20EncoderTests.swift
@@ -1,6 +1,7 @@
 import Testing
 @testable import Wallet
 
+@Suite("ERC20Encoder Tests")
 struct ERC20EncoderTest {
     @Test("Valid input")
     func testValidInput() async throws {

--- a/Tests/WalletTests/Model/SignMessageTests.swift
+++ b/Tests/WalletTests/Model/SignMessageTests.swift
@@ -3,6 +3,7 @@ import Testing
 import CrossmintCommonTypes
 import Foundation
 
+@Suite("SignMessage Tests")
 struct SignMessageTests {
 
     @Test

--- a/Tests/WalletTests/Model/SignMessageTests.swift
+++ b/Tests/WalletTests/Model/SignMessageTests.swift
@@ -3,7 +3,7 @@ import Testing
 import CrossmintCommonTypes
 import Foundation
 
-@Suite("SignMessage Tests")
+@Suite("SignMessage Tests", .tags(.unit))
 struct SignMessageTests {
 
     @Test

--- a/Tests/WalletTests/Model/SignerRegistrationServiceTests.swift
+++ b/Tests/WalletTests/Model/SignerRegistrationServiceTests.swift
@@ -2,7 +2,7 @@ import CrossmintCommonTypes
 import Testing
 @testable import Wallet
 
-@Suite("SignerRegistrationService Tests")
+@Suite("SignerRegistrationService Tests", .tags(.unit))
 struct SignerRegistrationServiceTests {
     private let chainType = ChainType.evm
     private let chainName = "polygon"

--- a/Tests/WalletTests/Model/SignerRegistrationServiceTests.swift
+++ b/Tests/WalletTests/Model/SignerRegistrationServiceTests.swift
@@ -2,6 +2,7 @@ import CrossmintCommonTypes
 import Testing
 @testable import Wallet
 
+@Suite("SignerRegistrationService Tests")
 struct SignerRegistrationServiceTests {
     private let chainType = ChainType.evm
     private let chainName = "polygon"

--- a/Tests/WalletTests/Model/TransferTests.swift
+++ b/Tests/WalletTests/Model/TransferTests.swift
@@ -12,9 +12,10 @@ import TestsUtils
 
 @testable import Wallet
 
+@Suite("Transfer Tests")
 struct TransferTests {
-    @Test("Will decode a list transfers response")
-    func willDecodeListTransfersResponse() async throws {
+    @Test("Decodes a list transfers response")
+    func decodesListTransfersResponse() async throws {
         let response: TransferListApiModel = try GetFromFile.getModelFrom(
             fileName: "ListTransfersResponse",
             bundle: Bundle.module
@@ -23,8 +24,8 @@ struct TransferTests {
         #expect(response.data.count == 3)
     }
 
-    @Test("Will map outgoing transfer correctly")
-    func willMapOutgoingTransfer() async throws {
+    @Test("Maps outgoing transfer correctly")
+    func mapsOutgoingTransferCorrectly() async throws {
         let response: TransferListApiModel = try GetFromFile.getModelFrom(
             fileName: "ListTransfersResponse",
             bundle: Bundle.module
@@ -41,8 +42,8 @@ struct TransferTests {
         #expect(transfer.transactionHash == "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
     }
 
-    @Test("Will map incoming transfer correctly")
-    func willMapIncomingTransfer() async throws {
+    @Test("Maps incoming transfer correctly")
+    func mapsIncomingTransferCorrectly() async throws {
         let response: TransferListApiModel = try GetFromFile.getModelFrom(
             fileName: "ListTransfersResponse",
             bundle: Bundle.module
@@ -57,8 +58,8 @@ struct TransferTests {
         #expect(transfer.amount == Decimal(string: "0.05"))
     }
 
-    @Test("Will parse ISO8601 date with fractional seconds")
-    func willParseDateWithFractionalSeconds() async throws {
+    @Test("Parses ISO8601 date with fractional seconds")
+    func parsesISO8601DateWithFractionalSeconds() async throws {
         let response: TransferListApiModel = try GetFromFile.getModelFrom(
             fileName: "ListTransfersResponse",
             bundle: Bundle.module
@@ -81,8 +82,8 @@ struct TransferTests {
         #expect(components.second == 30)
     }
 
-    @Test("Will parse ISO8601 date without fractional seconds")
-    func willParseDateWithoutFractionalSeconds() async throws {
+    @Test("Parses ISO8601 date without fractional seconds")
+    func parsesISO8601DateWithoutFractionalSeconds() async throws {
         let response: TransferListApiModel = try GetFromFile.getModelFrom(
             fileName: "ListTransfersResponse",
             bundle: Bundle.module

--- a/Tests/WalletTests/Model/TransferTests.swift
+++ b/Tests/WalletTests/Model/TransferTests.swift
@@ -12,7 +12,7 @@ import TestsUtils
 
 @testable import Wallet
 
-@Suite("Transfer Tests")
+@Suite("Transfer Tests", .tags(.unit))
 struct TransferTests {
     @Test("Decodes a list transfers response")
     func decodesListTransfersResponse() async throws {

--- a/Tests/WalletTests/Model/WalletBalanceSimpleTests.swift
+++ b/Tests/WalletTests/Model/WalletBalanceSimpleTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import Wallet
 
-@Suite("WalletBalance Tests")
+@Suite("WalletBalance Tests", .tags(.unit))
 struct WalletBalanceSimpleTest {
 
     @Test("New Balance structure works correctly")

--- a/Tests/WalletTests/Model/WalletBalanceSimpleTests.swift
+++ b/Tests/WalletTests/Model/WalletBalanceSimpleTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 @testable import Wallet
 
+@Suite("WalletBalance Tests")
 struct WalletBalanceSimpleTest {
 
     @Test("New Balance structure works correctly")

--- a/Tests/WalletTests/WalletLocatorTests.swift
+++ b/Tests/WalletTests/WalletLocatorTests.swift
@@ -2,9 +2,10 @@ import Testing
 
 @testable import Wallet
 
+@Suite("WalletLocator Tests")
 struct WalletLocatorTest {
     @Test(
-        "Will return the correct wallet locator for the given type",
+        "Returns the correct wallet locator for the given type",
         arguments: [
             (
                 "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
@@ -33,7 +34,7 @@ struct WalletLocatorTest {
             )
         ]
     )
-    func willReturnTheCorrectWalletLocatorForTheGivenType(expectAndActual: (String, WalletLocator))
+    func returnsCorrectWalletLocatorForGivenType(expectAndActual: (String, WalletLocator))
         async {
         #expect(expectAndActual.0 == expectAndActual.1.value)
     }

--- a/Tests/WalletTests/WalletLocatorTests.swift
+++ b/Tests/WalletTests/WalletLocatorTests.swift
@@ -2,7 +2,7 @@ import Testing
 
 @testable import Wallet
 
-@Suite("WalletLocator Tests")
+@Suite("WalletLocator Tests", .tags(.unit))
 struct WalletLocatorTest {
     @Test(
         "Returns the correct wallet locator for the given type",


### PR DESCRIPTION
## Summary

- Adds `@Suite("Descriptive Name")` to all 28 bare test structs that lacked it across CrossmintServiceTests (4), WalletTests (20), CrossmintCommonTypesTests (2), and PaymentTests (2)
- Renames 27 `will*` test functions to active-voice BDD style with matching `@Test` display strings updated:
  - `willParseEVMPasskeyWallet` → `parsesEVMPasskeyWallet`
  - `willThrowWhenTheApiKeyIsOld` → `rejectsOldApiKeyFormat`
  - `willNormalizeDecimalStrings` → `normalizesDecimalStringsToMatchDecimals`
  - (and 24 more — see commit for full list)
- No logic changes in any test

Resolves WAL-10126, WAL-10128

**Stream A — depends on PR-3 merging first.**

## Test plan

- [ ] `make test` passes
- [ ] `grep -rn "func will" Tests/` returns empty
- [ ] Every test struct has `@Suite`