### PR TITLE
Test restructure: add Helpers/ directories with factory functions (PR-6)

### DIFF
--- a/Tests/WalletTests/Helpers/WalletTestHelpers.swift
+++ b/Tests/WalletTests/Helpers/WalletTestHelpers.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Testing
+@testable import Wallet
+
+func decodeBalances(from json: String) -> Balances {
+    guard let data = json.data(using: .utf8),
+          let balances = try? JSONDecoder().decode(Balances.self, from: data) else {
+        Issue.record("Failed to decode balances from JSON")
+        return Balances()
+    }
+    return balances
+}

--- a/Tests/WalletTests/Model/BalanceTransformerTest.swift
+++ b/Tests/WalletTests/Model/BalanceTransformerTest.swift
@@ -3,17 +3,8 @@ import Foundation
 import Testing
 @testable import Wallet
 
+@Suite("BalanceTransformer Tests", .tags(.unit))
 struct BalanceTransformerTest {
-
-    // MARK: - Helper Methods
-
-    private func createBalances(from json: String) -> Balances {
-        guard let data = json.data(using: .utf8),
-              let balances = try? JSONDecoder().decode(Balances.self, from: data) else {
-            return Balances()
-        }
-        return balances
-    }
 
     // MARK: - Basic Functionality Tests
 
@@ -64,7 +55,7 @@ struct BalanceTransformerTest {
         ]
         """
 
-        let balances = createBalances(from: balancesJson)
+        let balances = decodeBalances(from: balancesJson)
         let result = BalanceTransformer.transform(
             from: balances,
             nativeToken: .eth,
@@ -106,7 +97,7 @@ struct BalanceTransformerTest {
         ]
         """
 
-        let balances = createBalances(from: balancesJson)
+        let balances = decodeBalances(from: balancesJson)
         let result = BalanceTransformer.transform(
             from: balances,
             nativeToken: .eth,
@@ -144,7 +135,7 @@ struct BalanceTransformerTest {
         ]
         """
 
-        let balances = createBalances(from: balancesJson)
+        let balances = decodeBalances(from: balancesJson)
         let result = BalanceTransformer.transform(
             from: balances,
             nativeToken: .eth,
@@ -195,7 +186,7 @@ struct BalanceTransformerTest {
         ]
         """
 
-        let balances = createBalances(from: balancesJson)
+        let balances = decodeBalances(from: balancesJson)
         let result = BalanceTransformer.transform(
             from: balances,
             nativeToken: .sol,
@@ -270,7 +261,7 @@ struct BalanceTransformerTest {
         ]
         """
 
-        let balances = createBalances(from: balancesJson)
+        let balances = decodeBalances(from: balancesJson)
         let result = BalanceTransformer.transform(
             from: balances,
             nativeToken: .eth,
@@ -348,7 +339,7 @@ struct BalanceTransformerTest {
         ]
         """
 
-        let balances = createBalances(from: balancesJson)
+        let balances = decodeBalances(from: balancesJson)
         // Request includes native token and USDC which should be filtered out
         let result = BalanceTransformer.transform(
             from: balances,
@@ -411,7 +402,7 @@ struct BalanceTransformerTest {
         ]
         """
 
-        let balances = createBalances(from: balancesJson)
+        let balances = decodeBalances(from: balancesJson)
         let result = BalanceTransformer.transform(
             from: balances,
             nativeToken: .eth,

--- a/Tests/WalletTests/Model/BalancesTest.swift
+++ b/Tests/WalletTests/Model/BalancesTest.swift
@@ -3,12 +3,13 @@ import Foundation
 import Testing
 @testable import Wallet
 
+@Suite("Balances Tests", .tags(.unit))
 struct BalancesTest {
     @Test(
         "Will handle Balance if the currency is not known"
     )
     func willHandleBalanceIfTheCurrencyIsNotKnown() async {
-        let balances = getBalances("""
+        let balances = decodeBalances(from: """
                 [
                   {
                     "symbol": "new_currency",
@@ -37,7 +38,7 @@ struct BalancesTest {
 
     @Test("Will get the right values for each chain for a given currency")
     func willGetTheRightValuesForEachChainForAGivenCurrency() async {
-        let balances = getBalances("""
+        let balances = decodeBalances(from: """
                 [
                   {
                     "symbol": "usdc",
@@ -79,7 +80,7 @@ struct BalancesTest {
 
     @Test("Will get all balances for the same currency together.")
     func willGetAllBalancesForTheSameCurrencyTogether() async {
-        let balances = getBalances("""
+        let balances = decodeBalances(from: """
                 [
                   {
                     "symbol": "usdc",
@@ -124,7 +125,7 @@ struct BalancesTest {
     @Test("Will parse different balances")
     // swiftlint:disable:next function_body_length
     func willGetDifferentTokensFromTheBalanceResponse() async {
-        let balances = getBalances("""
+        let balances = decodeBalances(from: """
                 [
                   {
                     "symbol": "eth",
@@ -181,12 +182,4 @@ struct BalancesTest {
         #expect(balances[.usdxm]?[.baseSepolia] == 30)
     }
 
-    private func getBalances(_ json: String) -> Balances {
-        guard let data = json.data(using: .utf8),
-                let balances = try? JSONDecoder().decode(Balances.self, from: data) else {
-            Issue.record("Failed to decode balances")
-            return Balances()
-        }
-        return balances
-    }
 }


### PR DESCRIPTION
## Summary

**WalletTests (WAL-10137):**
- Creates `Tests/WalletTests/Helpers/WalletTestHelpers.swift` with a shared `decodeBalances(from:)` free function, eliminating the duplicate private helpers that existed in `BalancesTest` and `BalanceTransformerTest`
- Adds `@Suite("Balances Tests", .tags(.unit))` to `BalancesTest`
- Adds `@Suite("BalanceTransformer Tests", .tags(.unit))` to `BalanceTransformerTest`

> **Note:** WAL-10136 (CrossmintClientTests helpers) is not included here — the `CrossmintClientTests` target does not exist in this repository. That issue is deferred.

Resolves WAL-10137

**Stream C — depends on PR-5 (#87) merging first.**

## Test plan

- [ ] `make test` passes