### PR TITLE
feat(ci): add mobile E2E dispatch trigger (ENG-2345)

### DIFF
--- a/.github/workflows/e2e-mobile-trigger.yml
+++ b/.github/workflows/e2e-mobile-trigger.yml
@@ -6,11 +6,15 @@ name: Trigger Mobile E2E Tests
 
 on:
     pull_request:
-        types: [opened, synchronize, reopened]
+        types: [opened, synchronize, reopened, ready_for_review]
         paths:
             - "Sources/**"
             - "Examples/SmartWalletsDemo/**"
             - "Package.swift"
+
+concurrency:
+    group: mobile-e2e-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
 
 permissions:
     contents: read
@@ -19,6 +23,7 @@ jobs:
     dispatch:
         name: Dispatch to mobile E2E test repo
         runs-on: ubuntu-latest
+        if: github.event.pull_request.draft == false
         steps:
             - name: Dispatch e2e tests
               uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4

--- a/.github/workflows/e2e-mobile-trigger.yml
+++ b/.github/workflows/e2e-mobile-trigger.yml
@@ -1,0 +1,36 @@
+name: Trigger Mobile E2E Tests
+# On every PR push that touches the SDK source or demo app,
+# dispatches to crossmint-mobile-e2e-tests which runs Maestro flows
+# and posts a commit status check back to this PR.
+# NOTE: Full Swift build support is tracked in ENG-2345.
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened]
+        paths:
+            - "Sources/**"
+            - "Examples/SmartWalletsDemo/**"
+            - "Package.swift"
+
+permissions:
+    contents: read
+
+jobs:
+    dispatch:
+        name: Dispatch to mobile E2E test repo
+        runs-on: ubuntu-latest
+        steps:
+            - name: Dispatch e2e tests
+              uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
+              with:
+                  token: ${{ secrets.CROSSMINT_E2E_BOT_TOKEN }}
+                  repository: Crossmint/crossmint-mobile-e2e-tests
+                  event-type: e2e-mobile-tests
+                  client-payload: |
+                      {
+                        "sdk": "swift",
+                        "sdk_repo": "Crossmint/crossmint-swift-sdk",
+                        "sdk_ref": "${{ github.event.pull_request.head.sha }}",
+                        "commit_sha": "${{ github.event.pull_request.head.sha }}",
+                        "pr_number": "${{ github.event.pull_request.number }}"
+                      }


### PR DESCRIPTION
## Summary

Adds `.github/workflows/e2e-mobile-trigger.yml` which fires on every PR push touching `Sources/**`, `Examples/SmartWalletsDemo/**`, or `Package.swift`.

Dispatches to `crossmint-mobile-e2e-tests` with \`sdk: swift\`. The test repo runs Maestro flows against the Swift app and posts a \`mobile-e2e / swift\` commit status check back to this PR.

## Status

The dispatch plumbing is ready. Full Swift build support in the test repo (checking out the repo, building with xcodebuild, booting a simulator) is the remaining work tracked in **ENG-2345**.

**Required secret**: `CROSSMINT_E2E_BOT_TOKEN` must be set on this repo.

**Depends on**: `crossmint-mobile-e2e-tests` PR #1 merged.

## Test plan

- [ ] Confirm `CROSSMINT_E2E_BOT_TOKEN` is set on `crossmint-swift-sdk`
- [ ] After `crossmint-mobile-e2e-tests` PR #1 merges, open a test PR touching `Sources/` — confirm `mobile-e2e / swift` status check appears (will fail until ENG-2345 build steps are added)
