### PR TITLE
Add AuthClient protocol and expose authClient on CrossmintSDK

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/OTPSignInView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/OTPSignInView.swift
@@ -78,8 +78,8 @@ struct OTPSignInView: View {
         isSigningIn = true
         Task {
             do {
-                let otp = try await CrossmintSDK.shared.authClient.sendOTP(to: email)
-                requestId = otp.requestId
+                let otpRequest = try await CrossmintSDK.shared.authClient.sendOTP(to: email)
+                requestId = otpRequest.requestId
                 isSigningIn = false
                 showOTPVerification = true
             } catch let authError as AuthError {

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/OTPSignInView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/OTPSignInView.swift
@@ -10,6 +10,7 @@ struct OTPSignInView: View {
     @State private var alertMessage = ""
     @State private var showOTPVerification = false
     @State private var verifiedAuthStatus: AuthenticationStatus?
+    @State private var requestId: String?
 
     var body: some View {
         VStack(spacing: 20) {
@@ -51,11 +52,14 @@ struct OTPSignInView: View {
             Alert(title: Text("Alert"), message: Text(alertMessage), dismissButton: .default(Text("OK")))
         }
         .sheet(isPresented: $showOTPVerification) {
-            VerificationView(
-                authenticationStatus: $verifiedAuthStatus,
-                email: email
-            )
-            .presentationDetents([.medium])
+            if let requestId {
+                VerificationView(
+                    authenticationStatus: $verifiedAuthStatus,
+                    email: email,
+                    requestId: requestId
+                )
+                .presentationDetents([.medium])
+            }
         }
         .onChange(of: verifiedAuthStatus) { _, value in
             guard let value else { return }
@@ -74,10 +78,11 @@ struct OTPSignInView: View {
         isSigningIn = true
         Task {
             do {
-                try await authManager.sendEmailOtp(email: email)
+                let otp = try await CrossmintSDK.shared.authClient.sendOTP(to: email)
+                requestId = otp.requestId
                 isSigningIn = false
                 showOTPVerification = true
-            } catch let authError as AuthManagerError {
+            } catch let authError as AuthError {
                 isSigningIn = false
                 alertMessage = authError.errorMessage
                 showAlert = true

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/OTPSignInView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/OTPSignInView.swift
@@ -8,9 +8,8 @@ struct OTPSignInView: View {
     @State private var isSigningIn = false
     @State private var showAlert = false
     @State private var alertMessage = ""
-    @State private var showOTPVerification = false
     @State private var verifiedAuthStatus: AuthenticationStatus?
-    @State private var requestId: String?
+    @State private var pendingOTPRequest: OTPRequest?
 
     var body: some View {
         VStack(spacing: 20) {
@@ -51,19 +50,17 @@ struct OTPSignInView: View {
         .alert(isPresented: $showAlert) {
             Alert(title: Text("Alert"), message: Text(alertMessage), dismissButton: .default(Text("OK")))
         }
-        .sheet(isPresented: $showOTPVerification) {
-            if let requestId {
-                VerificationView(
-                    authenticationStatus: $verifiedAuthStatus,
-                    email: email,
-                    requestId: requestId
-                )
-                .presentationDetents([.medium])
-            }
+        .sheet(item: $pendingOTPRequest) { request in
+            VerificationView(
+                authenticationStatus: $verifiedAuthStatus,
+                email: email,
+                requestId: request.requestId
+            )
+            .presentationDetents([.medium])
         }
         .onChange(of: verifiedAuthStatus) { _, value in
             guard let value else { return }
-            showOTPVerification = false
+            pendingOTPRequest = nil
             Task { @MainActor in
                 try? await Task.sleep(for: .seconds(AnimationConstants.duration))
                 withAnimation(AnimationConstants.easeInOut()) {
@@ -79,9 +76,8 @@ struct OTPSignInView: View {
         Task {
             do {
                 let otpRequest = try await CrossmintSDK.shared.authClient.sendOTP(to: email)
-                requestId = otpRequest.requestId
                 isSigningIn = false
-                showOTPVerification = true
+                pendingOTPRequest = otpRequest
             } catch let authError as AuthError {
                 isSigningIn = false
                 alertMessage = authError.errorMessage

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/VerificationView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/VerificationView.swift
@@ -94,9 +94,7 @@ struct VerificationView: View {
 
     private func resolveSession(for code: String) async throws -> AuthenticationStatus {
         let session = try await CrossmintSDK.shared.authClient.verifyOTP(code: code, requestId: currentRequestId)
-        // secret is empty here because this status is only used to signal the authenticated state up the
-        // view tree. The actual refresh token lives inside CrossmintAuthManager, which was populated by
-        // verifyOTP via establishSession. Logout flows through authManager, not this binding.
+        // secret is intentionally empty — refresh state lives in CrossmintAuthManager, not this binding
         return .authenticated(email: session.user.email, jwt: session.jwt, secret: "")
     }
 
@@ -110,8 +108,8 @@ struct VerificationView: View {
     private func resendCode() {
         Task {
             do {
-                let otp = try await CrossmintSDK.shared.authClient.sendOTP(to: email)
-                currentRequestId = otp.requestId
+                let otpRequest = try await CrossmintSDK.shared.authClient.sendOTP(to: email)
+                currentRequestId = otpRequest.requestId
                 showAlert(with: "A new verification code has been sent to your email.")
             } catch {
                 showAlert(with: "Error sending new code: \(error.localizedDescription)")

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/VerificationView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/VerificationView.swift
@@ -9,8 +9,15 @@ struct VerificationView: View {
     @State private var showAlert: Bool = false
     @State private var alertMessage: String = ""
     @State private var opacity: Double = 0
+    @State private var currentRequestId: String
 
     let email: String
+
+    init(authenticationStatus: Binding<AuthenticationStatus?>, email: String, requestId: String) {
+        self._authenticationStatus = authenticationStatus
+        self.email = email
+        self._currentRequestId = State(initialValue: requestId)
+    }
 
     var body: some View {
         VStack(spacing: 20) {
@@ -72,22 +79,11 @@ struct VerificationView: View {
 
     private func verifyCode() {
         guard !verificationCode.isEmpty else { return }
-
         isVerifying = true
         Task {
             do {
-                let status = try await authManager.confirmEmailOtp(email: email, code: verificationCode)
-
-                isVerifying = false
-
-                if case let .authenticationStatus(authStatus) = status, case .authenticated = authStatus {
-                    withAnimation(AnimationConstants.easeOut()) {
-                        opacity = 0
-                    }
-
-                    try? await Task.sleep(for: .seconds(AnimationConstants.duration))
-                    authenticationStatus = authStatus
-                }
+                let authStatus = try await resolveSession(for: verificationCode)
+                await animateSuccess(authStatus: authStatus)
             } catch {
                 isVerifying = false
                 showAlert(with: "Error: \(error.localizedDescription)")
@@ -96,10 +92,26 @@ struct VerificationView: View {
         }
     }
 
+    private func resolveSession(for code: String) async throws -> AuthenticationStatus {
+        let session = try await CrossmintSDK.shared.authClient.verifyOTP(code: code, requestId: currentRequestId)
+        // secret is empty here because this status is only used to signal the authenticated state up the
+        // view tree. The actual refresh token lives inside CrossmintAuthManager, which was populated by
+        // verifyOTP via establishSession. Logout flows through authManager, not this binding.
+        return .authenticated(email: session.user.email, jwt: session.jwt, secret: "")
+    }
+
+    private func animateSuccess(authStatus: AuthenticationStatus) async {
+        isVerifying = false
+        withAnimation(AnimationConstants.easeOut()) { opacity = 0 }
+        try? await Task.sleep(for: .seconds(AnimationConstants.duration))
+        authenticationStatus = authStatus
+    }
+
     private func resendCode() {
         Task {
             do {
-                try await authManager.sendEmailOtp(email: email)
+                let otp = try await CrossmintSDK.shared.authClient.sendOTP(to: email)
+                currentRequestId = otp.requestId
                 showAlert(with: "A new verification code has been sent to your email.")
             } catch {
                 showAlert(with: "Error sending new code: \(error.localizedDescription)")
@@ -114,7 +126,6 @@ struct VerificationView: View {
         }
 
         Task {
-            _ = await authManager.reset()
             try? await Task.sleep(for: .seconds(AnimationConstants.duration))
             authenticationStatus = .nonAuthenticated
         }
@@ -129,6 +140,7 @@ struct VerificationView: View {
 #Preview {
     VerificationView(
         authenticationStatus: .constant(nil),
-        email: "example@email.com"
+        email: "example@email.com",
+        requestId: "preview-request-id"
     )
 }

--- a/Sources/CrossmintAuth/AuthClient.swift
+++ b/Sources/CrossmintAuth/AuthClient.swift
@@ -1,0 +1,18 @@
+public protocol AuthClient: Sendable {
+    func sendOTP(to email: String) async throws(AuthError) -> OTPRequest
+    func verifyOTP(code: String, requestId: String) async throws(AuthError) -> AuthSession
+    func logout() async
+}
+
+public struct OTPRequest: Sendable {
+    public let requestId: String
+}
+
+public struct AuthSession: Sendable {
+    public let jwt: String
+    public let user: AuthUser
+}
+
+public struct AuthUser: Sendable {
+    public let email: String
+}

--- a/Sources/CrossmintAuth/AuthClient.swift
+++ b/Sources/CrossmintAuth/AuthClient.swift
@@ -1,18 +1,12 @@
+//
+//  AuthClient.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 6/1/26.
+//
+
 public protocol AuthClient: Sendable {
     func sendOTP(to email: String) async throws(AuthError) -> OTPRequest
     func verifyOTP(code: String, requestId: String) async throws(AuthError) -> AuthSession
     func logout() async
-}
-
-public struct OTPRequest: Sendable {
-    public let requestId: String
-}
-
-public struct AuthSession: Sendable {
-    public let jwt: String
-    public let user: AuthUser
-}
-
-public struct AuthUser: Sendable {
-    public let email: String
 }

--- a/Sources/CrossmintAuth/AuthSession.swift
+++ b/Sources/CrossmintAuth/AuthSession.swift
@@ -1,0 +1,11 @@
+//
+//  AuthSession.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 6/1/26.
+//
+
+public struct AuthSession: Sendable {
+    public let jwt: String
+    public let user: AuthUser
+}

--- a/Sources/CrossmintAuth/AuthUser.swift
+++ b/Sources/CrossmintAuth/AuthUser.swift
@@ -1,0 +1,10 @@
+//
+//  AuthUser.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 6/1/26.
+//
+
+public struct AuthUser: Sendable {
+    public let email: String
+}

--- a/Sources/CrossmintAuth/DefaultAuthClient.swift
+++ b/Sources/CrossmintAuth/DefaultAuthClient.swift
@@ -1,3 +1,10 @@
+//
+//  DefaultAuthClient.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 6/1/26.
+//
+
 import Utils
 
 public actor DefaultAuthClient: AuthClient {
@@ -33,7 +40,7 @@ public actor DefaultAuthClient: AuthClient {
     }
 
     public func logout() async {
-        try? await authManager.logout()
+        _ = try? await authManager.logout()
         pendingEmailsByRequestId.removeAll()
     }
 }

--- a/Sources/CrossmintAuth/DefaultAuthClient.swift
+++ b/Sources/CrossmintAuth/DefaultAuthClient.swift
@@ -5,7 +5,7 @@ public actor DefaultAuthClient: AuthClient {
     private let authManager: CrossmintAuthManager
     private var pendingEmailsByRequestId: [String: String] = [:]
 
-    public init(authService: AuthService, authManager: CrossmintAuthManager) {
+    package init(authService: AuthService, authManager: CrossmintAuthManager) {
         self.authService = authService
         self.authManager = authManager
     }
@@ -27,15 +27,9 @@ public actor DefaultAuthClient: AuthClient {
         let tokenResponse = try await authService.validateToken(
             ValidateTokenRequest(email: email, token: code, emailID: requestId)
         )
-        try await authManager.establishSession(oneTimeSecret: tokenResponse.oneTimeSecret)
-        guard let jwt = await authManager.jwt else {
-            throw AuthError.generic("Session could not be established")
-        }
-        guard let userEmail = await authManager.email else {
-            throw AuthError.generic("Session could not be established")
-        }
+        let session = try await authManager.establishSession(oneTimeSecret: tokenResponse.oneTimeSecret)
         pendingEmailsByRequestId.removeValue(forKey: requestId)
-        return AuthSession(jwt: jwt, user: AuthUser(email: userEmail))
+        return AuthSession(jwt: session.jwt, user: AuthUser(email: session.email))
     }
 
     public func logout() async {

--- a/Sources/CrossmintAuth/DefaultAuthClient.swift
+++ b/Sources/CrossmintAuth/DefaultAuthClient.swift
@@ -1,0 +1,45 @@
+import Utils
+
+public actor DefaultAuthClient: AuthClient {
+    private let authService: AuthService
+    private let authManager: CrossmintAuthManager
+    private var pendingEmailsByRequestId: [String: String] = [:]
+
+    public init(authService: AuthService, authManager: CrossmintAuthManager) {
+        self.authService = authService
+        self.authManager = authManager
+    }
+
+    public func sendOTP(to email: String) async throws(AuthError) -> OTPRequest {
+        let normalizedEmail = normalizeEmail(email)
+        guard isValidEmail(normalizedEmail) else {
+            throw AuthError.generic("Invalid email address")
+        }
+        let response = try await authService.validateEmail(ValidateEmailRequest(email: normalizedEmail))
+        pendingEmailsByRequestId[response.emailId] = normalizedEmail
+        return OTPRequest(requestId: response.emailId)
+    }
+
+    public func verifyOTP(code: String, requestId: String) async throws(AuthError) -> AuthSession {
+        guard let email = pendingEmailsByRequestId[requestId] else {
+            throw AuthError.generic("No pending OTP for the provided requestId")
+        }
+        let tokenResponse = try await authService.validateToken(
+            ValidateTokenRequest(email: email, token: code, emailID: requestId)
+        )
+        try await authManager.establishSession(oneTimeSecret: tokenResponse.oneTimeSecret)
+        guard let jwt = await authManager.jwt else {
+            throw AuthError.generic("Session could not be established")
+        }
+        guard let userEmail = await authManager.email else {
+            throw AuthError.generic("Session could not be established")
+        }
+        pendingEmailsByRequestId.removeValue(forKey: requestId)
+        return AuthSession(jwt: jwt, user: AuthUser(email: userEmail))
+    }
+
+    public func logout() async {
+        try? await authManager.logout()
+        pendingEmailsByRequestId.removeAll()
+    }
+}

--- a/Sources/CrossmintAuth/DefaultAuthManager.swift
+++ b/Sources/CrossmintAuth/DefaultAuthManager.swift
@@ -143,8 +143,12 @@ public actor CrossmintAuthManager: AuthManager {
         _authenticationStatus = authStatus
     }
 
-    internal func establishSession(oneTimeSecret: String) async throws(AuthError) {
-        try await refreshJWT(oneTimeSecret)
+    internal func establishSession(oneTimeSecret: String) async throws(AuthError) -> (jwt: String, email: String) {
+        let authStatus = try await refreshJWT(oneTimeSecret)
+        guard case let .authenticated(email, jwt, _) = authStatus else {
+            throw AuthError.generic("Session could not be established")
+        }
+        return (jwt: jwt, email: email)
     }
 
     private func startEmailValidation(email: String) async throws(AuthError) -> OTPAuthenticationStatus {

--- a/Sources/CrossmintAuth/DefaultAuthManager.swift
+++ b/Sources/CrossmintAuth/DefaultAuthManager.swift
@@ -143,8 +143,8 @@ public actor CrossmintAuthManager: AuthManager {
         _authenticationStatus = authStatus
     }
 
-    private func normalizeEmail(_ email: String) -> String {
-        email.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    internal func establishSession(oneTimeSecret: String) async throws(AuthError) {
+        try await refreshJWT(oneTimeSecret)
     }
 
     private func startEmailValidation(email: String) async throws(AuthError) -> OTPAuthenticationStatus {

--- a/Sources/CrossmintAuth/OTPRequest.swift
+++ b/Sources/CrossmintAuth/OTPRequest.swift
@@ -1,0 +1,11 @@
+//
+//  OTPRequest.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 6/1/26.
+//
+
+public struct OTPRequest: Sendable, Identifiable {
+    public var id: String { requestId }
+    public let requestId: String
+}

--- a/Sources/CrossmintClient/ClientSDK.swift
+++ b/Sources/CrossmintClient/ClientSDK.swift
@@ -5,5 +5,6 @@ import Wallet
 protocol ClientSDK {
     func crossmintWallets() -> CrossmintWallets
     var authManager: CrossmintAuthManager { get }
+    var authClient: any AuthClient { get }
     var crossmintService: CrossmintService { get }
 }

--- a/Sources/CrossmintClient/ClientSDK.swift
+++ b/Sources/CrossmintClient/ClientSDK.swift
@@ -5,6 +5,6 @@ import Wallet
 protocol ClientSDK {
     func crossmintWallets() -> CrossmintWallets
     var authManager: CrossmintAuthManager { get }
-    var authClient: any AuthClient { get }
+    var authClient: AuthClient { get }
     var crossmintService: CrossmintService { get }
 }

--- a/Sources/CrossmintClient/CrossmintClientSDK.swift
+++ b/Sources/CrossmintClient/CrossmintClientSDK.swift
@@ -11,6 +11,7 @@ final class CrossmintClientSDK: ClientSDK, Sendable {
     private let secureWalletStorage: SecureWalletStorage
     let crossmintService: CrossmintService
     let authManager: CrossmintAuthManager
+    let authClient: any AuthClient
 
     init(apiKey: ApiKey, authManager: CrossmintAuthManager? = nil) {
         self.apiKey = apiKey
@@ -24,18 +25,11 @@ final class CrossmintClientSDK: ClientSDK, Sendable {
         secureWalletStorage = KeychainSecureWalletStorage(bundleId: bundleId)
         crossmintService = DefaultCrossmintService(apiKey: apiKey, appIdentifier: bundleId)
 
-        if let authManager {
-            self.authManager = authManager
-        } else {
-            self.authManager = CrossmintAuthManager(
-                authService: DefaultAuthService(crossmintService: crossmintService),
-                secureStorage: secureStorage
-            )
-        }
-    }
-
-    var isProductionEnvironment: Bool {
-        crossmintService.isProductionEnvironment
+        let authService = DefaultAuthService(crossmintService: crossmintService)
+        let resolvedAuthManager = authManager
+            ?? CrossmintAuthManager(authService: authService, secureStorage: secureStorage)
+        self.authManager = resolvedAuthManager
+        self.authClient = DefaultAuthClient(authService: authService, authManager: resolvedAuthManager)
     }
 
     func crossmintWallets() -> CrossmintWallets {

--- a/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
+++ b/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
@@ -101,6 +101,7 @@ final public class CrossmintSDK: ObservableObject {
         } catch {
             Logger.sdk.warn("Logout request failed: \(error) — clearing local state anyway")
         }
+        await authClient.logout()
         crossmintTEE.resetState()
     }
 

--- a/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
+++ b/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
@@ -40,6 +40,7 @@ final public class CrossmintSDK: ObservableObject {
     public let crossmintWallets: CrossmintWallets
     public let authManager: CrossmintAuthManager
     public let crossmintService: CrossmintService
+    public let authClient: any AuthClient
 
     let crossmintTEE: CrossmintTEE
 
@@ -84,6 +85,7 @@ final public class CrossmintSDK: ObservableObject {
         sdk = innerSdk
         crossmintWallets = innerSdk.crossmintWallets()
         self.authManager = authManager
+        self.authClient = innerSdk.authClient
         crossmintService = innerSdk.crossmintService
         crossmintTEE = CrossmintTEE.start(
             auth: authManager,

--- a/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
+++ b/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
@@ -40,7 +40,7 @@ final public class CrossmintSDK: ObservableObject {
     public let crossmintWallets: CrossmintWallets
     public let authManager: CrossmintAuthManager
     public let crossmintService: CrossmintService
-    public let authClient: any AuthClient
+    public let authClient: AuthClient
 
     let crossmintTEE: CrossmintTEE
 

--- a/Sources/Utils/EmailValidation.swift
+++ b/Sources/Utils/EmailValidation.swift
@@ -3,3 +3,7 @@ import SwiftEmailValidator
 public func isValidEmail(_ email: String) -> Bool {
     return EmailSyntaxValidator.correctlyFormatted(email)
 }
+
+public func normalizeEmail(_ email: String) -> String {
+    email.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+}

--- a/Tests/UtilsTests/EmailValidationTests.swift
+++ b/Tests/UtilsTests/EmailValidationTests.swift
@@ -1,7 +1,7 @@
 import Testing
 @testable import Utils
 
-@Suite("Email Validation Tests", .tags(.unit))
+@Suite("Email Validation", .tags(.unit))
 struct EmailValidationTests {
     @Test(
         "Rejects invalid emails",
@@ -26,5 +26,27 @@ struct EmailValidationTests {
     )
     func acceptsValidEmails(email: String) {
         #expect(isValidEmail(email))
+    }
+
+    @Test(
+        "Lowercases email",
+        arguments: [
+            ("USER@EXAMPLE.COM", "user@example.com"),
+            ("Test.User@Domain.Org", "test.user@domain.org")
+        ]
+    )
+    func lowercasesEmail(input: String, expected: String) {
+        #expect(normalizeEmail(input) == expected)
+    }
+
+    @Test(
+        "Trims surrounding whitespace",
+        arguments: [
+            ("  user@example.com  ", "user@example.com"),
+            ("\tuser@example.com\n", "user@example.com")
+        ]
+    )
+    func trimsSurroundingWhitespace(input: String, expected: String) {
+        #expect(normalizeEmail(input) == expected)
     }
 }

--- a/Tests/WebTests/CrossmintAuthManagerTests.swift
+++ b/Tests/WebTests/CrossmintAuthManagerTests.swift
@@ -28,4 +28,10 @@ struct CrossmintAuthManagerTests {
         try await authManager.sendEmailOtp(email: "user@example.com")
         _ = try await authManager.confirmEmailOtp(email: "user@example.com", code: "123456")
     }
+
+    @Test func establishesSessionFromOneTimeSecret() async throws {
+        let session = try await authManager.establishSession(oneTimeSecret: "test-secret")
+        #expect(session.jwt == "test-jwt")
+        #expect(session.email == "user@example.com")
+    }
 }

--- a/Tests/WebTests/CrossmintAuthManagerTests.swift
+++ b/Tests/WebTests/CrossmintAuthManagerTests.swift
@@ -1,68 +1,31 @@
-import Foundation
 import Testing
 @testable import CrossmintAuth
-import SecureStorage
 
+@Suite("AuthManager", .tags(.unit))
 struct CrossmintAuthManagerTests {
     private let authManager = CrossmintAuthManager(
-        authService: StubAuthService(),
-        secureStorage: StubSecureStorage()
+        authService: MockAuthService(),
+        secureStorage: MockSecureStorage()
     )
 
-    @Test("Throws invalidInput when OTP code is empty")
-    func throwsOnEmptyCode() async {
+    @Test func rejectsEmptyOtpCode() async {
         await #expect(throws: AuthManagerError.invalidInput("OTP code cannot be empty")) {
             _ = try await authManager.confirmEmailOtp(email: "user@example.com", code: "")
         }
     }
 
-    @Test("Throws invalidInput when OTP code is whitespace only")
-    func throwsOnWhitespaceCode() async {
+    @Test func rejectsWhitespaceOtpCode() async {
         await #expect(throws: AuthManagerError.invalidInput("OTP code cannot be empty")) {
             _ = try await authManager.confirmEmailOtp(email: "user@example.com", code: "   ")
         }
     }
 
-    @Test("Does not throw when sending email OTP")
-    func doesNotThrowOnSendEmailOtp() async throws {
+    @Test func sendsOtpToValidEmail() async throws {
         try await authManager.sendEmailOtp(email: "user@example.com")
     }
 
-    @Test("Does not throw when OTP code is non-empty")
-    func doesNotThrowOnNonEmptyCode() async throws {
+    @Test func authenticatesWithValidOtpCode() async throws {
         try await authManager.sendEmailOtp(email: "user@example.com")
         _ = try await authManager.confirmEmailOtp(email: "user@example.com", code: "123456")
     }
-}
-
-// MARK: - Test Doubles
-
-private struct StubAuthService: AuthService {
-    func validateEmail(_ request: ValidateEmailRequest) async throws(AuthError) -> ValidateEmailResponse {
-        ValidateEmailResponse(emailId: "test-email-id")
-    }
-
-    func validateToken(_ request: ValidateTokenRequest) async throws(AuthError) -> ValidateTokenResponse {
-        ValidateTokenResponse(callbackUrl: "", oneTimeSecret: "test-secret")
-    }
-
-    func refreshJWT(_ request: RefreshJWTRequest) async throws(AuthError) -> RefreshJWTResponse {
-        RefreshJWTResponse(
-            jwt: "test-jwt",
-            refresh: .init(secret: "test-secret", expiresAt: Date().addingTimeInterval(3600)),
-            user: .init(id: "test-id", email: "user@example.com")
-        )
-    }
-
-    func logout(_ request: LogoutRequest) async throws(AuthError) {}
-}
-
-private struct StubSecureStorage: SecureStorage {
-    func getOneTimeSecret() async throws(SecureStorageError) -> String? { nil }
-    func storeOneTimeSecret(_ secret: String) async throws(SecureStorageError) {}
-    func getJWT() async throws(SecureStorageError) -> String? { nil }
-    func storeJWT(_ secret: String) async throws(SecureStorageError) {}
-    func getEmail() async throws(SecureStorageError) -> String? { nil }
-    func storeEmail(_ email: String) async throws(SecureStorageError) {}
-    func clear() {}
 }

--- a/Tests/WebTests/DefaultAuthClientTests.swift
+++ b/Tests/WebTests/DefaultAuthClientTests.swift
@@ -1,3 +1,10 @@
+//
+//  DefaultAuthClientTests.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 6/1/26.
+//
+
 import Testing
 @testable import CrossmintAuth
 

--- a/Tests/WebTests/DefaultAuthClientTests.swift
+++ b/Tests/WebTests/DefaultAuthClientTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import CrossmintAuth
+
+@Suite("AuthClient", .tags(.unit))
+struct DefaultAuthClientTests {
+
+    private func makeClient() -> DefaultAuthClient {
+        let authService = MockAuthService()
+        let authManager = CrossmintAuthManager(authService: authService, secureStorage: MockSecureStorage())
+        return DefaultAuthClient(authService: authService, authManager: authManager)
+    }
+
+    @Test func sendsOTPAndReturnsRequestId() async throws {
+        let client = makeClient()
+        let request = try await client.sendOTP(to: "user@example.com")
+        #expect(request.requestId == "test-email-id")
+    }
+
+    @Test func verifiesOTPWithValidCodeAndReturnsSession() async throws {
+        let client = makeClient()
+        let request = try await client.sendOTP(to: "user@example.com")
+        let session = try await client.verifyOTP(code: "123456", requestId: request.requestId)
+        #expect(session.jwt == "test-jwt")
+        #expect(session.user.email == "user@example.com")
+    }
+
+    @Test func verifiesOTPWithUnknownRequestIdThrows() async {
+        let client = makeClient()
+        await #expect(throws: AuthError.self) {
+            _ = try await client.verifyOTP(code: "123456", requestId: "unknown-id")
+        }
+    }
+
+    @Test func logoutCompletesCleanly() async {
+        let client = makeClient()
+        await client.logout()
+    }
+}

--- a/Tests/WebTests/DefaultAuthClientTests.swift
+++ b/Tests/WebTests/DefaultAuthClientTests.swift
@@ -12,15 +12,32 @@ import Testing
 struct DefaultAuthClientTests {
 
     private func makeClient() -> DefaultAuthClient {
+        makeClientWithService().0
+    }
+
+    private func makeClientWithService() -> (DefaultAuthClient, MockAuthService) {
         let authService = MockAuthService()
         let authManager = CrossmintAuthManager(authService: authService, secureStorage: MockSecureStorage())
-        return DefaultAuthClient(authService: authService, authManager: authManager)
+        return (DefaultAuthClient(authService: authService, authManager: authManager), authService)
     }
 
     @Test func sendsOTPAndReturnsRequestId() async throws {
         let client = makeClient()
         let request = try await client.sendOTP(to: "user@example.com")
         #expect(request.requestId == "test-email-id")
+    }
+
+    @Test func normalizesEmailBeforeSending() async throws {
+        let (client, authService) = makeClientWithService()
+        _ = try await client.sendOTP(to: "  USER@EXAMPLE.COM  ")
+        #expect(authService.validateEmailLastRequest?.email == "user@example.com")
+    }
+
+    @Test func rejectsInvalidEmail() async {
+        let client = makeClient()
+        await #expect(throws: AuthError.self) {
+            _ = try await client.sendOTP(to: "not-an-email")
+        }
     }
 
     @Test func verifiesOTPWithValidCodeAndReturnsSession() async throws {
@@ -31,10 +48,35 @@ struct DefaultAuthClientTests {
         #expect(session.user.email == "user@example.com")
     }
 
-    @Test func verifiesOTPWithUnknownRequestIdThrows() async {
+    @Test func verifiesOTPPassesCorrectRequestToService() async throws {
+        let (client, authService) = makeClientWithService()
+        let request = try await client.sendOTP(to: "user@example.com")
+        _ = try await client.verifyOTP(code: "123456", requestId: request.requestId)
+        #expect(authService.validateTokenLastRequest?.email == "user@example.com")
+        #expect(authService.validateTokenLastRequest?.token == "123456")
+        #expect(authService.validateTokenLastRequest?.emailID == request.requestId)
+    }
+
+    @Test func verifiesOTPEstablishesSessionWithCorrectOneTimeSecret() async throws {
+        let (client, authService) = makeClientWithService()
+        let request = try await client.sendOTP(to: "user@example.com")
+        _ = try await client.verifyOTP(code: "123456", requestId: request.requestId)
+        #expect(authService.refreshJWTLastRequest?.refresh == "test-secret")
+    }
+
+    @Test func rejectsUnknownRequestId() async {
         let client = makeClient()
         await #expect(throws: AuthError.self) {
             _ = try await client.verifyOTP(code: "123456", requestId: "unknown-id")
+        }
+    }
+
+    @Test func rejectsDoubleVerifyOfSameOTP() async throws {
+        let client = makeClient()
+        let request = try await client.sendOTP(to: "user@example.com")
+        _ = try await client.verifyOTP(code: "123456", requestId: request.requestId)
+        await #expect(throws: AuthError.self) {
+            _ = try await client.verifyOTP(code: "123456", requestId: request.requestId)
         }
     }
 

--- a/Tests/WebTests/Mocks/MockAuthService.swift
+++ b/Tests/WebTests/Mocks/MockAuthService.swift
@@ -1,14 +1,24 @@
+//
+//  MockAuthService.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 6/1/26.
+//
+
 import Foundation
 @testable import CrossmintAuth
 
-// @unchecked Sendable: safe because each test creates a fresh instance and calls are sequential via actor isolation
 final class MockAuthService: AuthService, @unchecked Sendable {
 
     // MARK: - Call tracking
     var validateEmailCallCount = 0
+    var validateEmailLastRequest: ValidateEmailRequest?
     var validateTokenCallCount = 0
+    var validateTokenLastRequest: ValidateTokenRequest?
     var refreshJWTCallCount = 0
+    var refreshJWTLastRequest: RefreshJWTRequest?
     var logoutCallCount = 0
+    var logoutLastRequest: LogoutRequest?
 
     // MARK: - Configurable outcomes
     var validateEmailResponse = ValidateEmailResponse(emailId: "test-email-id")
@@ -25,23 +35,27 @@ final class MockAuthService: AuthService, @unchecked Sendable {
     // MARK: - Protocol implementation
     func validateEmail(_ request: ValidateEmailRequest) async throws(AuthError) -> ValidateEmailResponse {
         validateEmailCallCount += 1
+        validateEmailLastRequest = request
         if let error = validateEmailError { throw error }
         return validateEmailResponse
     }
 
     func validateToken(_ request: ValidateTokenRequest) async throws(AuthError) -> ValidateTokenResponse {
         validateTokenCallCount += 1
+        validateTokenLastRequest = request
         if let error = validateTokenError { throw error }
         return validateTokenResponse
     }
 
     func refreshJWT(_ request: RefreshJWTRequest) async throws(AuthError) -> RefreshJWTResponse {
         refreshJWTCallCount += 1
+        refreshJWTLastRequest = request
         if let error = refreshJWTError { throw error }
         return refreshJWTResponse
     }
 
     func logout(_ request: LogoutRequest) async throws(AuthError) {
         logoutCallCount += 1
+        logoutLastRequest = request
     }
 }

--- a/Tests/WebTests/Mocks/MockAuthService.swift
+++ b/Tests/WebTests/Mocks/MockAuthService.swift
@@ -1,6 +1,7 @@
 import Foundation
 @testable import CrossmintAuth
 
+// @unchecked Sendable: safe because each test creates a fresh instance and calls are sequential via actor isolation
 final class MockAuthService: AuthService, @unchecked Sendable {
 
     // MARK: - Call tracking

--- a/Tests/WebTests/Mocks/MockAuthService.swift
+++ b/Tests/WebTests/Mocks/MockAuthService.swift
@@ -1,0 +1,46 @@
+import Foundation
+@testable import CrossmintAuth
+
+final class MockAuthService: AuthService, @unchecked Sendable {
+
+    // MARK: - Call tracking
+    var validateEmailCallCount = 0
+    var validateTokenCallCount = 0
+    var refreshJWTCallCount = 0
+    var logoutCallCount = 0
+
+    // MARK: - Configurable outcomes
+    var validateEmailResponse = ValidateEmailResponse(emailId: "test-email-id")
+    var validateTokenResponse = ValidateTokenResponse(callbackUrl: "", oneTimeSecret: "test-secret")
+    var refreshJWTResponse = RefreshJWTResponse(
+        jwt: "test-jwt",
+        refresh: .init(secret: "test-secret", expiresAt: Date().addingTimeInterval(3600)),
+        user: .init(id: "test-id", email: "user@example.com")
+    )
+    var validateEmailError: AuthError?
+    var validateTokenError: AuthError?
+    var refreshJWTError: AuthError?
+
+    // MARK: - Protocol implementation
+    func validateEmail(_ request: ValidateEmailRequest) async throws(AuthError) -> ValidateEmailResponse {
+        validateEmailCallCount += 1
+        if let error = validateEmailError { throw error }
+        return validateEmailResponse
+    }
+
+    func validateToken(_ request: ValidateTokenRequest) async throws(AuthError) -> ValidateTokenResponse {
+        validateTokenCallCount += 1
+        if let error = validateTokenError { throw error }
+        return validateTokenResponse
+    }
+
+    func refreshJWT(_ request: RefreshJWTRequest) async throws(AuthError) -> RefreshJWTResponse {
+        refreshJWTCallCount += 1
+        if let error = refreshJWTError { throw error }
+        return refreshJWTResponse
+    }
+
+    func logout(_ request: LogoutRequest) async throws(AuthError) {
+        logoutCallCount += 1
+    }
+}

--- a/Tests/WebTests/Mocks/MockSecureStorage.swift
+++ b/Tests/WebTests/Mocks/MockSecureStorage.swift
@@ -1,0 +1,15 @@
+import SecureStorage
+
+final class MockSecureStorage: SecureStorage, @unchecked Sendable {
+    private var oneTimeSecret: String?
+    private var jwt: String?
+    private var storedEmail: String?
+
+    func getOneTimeSecret() async throws(SecureStorageError) -> String? { oneTimeSecret }
+    func storeOneTimeSecret(_ secret: String) async throws(SecureStorageError) { oneTimeSecret = secret }
+    func getJWT() async throws(SecureStorageError) -> String? { jwt }
+    func storeJWT(_ secret: String) async throws(SecureStorageError) { jwt = secret }
+    func getEmail() async throws(SecureStorageError) -> String? { storedEmail }
+    func storeEmail(_ email: String) async throws(SecureStorageError) { storedEmail = email }
+    func clear() { oneTimeSecret = nil; jwt = nil; storedEmail = nil }
+}

--- a/Tests/WebTests/Mocks/MockSecureStorage.swift
+++ b/Tests/WebTests/Mocks/MockSecureStorage.swift
@@ -1,5 +1,6 @@
 import SecureStorage
 
+// @unchecked Sendable: safe because each test creates a fresh instance and calls are sequential via actor isolation
 final class MockSecureStorage: SecureStorage, @unchecked Sendable {
     private var oneTimeSecret: String?
     private var jwt: String?

--- a/Tests/WebTests/Mocks/MockSecureStorage.swift
+++ b/Tests/WebTests/Mocks/MockSecureStorage.swift
@@ -1,6 +1,12 @@
+//
+//  MockSecureStorage.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 6/1/26.
+//
+
 import SecureStorage
 
-// @unchecked Sendable: safe because each test creates a fresh instance and calls are sequential via actor isolation
 final class MockSecureStorage: SecureStorage, @unchecked Sendable {
     private var oneTimeSecret: String?
     private var jwt: String?


### PR DESCRIPTION
This PR introduces `AuthClient`, a protocol that exposes the OTP authentication flow as a clean public API. Previously the only way to do email OTP was to call `sendEmailOtp` and `confirmEmailOtp` directly on `CrossmintAuthManager`, which wasn't on any public protocol and forced callers to reach through implementation details.

`CrossmintSDK.shared.authClient` is now the intended entry point for authentication.

## Changes

- Added `AuthClient` protocol with `sendOTP(to:)`, `verifyOTP(code:requestId:)`, and `logout()`. All methods use typed throws (`throws(AuthError)`) to match the existing convention in the SDK.
- Added `DefaultAuthClient` as a Swift `actor`. It owns the pending OTP state (`[requestId: email]`) and delegates all JWT and keychain management to `CrossmintAuthManager` via a new internal `establishSession(oneTimeSecret:)` method, so there's only one source of truth for session state.
- `normalizeEmail` moved from `CrossmintAuthManager` to `Utils/EmailValidation.swift` so both `DefaultAuthClient` and `CrossmintAuthManager` share the same implementation.
- Wired `authClient` on `CrossmintClientSDK` and `CrossmintSDK.shared`. The `DefaultAuthClient` shares the same `CrossmintAuthManager` instance as the rest of the SDK, so JWT refresh and logout stay in sync.
- Updated `OTPSignInView` and `VerificationView` in the demo app to use `CrossmintSDK.shared.authClient`. `VerificationView` now accepts a `requestId` at init and handles resend by updating it in place.
- Added `DefaultAuthClientTests` and extracted shared mocks (`MockAuthService`, `MockSecureStorage`) to `Tests/WebTests/Mocks/` for reuse across test suites.