### PR TITLE
Update Xcode and iOS simulator to 26.5

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,7 +12,7 @@ on:
           - main
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_26.1.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
 
 jobs:
   build:
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '26.1'
+        xcode-version: '26.5'
     
     - name: Cache SPM packages
       uses: actions/cache@v4

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: build
 # ==========================================
 
 # Simulator destination for builds and tests
-SIMULATOR_DEST := platform=iOS Simulator,name=iPhone 17 Pro,OS=26.1
+SIMULATOR_DEST := platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5
 
 # Scheme names
 SDK_SCHEME := CrossmintClientSDK


### PR DESCRIPTION
This updates the Xcode and simulator configuration from 26.1 to 26.5 across the `Makefile` and the CI workflow.

Recent CI runs have been failing intermittently because the runner can't fetch the iOS 26.1 simulator runtime. It's pretty spotty, to the point where running the same workflow again without any new commits sometimes just works. Bumping to 26.5 is the most straightforward fix.

## Changes

- `Makefile`: `SIMULATOR_DEST` OS updated from 26.1 to 26.5
- `.github/workflows/swift.yml`: `DEVELOPER_DIR` and `xcode-version` updated from 26.1 to 26.5