### PR TITLE
fix: prevent iOS WKWebView JS throttling from zero-area frame

### DIFF
--- a/Sources/CrossmintClient/SwiftUI/View+NonCustodialSigner.swift
+++ b/Sources/CrossmintClient/SwiftUI/View+NonCustodialSigner.swift
@@ -52,7 +52,8 @@ private struct HiddenEmailSignersView: View {
 
     var body: some View {
         CrossmintWebView(tee: crossmintTEE)
-        .frame(width: 20, height: 20) // 1x1 WebViews may be throttled, so give some margin
+        .frame(width: 1, height: 1)
+        .opacity(0)
         .allowsHitTesting(false)
         .accessibilityHidden(true)
         .task {

--- a/Sources/Web/CrossmintWebView.swift
+++ b/Sources/Web/CrossmintWebView.swift
@@ -45,7 +45,10 @@ public struct CrossmintWebView: UIViewRepresentable {
 
         configuration.userContentController = userContentController
 
-        let webView = WKWebView(frame: .zero, configuration: configuration)
+        // Use a nonzero initial frame so iOS considers the WebView composited from creation.
+        // A .zero frame can cause ActivityState::IsVisible to be unset, which triggers
+        // updateThrottleState() to drop the foreground assertion on the WebContent process.
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 1, height: 1), configuration: configuration)
         webView.navigationDelegate = webViewCommunicationProxy
 #if DEBUG
         if #available(iOS 16.4, *) {


### PR DESCRIPTION
## Summary

Port of [crossmint-sdk#1878](https://github.com/Crossmint/crossmint-sdk/pull/1878) — same root cause, same fix, different platform.

A `WKWebView(frame: .zero, ...)` causes WebKit to clear `ActivityState::IsVisible`, which triggers `updateThrottleState()` → `dropVisibleActivity()` — the WebContent process loses its foreground assertion and becomes eligible for suspension, timer throttling, and priority termination under memory pressure.

**Changes:**

- `CrossmintWebView.swift`: `WKWebView(frame: .zero, ...)` → `WKWebView(frame: CGRect(x: 0, y: 0, width: 1, height: 1), ...)` so the backing layer is composited from creation
- `View+NonCustodialSigner.swift`: `.frame(width: 20, height: 20)` → `.frame(width: 1, height: 1)` + `.opacity(0)` — the previous 20×20 was unnecessary padding; a 1×1 composited layer is sufficient, and `.opacity(0)` ensures the view is truly invisible while keeping iOS's visibility flag set

WebKit source references: see [detailed walkthrough](https://github.com/Crossmint/crossmint-sdk/pull/1878#issuecomment-4596988817).

Link to Devin session: https://crossmint.devinenterprise.com/sessions/aa42293821a24fee86c25e350715efd5
Requested by: @panosinthezone