### PR TITLE
Internalize factory layer and remove crossmintService from public API

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/PlaygroundView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/PlaygroundView.swift
@@ -80,7 +80,7 @@ struct PlaygroundView: View {
 
     private func signOut() async {
         try? await crossmintAuthManager.logout()
-        try? await CrossmintSDK.shared.logout()
+        CrossmintSDK.shared.logout()
         authenticationStatus = .nonAuthenticated
     }
 }

--- a/Sources/CrossmintClient/ClientSDK.swift
+++ b/Sources/CrossmintClient/ClientSDK.swift
@@ -1,9 +1,8 @@
 import CrossmintAuth
-import CrossmintService
 import Wallet
 
-public protocol ClientSDK {
+protocol ClientSDK {
     func crossmintWallets() -> CrossmintWallets
     var authManager: AuthManager { get }
-    var crossmintService: CrossmintService { get }
+    var isProductionEnvironment: Bool { get }
 }

--- a/Sources/CrossmintClient/CrossmintClient.swift
+++ b/Sources/CrossmintClient/CrossmintClient.swift
@@ -2,8 +2,8 @@ import CrossmintService
 import Logger
 import CrossmintAuth
 
-public actor CrossmintClient {
-    public enum Error: Swift.Error {
+actor CrossmintClient {
+    enum Error: Swift.Error {
         case invalidApiKeyType
     }
 
@@ -16,7 +16,7 @@ public actor CrossmintClient {
         self.apiKey = apiKey
     }
 
-    public static func sdk(key: String, authManager: AuthManager? = nil) throws -> ClientSDK {
+    static func sdk(key: String, authManager: AuthManager? = nil) throws -> ClientSDK {
         lock.lock()
         defer { lock.unlock() }
 

--- a/Sources/CrossmintClient/CrossmintClientSDK.swift
+++ b/Sources/CrossmintClient/CrossmintClientSDK.swift
@@ -9,7 +9,7 @@ final class CrossmintClientSDK: ClientSDK, Sendable {
     private let apiKey: ApiKey
     private let secureStorage: SecureStorage
     private let secureWalletStorage: SecureWalletStorage
-    let crossmintService: CrossmintService
+    private let crossmintService: CrossmintService
     let authManager: any CrossmintAuth.AuthManager
 
     init(apiKey: ApiKey, authManager: AuthManager? = nil) {

--- a/Sources/CrossmintClient/CrossmintClientSDK.swift
+++ b/Sources/CrossmintClient/CrossmintClientSDK.swift
@@ -5,12 +5,12 @@ import Logger
 import SecureStorage
 import Wallet
 
-public final class CrossmintClientSDK: ClientSDK, Sendable {
+final class CrossmintClientSDK: ClientSDK, Sendable {
     private let apiKey: ApiKey
     private let secureStorage: SecureStorage
     private let secureWalletStorage: SecureWalletStorage
-    public let crossmintService: CrossmintService
-    public let authManager: any CrossmintAuth.AuthManager
+    let crossmintService: CrossmintService
+    let authManager: any CrossmintAuth.AuthManager
 
     init(apiKey: ApiKey, authManager: AuthManager? = nil) {
         self.apiKey = apiKey
@@ -34,7 +34,11 @@ public final class CrossmintClientSDK: ClientSDK, Sendable {
         }
     }
 
-    public func crossmintWallets() -> CrossmintWallets {
+    var isProductionEnvironment: Bool {
+        crossmintService.isProductionEnvironment
+    }
+
+    func crossmintWallets() -> CrossmintWallets {
         DefaultCrossmintWallets(
             service: DefaultSmartWalletService(
                 crossmintService: crossmintService,

--- a/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
+++ b/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
@@ -12,7 +12,7 @@ import Web
 
 @MainActor
 final public class CrossmintSDK: ObservableObject {
-    nonisolated(unsafe) private static var _shared: CrossmintSDK?
+    private static var _shared: CrossmintSDK?
 
     public static var shared: CrossmintSDK {
         guard let shared = _shared else {

--- a/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
+++ b/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
@@ -42,7 +42,7 @@ final public class CrossmintSDK: ObservableObject {
 
     public let crossmintWallets: CrossmintWallets
     public let authManager: AuthManager
-    public let crossmintService: CrossmintService
+    public let isProductionEnvironment: Bool
 
     let crossmintTEE: CrossmintTEE
 
@@ -54,10 +54,6 @@ final public class CrossmintSDK: ObservableObject {
     }
     public func cancelTransaction() {
         crossmintTEE.cancelOTP()
-    }
-
-    public var isProductionEnvironment: Bool {
-        crossmintService.isProductionEnvironment
     }
 
     private convenience init() {
@@ -86,12 +82,12 @@ final public class CrossmintSDK: ObservableObject {
             let authManager = sdk.authManager
             self.crossmintWallets = sdk.crossmintWallets()
             self.authManager = authManager
-            self.crossmintService = sdk.crossmintService
+            self.isProductionEnvironment = sdk.isProductionEnvironment
             self.crossmintTEE = CrossmintTEE.start(
                 auth: authManager,
                 webProxy: DefaultWebViewCommunicationProxy(),
                 apiKey: apiKey,
-                isProductionEnvironment: sdk.crossmintService.isProductionEnvironment
+                isProductionEnvironment: sdk.isProductionEnvironment
             )
         } catch {
             Logger.client.error("Invalid Crossmint API key provided: \(error)")

--- a/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
+++ b/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
@@ -1,7 +1,7 @@
 import CrossmintAuth
 import Combine
 @_exported import CrossmintCommonTypes
-@_exported import CrossmintService
+import CrossmintService
 import Logger
 import SwiftUI
 import Utils
@@ -87,7 +87,7 @@ final public class CrossmintSDK: ObservableObject {
                 auth: authManager,
                 webProxy: DefaultWebViewCommunicationProxy(),
                 apiKey: apiKey,
-                isProductionEnvironment: sdk.isProductionEnvironment
+                isProductionEnvironment: isProductionEnvironment
             )
         } catch {
             Logger.client.error("Invalid Crossmint API key provided: \(error)")

--- a/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
+++ b/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
@@ -95,7 +95,7 @@ final public class CrossmintSDK: ObservableObject {
         }
     }
 
-    public func logout() async throws {
+    public func logout() {
         crossmintTEE.resetState()
     }
 


### PR DESCRIPTION
`CrossmintClient`, `ClientSDK`, and `CrossmintClientSDK` were public but created a confusing second entry point into the SDK: a developer reading the public API could reasonably wonder whether to use `CrossmintClient.sdk()` or `CrossmintSDK.shared()`, and what the difference was. `crossmintService: CrossmintService` also leaked the raw HTTP client publicly, letting callers bypass auth and error handling entirely. No other Crossmint SDK exposes anything like it.

This pull request makes those types internal and removes the service leak, without changing any observable behavior.

## Changes
- Made `CrossmintClient`, `ClientSDK`, and `CrossmintClientSDK` internal so `CrossmintSDK` is the only public entry point
- Removed `crossmintService: CrossmintService` from the public API; `isProductionEnvironment` is now a stored `Bool` derived at init time
- Dropped `@_exported import CrossmintService` so consumers no longer get all `CrossmintService` types injected into their namespace
- Made `crossmintService` `private` inside `CrossmintClientSDK`
- Removed `async throws` from `logout()` since the implementation was never async or throwing
- Removed `nonisolated(unsafe)` from `CrossmintSDK._shared` since the class is `@MainActor` and the compiler already enforces single actor access