### PR TITLE
Test restructure: mock cleanup and CrossmintClientTests setup (PR-5)

### DIFF
--- a/Tests/WebTests/Mocks/MockWebViewMessageHandlerDelegate.swift
+++ b/Tests/WebTests/Mocks/MockWebViewMessageHandlerDelegate.swift
@@ -1,0 +1,15 @@
+import Foundation
+@testable import Web
+
+final class MockWebViewMessageHandlerDelegate: WebViewMessageHandlerDelegate {
+    var receivedMessages: [any WebViewMessage] = []
+    var receivedUnknownMessages: [(type: String, data: Data)] = []
+
+    func handleWebViewMessage<T: WebViewMessage>(_ message: T) {
+        receivedMessages.append(message)
+    }
+
+    func handleUnknownMessage(_ messageType: String, data: Data) {
+        receivedUnknownMessages.append((type: messageType, data: data))
+    }
+}

--- a/Tests/WebTests/WebViewMessageHandlerTests.swift
+++ b/Tests/WebTests/WebViewMessageHandlerTests.swift
@@ -6,19 +6,6 @@ import Testing
 @Suite("WebViewMessageHandler Tests")
 @MainActor
 struct WebViewMessageHandlerTests {
-    final class MockWebViewMessageHandlerDelegate: WebViewMessageHandlerDelegate {
-        var receivedMessages: [any WebViewMessage] = []
-        var receivedUnknownMessages: [(type: String, data: Data)] = []
-
-        func handleWebViewMessage<T: WebViewMessage>(_ message: T) {
-            receivedMessages.append(message)
-        }
-
-        func handleUnknownMessage(_ messageType: String, data: Data) {
-            receivedUnknownMessages.append((type: messageType, data: data))
-        }
-    }
-
     @Test("Process console.log message with data array")
     func testProcessConsoleLogMessage() throws {
         let handler = WebViewMessageHandler()


### PR DESCRIPTION
## Summary

- Adds `CrossmintClientTests` as a new test target in `Package.swift` and `CrossmintSDK.xctestplan`
- Extracts `MockWebViewMessageHandlerDelegate` from inside `WebViewMessageHandlerTests.swift` into its own file `Tests/WebTests/Mocks/MockWebViewMessageHandlerDelegate.swift`
- Adds explanatory comments to both `MockSmartWalletService` copies (CrossmintClientTests + WalletTests) documenting why they are intentionally kept separate (wallet-operation-focused vs. signer-focused)
- Wraps free staging `@Test` functions in `StagingIntegrationTests.swift` inside a `@Suite` struct

Resolves WAL-10127

**Stream C — must merge before PR-6 (helpers).**

## Test plan

- [ ] `make test` passes
- [ ] `grep -rn "MockWebViewMessageHandlerDelegate" Tests/WebTests/WebViewMessageHandlerTests.swift` returns empty
