### PR TITLE
Demo app fixes and improvements for TestFlight

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Components/OTPSheet.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Components/OTPSheet.swift
@@ -17,7 +17,7 @@ private struct OTPSheetModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .sheet(isPresented: $showOTPView, onDismiss: {
+            .sheet(isPresented: $showOTPView, onDismiss: { @MainActor in
                 CrossmintSDK.shared.cancelTransaction()
             }) { OTPValidatorView() }
             .onReceive(CrossmintSDK.shared.isOTPRequired) { showOTPView = $0 }

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Components/OTPSheet.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Components/OTPSheet.swift
@@ -17,7 +17,9 @@ private struct OTPSheetModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .sheet(isPresented: $showOTPView) { OTPValidatorView() }
+            .sheet(isPresented: $showOTPView, onDismiss: {
+                CrossmintSDK.shared.cancelTransaction()
+            }) { OTPValidatorView() }
             .onReceive(CrossmintSDK.shared.isOTPRequired) { showOTPView = $0 }
     }
 }

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Activity/ActivityView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Activity/ActivityView.swift
@@ -35,7 +35,7 @@ struct ActivityView: View {
                     List(transfers) { transfer in
                         TransferRow(transfer: transfer)
                     }
-                    .refreshable { await loadTransfers() }
+                    .refreshable { await loadTransfers(isRefresh: true) }
                 }
             }
             .navigationTitle("Activity")
@@ -49,9 +49,9 @@ struct ActivityView: View {
         .task { await loadTransfers() }
     }
 
-    private func loadTransfers() async {
+    private func loadTransfers(isRefresh: Bool = false) async {
         guard let wallet = appState.wallet else { return }
-        isLoading = true
+        if !isRefresh { isLoading = true }
         errorMessage = nil
         do {
             let result = try await wallet.listTransfers(tokens: appState.selectedChain.balanceCurrencies)

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/AppState.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/AppState.swift
@@ -224,41 +224,49 @@ final class AppState {
     }
 
     private func fetchWallet(chain: SupportedChain, email: String) async throws -> Wallet? {
+        let options = WalletOptions(deviceSigner: true)
         switch chain {
         case .evm:
             return try await sdk.crossmintWallets.getWallet(
                 chain: EVMChain.baseSepolia,
-                recovery: EVMSigners.email(email)
+                recovery: EVMSigners.email(email),
+                options: options
             )
         case .solana:
             return try await sdk.crossmintWallets.getWallet(
                 chain: SolanaChain.solana,
-                recovery: SolanaSigners.email(email)
+                recovery: SolanaSigners.email(email),
+                options: options
             )
         case .stellar:
             return try await sdk.crossmintWallets.getWallet(
                 chain: StellarChain.stellar,
-                recovery: StellarSigners.email(email)
+                recovery: StellarSigners.email(email),
+                options: options
             )
         }
     }
 
     private func makeWallet(chain: SupportedChain, email: String) async throws -> Wallet {
+        let options = WalletOptions(deviceSigner: true)
         switch chain {
         case .evm:
             return try await sdk.crossmintWallets.createWallet(
                 chain: EVMChain.baseSepolia,
-                recovery: EVMSigners.email(email)
+                recovery: EVMSigners.email(email),
+                options: options
             )
         case .solana:
             return try await sdk.crossmintWallets.createWallet(
                 chain: SolanaChain.solana,
-                recovery: SolanaSigners.email(email)
+                recovery: SolanaSigners.email(email),
+                options: options
             )
         case .stellar:
             return try await sdk.crossmintWallets.createWallet(
                 chain: StellarChain.stellar,
-                recovery: StellarSigners.email(email)
+                recovery: StellarSigners.email(email),
+                options: options
             )
         }
     }

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/SmartWalletsDemo.entitlements
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/SmartWalletsDemo.entitlements
@@ -4,6 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>webcredentials:wallets-ios.demos-crossmint.com</string>
 		<string>webcredentials:wallets-ios.demos-crossmint.com?mode=developer</string>
 	</array>
 </dict>

--- a/Sources/CrossmintAuth/DefaultAuthManager.swift
+++ b/Sources/CrossmintAuth/DefaultAuthManager.swift
@@ -223,12 +223,8 @@ public actor CrossmintAuthManager: AuthManager {
             _authenticationStatus = authStatus
             return authStatus
         } catch {
-            if case .signInRequired = error {
-                _authenticationStatus = .nonAuthenticated
-            } else {
-                _authenticationStatus = nil
-            }
-            throw error
+            _authenticationStatus = .nonAuthenticated
+            throw AuthError.signInRequired
         }
     }
 }


### PR DESCRIPTION
This pull request fixes four issues found while testing the SmartWalletsDemo on TestFlight and adds device signer setup by default to reduce how often users hit the OTP flow.

## Changes

- The `SmartWalletsDemo.entitlements` file only had `webcredentials:wallets-ios.demos-crossmint.com?mode=developer`, which bypasses AASA validation for Xcode-installed builds but not for TestFlight. Adding the entry without `?mode=developer` alongside the existing one lets passkey registration work on distributed builds.
- `fetchWallet` and `makeWallet` in `AppState` now pass `WalletOptions(deviceSigner: true)`. This registers the device key on first load and on wallet creation, so subsequent transfers can be signed locally without triggering OTP.
- The OTP sheet's `onDismiss` now calls `cancelTransaction()` annotated with `@MainActor`. Previously, swiping the sheet down would close the UI but leave the underlying send task suspended indefinitely since only the X button wired up cancellation. `cancelOTP()` is already idempotent so calling it after a successful submission is safe.
- `loadTransfers` no longer sets `isLoading = true` when called from pull-to-refresh. The previous behavior toggled the view from `List` to `ProgressView`, which removed the list from the hierarchy and caused SwiftUI to cancel the `.refreshable` task mid-flight, which is why every manual refresh landed on "Unknown error: cancelled".