### PR TITLE
Make Solana device-signer registration provider-aware

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -160,6 +160,7 @@ let package = Package(
                 .process("Resources/Transaction/SignTransactionResponse.json"),
                 .process("Resources/Transaction/FailedTransactionResponse.json"),
                 .process("Resources/Transaction/CreateSolanaTransactionResponse.json"),
+                .process("Resources/Transaction/SolanaSignerRegistrationAwaitingApproval.json"),
                 .process("Resources/Signature/CreateSignatureAwaitingApproval.json"),
                 .process("Resources/WalletEVMApiKey.json"),
                 .process("Resources/WalletEVMEmail.json"),

--- a/Sources/Http/NetworkError.swift
+++ b/Sources/Http/NetworkError.swift
@@ -32,16 +32,7 @@ public enum NetworkError: LocalizedError {
     }
 
     public var serviceErrorMessage: String? {
-        guard let errorData = errorData else { return nil }
-        do {
-            guard let jsonObject = try JSONSerialization.jsonObject(with: errorData, options: []) as? [String: Any],
-                  let message = jsonObject["message"] as? String else {
-                return nil
-            }
-            return message
-        } catch {
-            return nil
-        }
+        serviceErrorBody?.message
     }
 
     /// The stable `code` field from the error response body, when present.
@@ -49,16 +40,12 @@ public enum NetworkError: LocalizedError {
     /// The Crossmint API attaches machine-readable codes (e.g. `DEVICE_SIGNER_NOT_SUPPORTED`)
     /// to some error responses so callers can branch on them instead of parsing messages.
     public var serviceErrorCode: String? {
+        serviceErrorBody?.code
+    }
+
+    private var serviceErrorBody: ServiceErrorBody? {
         guard let errorData = errorData else { return nil }
-        do {
-            guard let jsonObject = try JSONSerialization.jsonObject(with: errorData, options: []) as? [String: Any],
-                  let code = jsonObject["code"] as? String else {
-                return nil
-            }
-            return code
-        } catch {
-            return nil
-        }
+        return try? JSONDecoder().decode(ServiceErrorBody.self, from: errorData)
     }
 
     private var errorData: Data? {
@@ -87,4 +74,9 @@ public enum NetworkError: LocalizedError {
 
         return String(data: data, encoding: .utf8) ?? "Unable to parse error data"
     }
+}
+
+private struct ServiceErrorBody: Decodable {
+    let message: String?
+    let code: String?
 }

--- a/Sources/Http/NetworkError.swift
+++ b/Sources/Http/NetworkError.swift
@@ -44,6 +44,23 @@ public enum NetworkError: LocalizedError {
         }
     }
 
+    /// The stable `code` field from the error response body, when present.
+    ///
+    /// The Crossmint API attaches machine-readable codes (e.g. `DEVICE_SIGNER_NOT_SUPPORTED`)
+    /// to some error responses so callers can branch on them instead of parsing messages.
+    public var serviceErrorCode: String? {
+        guard let errorData = errorData else { return nil }
+        do {
+            guard let jsonObject = try JSONSerialization.jsonObject(with: errorData, options: []) as? [String: Any],
+                  let code = jsonObject["code"] as? String else {
+                return nil
+            }
+            return code
+        } catch {
+            return nil
+        }
+    }
+
     private var errorData: Data? {
         switch self {
         case .badRequest(let data),

--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -408,6 +408,9 @@ public enum LogEvents {
     /// Recover failed
     public static let walletRecoverError = "wallet.recover.error"
 
+    /// Recover fell back to the recovery signer — the wallet's provider does not support device signers
+    public static let walletRecoverDeviceSignerUnsupported = "wallet.recover.deviceSignerUnsupported"
+
     // MARK: - registerDeviceSigner Events
 
     /// Starting device signer registration

--- a/Sources/Wallet/Data/CreateWallet/AddDelegatedSignerResponse.swift
+++ b/Sources/Wallet/Data/CreateWallet/AddDelegatedSignerResponse.swift
@@ -12,15 +12,10 @@ public struct ChainRegistrationEntry: Decodable {
 /// which approve registrations through a regular transaction instead of the per-chain
 /// entries EVM returns under `chains`.
 public struct RegistrationTransaction: Decodable {
-    public let id: String?
+    public let id: String
 }
 
 public struct AddDelegatedSignerResponse: Decodable {
     public let chains: [String: ChainRegistrationEntry]?
     public let transaction: RegistrationTransaction?
-
-    init(chains: [String: ChainRegistrationEntry]?, transaction: RegistrationTransaction? = nil) {
-        self.chains = chains
-        self.transaction = transaction
-    }
 }

--- a/Sources/Wallet/Data/CreateWallet/AddDelegatedSignerResponse.swift
+++ b/Sources/Wallet/Data/CreateWallet/AddDelegatedSignerResponse.swift
@@ -8,6 +8,19 @@ public struct ChainRegistrationEntry: Decodable {
     public let approvals: RegistrationApprovals?
 }
 
+/// Pending transaction returned when registering a signer on Solana/Stellar wallets,
+/// which approve registrations through a regular transaction instead of the per-chain
+/// entries EVM returns under `chains`.
+public struct RegistrationTransaction: Decodable {
+    public let id: String?
+}
+
 public struct AddDelegatedSignerResponse: Decodable {
     public let chains: [String: ChainRegistrationEntry]?
+    public let transaction: RegistrationTransaction?
+
+    init(chains: [String: ChainRegistrationEntry]?, transaction: RegistrationTransaction? = nil) {
+        self.chains = chains
+        self.transaction = transaction
+    }
 }

--- a/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
+++ b/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
@@ -120,11 +120,24 @@ struct DefaultWalletService: WalletService {
         let responseData = try await crossmintService.executeRequestForRawData(
             .meWalletSigners(chainType: chainType, body: bodyData),
             errorType: WalletError.self
-        )
+        ) { networkError in
+            Self.deviceSignerNotSupportedError(code: networkError.serviceErrorCode,
+                                               message: networkError.serviceErrorMessage)
+        }
         guard let result = try? jsonCoder.decode(AddDelegatedSignerResponse.self, from: responseData) else {
             throw WalletError.walletGeneric("Failed to decode signer registration response")
         }
         return result
+    }
+
+    // Must match the backend constant, which returns this code on a 400 response.
+    private static let deviceSignerNotSupportedCode = "DEVICE_SIGNER_NOT_SUPPORTED"
+
+    private static func deviceSignerNotSupportedError(code: String?, message: String?) -> WalletError? {
+        guard code == deviceSignerNotSupportedCode else { return nil }
+        return .deviceSignerNotSupported(
+            message ?? "Device signers are not supported for this wallet's provider."
+        )
     }
 
     private func signerRegistrationChain(chainType: ChainType, chainName: String) -> String? {

--- a/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
+++ b/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
@@ -130,7 +130,6 @@ struct DefaultWalletService: WalletService {
         return result
     }
 
-    // Must match the backend constant, which returns this code on a 400 response.
     private static let deviceSignerNotSupportedCode = "DEVICE_SIGNER_NOT_SUPPORTED"
 
     private static func deviceSignerNotSupportedError(code: String?, message: String?) -> WalletError? {

--- a/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
+++ b/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
@@ -121,8 +121,10 @@ struct DefaultWalletService: WalletService {
             .meWalletSigners(chainType: chainType, body: bodyData),
             errorType: WalletError.self
         ) { networkError in
-            deviceSignerNotSupportedError(code: networkError.serviceErrorCode,
-                                          message: networkError.serviceErrorMessage)
+            deviceSignerNotSupportedError(
+                code: networkError.serviceErrorCode,
+                message: networkError.serviceErrorMessage
+            )
         }
         guard let result = try? jsonCoder.decode(AddDelegatedSignerResponse.self, from: responseData) else {
             throw WalletError.walletGeneric("Failed to decode signer registration response")

--- a/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
+++ b/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
@@ -121,7 +121,7 @@ struct DefaultWalletService: WalletService {
             .meWalletSigners(chainType: chainType, body: bodyData),
             errorType: WalletError.self
         ) { networkError in
-            deviceSignerNotSupportedError(
+            mapToDeviceSignerNotSupportedErrorIfApplicable(
                 code: networkError.serviceErrorCode,
                 message: networkError.serviceErrorMessage
             )
@@ -132,7 +132,7 @@ struct DefaultWalletService: WalletService {
         return result
     }
 
-    private func deviceSignerNotSupportedError(code: String?, message: String?) -> WalletError? {
+    private func mapToDeviceSignerNotSupportedErrorIfApplicable(code: String?, message: String?) -> WalletError? {
         guard code == "DEVICE_SIGNER_NOT_SUPPORTED" else { return nil }
         return .deviceSignerNotSupported(
             message ?? "Device signers are not supported for this wallet's provider."

--- a/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
+++ b/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
@@ -121,8 +121,8 @@ struct DefaultWalletService: WalletService {
             .meWalletSigners(chainType: chainType, body: bodyData),
             errorType: WalletError.self
         ) { networkError in
-            Self.deviceSignerNotSupportedError(code: networkError.serviceErrorCode,
-                                               message: networkError.serviceErrorMessage)
+            deviceSignerNotSupportedError(code: networkError.serviceErrorCode,
+                                          message: networkError.serviceErrorMessage)
         }
         guard let result = try? jsonCoder.decode(AddDelegatedSignerResponse.self, from: responseData) else {
             throw WalletError.walletGeneric("Failed to decode signer registration response")
@@ -130,10 +130,8 @@ struct DefaultWalletService: WalletService {
         return result
     }
 
-    private static let deviceSignerNotSupportedCode = "DEVICE_SIGNER_NOT_SUPPORTED"
-
-    private static func deviceSignerNotSupportedError(code: String?, message: String?) -> WalletError? {
-        guard code == deviceSignerNotSupportedCode else { return nil }
+    private func deviceSignerNotSupportedError(code: String?, message: String?) -> WalletError? {
+        guard code == "DEVICE_SIGNER_NOT_SUPPORTED" else { return nil }
         return .deviceSignerNotSupported(
             message ?? "Device signers are not supported for this wallet's provider."
         )

--- a/Sources/Wallet/Data/SmartWalletService+Approvals.swift
+++ b/Sources/Wallet/Data/SmartWalletService+Approvals.swift
@@ -1,0 +1,48 @@
+import CrossmintCommonTypes
+
+extension SmartWalletService {
+    /// Fetches a transaction and returns it as the domain model.
+    func transaction(withId id: String, chainType: ChainType) async throws(TransactionError) -> Transaction {
+        let transactionModel = try await fetchTransaction(
+            .init(transactionId: id, chainType: chainType)
+        )
+        guard let transaction = transactionModel.toDomain(withService: self) else {
+            throw TransactionError.transactionGeneric("Failed to decode transaction response")
+        }
+        return transaction
+    }
+
+    /// Signs the approval message with the given signer and submits it for the transaction.
+    func signTransaction(
+        transactionId: String,
+        chainType: ChainType,
+        signer: any Signer,
+        message: String
+    ) async throws {
+        let request = try await makeSignRequest(signer: signer, message: message)
+        _ = try await signTransaction(
+            .init(transactionId: transactionId, apiRequest: request, chainType: chainType)
+        )
+    }
+
+    /// Signs the approval message with the given signer and submits it for the signature.
+    func approveSignature(
+        signatureId: String,
+        chainType: ChainType,
+        signer: any Signer,
+        message: String
+    ) async throws {
+        let request = try await makeSignRequest(signer: signer, message: message)
+        try await approveSignature(
+            .init(transactionId: signatureId, apiRequest: request, chainType: chainType)
+        )
+    }
+
+    private func makeSignRequest(signer: any Signer, message: String) async throws(SignerError) -> SignRequestApi {
+        SignRequestApi(
+            approvals: try await signer.approvals(
+                withSignature: try await signer.sign(message: message)
+            )
+        )
+    }
+}

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -78,9 +78,6 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
         try assertValid(chain)
 
         let deviceSignerStorage = makeDeviceSignerStorage(options: options)
-        // Solana skips the eager attach: device-signer support depends on the wallet's
-        // provider, only known server-side. The first recover() registers the signer
-        // instead, falling back to the recovery signer if the provider rejects it.
         let creationDeviceSignerStorage = chain.chainType == .solana ? nil : deviceSignerStorage
         let walletApiModel = try await createWalletApiModel(
             signer: recovery,

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -78,13 +78,12 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
         try assertValid(chain)
 
         let deviceSignerStorage = makeDeviceSignerStorage(options: options)
-        let creationDeviceSignerStorage = chain.chainType == .solana ? nil : deviceSignerStorage
         let walletApiModel = try await createWalletApiModel(
             signer: recovery,
             chainType: chain.chainType,
             walletType: .smart,
             options: options,
-            deviceSignerStorage: creationDeviceSignerStorage
+            deviceSignerStorage: deviceSignerStorage
         )
 
         let wallet = try buildWallet(
@@ -166,7 +165,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
         var delegatedSigners: [DelegatedSignerEntry]?
         var pendingPublicKeyBase64: String?
 
-        if let storage = deviceSignerStorage {
+        if let storage = deviceSignerStorage, chainType != .solana {
             do {
                 let publicKeyBase64 = try await storage.generateKey(address: nil)
                 let entry = try makeDelegatedSignerEntry(publicKeyBase64: publicKeyBase64)

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -78,12 +78,16 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
         try assertValid(chain)
 
         let deviceSignerStorage = makeDeviceSignerStorage(options: options)
+        // Solana skips the eager attach: device-signer support depends on the wallet's
+        // provider, only known server-side. The first recover() registers the signer
+        // instead, falling back to the recovery signer if the provider rejects it.
+        let creationDeviceSignerStorage = chain.chainType == .solana ? nil : deviceSignerStorage
         let walletApiModel = try await createWalletApiModel(
             signer: recovery,
             chainType: chain.chainType,
             walletType: .smart,
             options: options,
-            deviceSignerStorage: deviceSignerStorage
+            deviceSignerStorage: creationDeviceSignerStorage
         )
 
         let wallet = try buildWallet(

--- a/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
+++ b/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
@@ -54,6 +54,9 @@ final class DeviceSignerService: Sendable {
         } catch {
             try? await storage.deletePendingKey(publicKeyBase64: publicKeyBase64)
             Logger.smartWallet.error(LogEvents.walletRegisterDeviceSignerError, attributes: ["error": "\(error)"])
+            if case .deviceSignerNotSupported = error {
+                throw error
+            }
             throw WalletError.walletGeneric("Failed to register device signer: \(error)")
         }
 
@@ -92,7 +95,9 @@ final class DeviceSignerService: Sendable {
         return "device:\(publicKeyBase64)"
     }
 
-    func ensureRegistered(storage: any DeviceSignerKeyStorage, signer: any Signer) async {
+    // Best-effort: failures are swallowed so a transfer never breaks on registration, except
+    // deviceSignerNotSupported, rethrown so the wallet can remember it and stop retrying.
+    func ensureRegistered(storage: any DeviceSignerKeyStorage, signer: any Signer) async throws(WalletError) {
         guard await storage.getKey(address: address) == nil else { return }
         Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerStart, attributes: ["address": address])
         do {
@@ -100,6 +105,9 @@ final class DeviceSignerService: Sendable {
             Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerSuccess, attributes: ["address": address])
         } catch {
             Logger.smartWallet.warn(LogEvents.walletAddDelegatedSignerError, attributes: ["error": "\(error)"])
+            if case .deviceSignerNotSupported = error {
+                throw error
+            }
         }
     }
 

--- a/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
+++ b/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
@@ -29,16 +29,28 @@ final class DeviceSignerService: Sendable {
 
     func register(storage: any DeviceSignerKeyStorage, signer: any Signer) async throws(WalletError) {
         Logger.smartWallet.info(LogEvents.walletRegisterDeviceSignerStart)
+        let publicKeyBase64 = try await generatePendingKey(in: storage)
+        let registration = try await submitRegistration(of: publicKeyBase64, storage: storage)
+        try await approveRegistration(registration, signer: signer, publicKeyBase64: publicKeyBase64, storage: storage)
+        try await persistKey(publicKeyBase64, in: storage)
+        Logger.smartWallet.info(LogEvents.walletRegisterDeviceSignerSuccess)
+    }
 
-        let publicKeyBase64: String
+    private func generatePendingKey(in storage: any DeviceSignerKeyStorage) async throws(WalletError) -> String {
         do {
-            publicKeyBase64 = try await storage.generateKey(address: nil)
+            let publicKeyBase64 = try await storage.generateKey(address: nil)
             Logger.smartWallet.info(LogEvents.walletRegisterDeviceSignerKeyGenerated)
+            return publicKeyBase64
         } catch {
             Logger.smartWallet.error(LogEvents.walletRegisterDeviceSignerError, attributes: ["error": "\(error)"])
             throw WalletError.walletGeneric("Failed to generate device key: \(error)")
         }
+    }
 
+    private func submitRegistration(
+        of publicKeyBase64: String,
+        storage: any DeviceSignerKeyStorage
+    ) async throws(WalletError) -> AddDelegatedSignerResponse {
         let entry: DelegatedSignerEntry
         do {
             entry = try makeDelegatedSignerEntry(publicKeyBase64: publicKeyBase64)
@@ -47,10 +59,8 @@ final class DeviceSignerService: Sendable {
             Logger.smartWallet.error(LogEvents.walletRegisterDeviceSignerError, attributes: ["error": "\(error)"])
             throw error
         }
-
-        let registration: AddDelegatedSignerResponse
         do {
-            registration = try await smartWalletService.addSigner(entry, chainType: chainType, chainName: chainName)
+            return try await smartWalletService.addSigner(entry, chainType: chainType, chainName: chainName)
         } catch {
             try? await storage.deletePendingKey(publicKeyBase64: publicKeyBase64)
             Logger.smartWallet.error(LogEvents.walletRegisterDeviceSignerError, attributes: ["error": "\(error)"])
@@ -59,7 +69,14 @@ final class DeviceSignerService: Sendable {
             }
             throw WalletError.walletGeneric("Failed to register device signer: \(error)")
         }
+    }
 
+    private func approveRegistration(
+        _ registration: AddDelegatedSignerResponse,
+        signer: any Signer,
+        publicKeyBase64: String,
+        storage: any DeviceSignerKeyStorage
+    ) async throws(WalletError) {
         let chainEntry = registration.chains?[chainName]
         let pendingApprovalId = chainEntry?.status == "awaiting-approval" ? chainEntry?.id : registration.transaction?.id
         if let pendingApprovalId {
@@ -79,15 +96,15 @@ final class DeviceSignerService: Sendable {
             Logger.smartWallet.error(LogEvents.walletRegisterDeviceSignerError, attributes: ["error": "\(error)"])
             throw error
         }
+    }
 
+    private func persistKey(_ publicKeyBase64: String, in storage: any DeviceSignerKeyStorage) async throws(WalletError) {
         do {
             try await storage.mapAddressToKey(address: address, publicKeyBase64: publicKeyBase64)
         } catch {
             Logger.smartWallet.error(LogEvents.walletRegisterDeviceSignerError, attributes: ["error": "\(error)"])
             throw WalletError.walletGeneric("Failed to persist device key: \(error)")
         }
-
-        Logger.smartWallet.info(LogEvents.walletRegisterDeviceSignerSuccess)
     }
 
     func locator(for storage: any DeviceSignerKeyStorage) async -> String? {

--- a/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
+++ b/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
@@ -95,8 +95,6 @@ final class DeviceSignerService: Sendable {
         return "device:\(publicKeyBase64)"
     }
 
-    // Best-effort: failures are swallowed so a transfer never breaks on registration, except
-    // deviceSignerNotSupported, rethrown so the wallet can remember it and stop retrying.
     func ensureRegistered(storage: any DeviceSignerKeyStorage, signer: any Signer) async throws(WalletError) {
         guard await storage.getKey(address: address) == nil else { return }
         Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerStart, attributes: ["address": address])

--- a/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
+++ b/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
@@ -60,22 +60,24 @@ final class DeviceSignerService: Sendable {
             throw WalletError.walletGeneric("Failed to register device signer: \(error)")
         }
 
-        if let chainEntry = registration.chains?[chainName],
-           chainEntry.status == "awaiting-approval",
-           let signatureId = chainEntry.id {
+        let chainEntry = registration.chains?[chainName]
+        let pendingApprovalId = chainEntry?.status == "awaiting-approval" ? chainEntry?.id : registration.transaction?.id
+        if let pendingApprovalId {
             Logger.smartWallet.info(LogEvents.walletRegisterDeviceSignerAwaitingApproval, attributes: [
-                "signatureId": signatureId
+                "approvalId": pendingApprovalId
             ])
-            do {
-                try await registrationService.approveIfNeeded(registration: registration, signer: signer)
+        }
+        do {
+            try await registrationService.approveIfNeeded(registration: registration, signer: signer)
+            if let pendingApprovalId {
                 Logger.smartWallet.info(LogEvents.walletRegisterDeviceSignerApproved, attributes: [
-                    "signatureId": signatureId
+                    "approvalId": pendingApprovalId
                 ])
-            } catch {
-                try? await storage.deletePendingKey(publicKeyBase64: publicKeyBase64)
-                Logger.smartWallet.error(LogEvents.walletRegisterDeviceSignerError, attributes: ["error": "\(error)"])
-                throw error
             }
+        } catch {
+            try? await storage.deletePendingKey(publicKeyBase64: publicKeyBase64)
+            Logger.smartWallet.error(LogEvents.walletRegisterDeviceSignerError, attributes: ["error": "\(error)"])
+            throw error
         }
 
         do {

--- a/Sources/Wallet/Model/Wallet/SignerRegistrationService.swift
+++ b/Sources/Wallet/Model/Wallet/SignerRegistrationService.swift
@@ -39,17 +39,33 @@ final class SignerRegistrationService: Sendable {
     }
 
     func approveIfNeeded(registration: AddDelegatedSignerResponse, signer: any Signer) async throws(WalletError) {
+        switch pendingApproval(in: registration) {
+        case let .signature(signatureId, pending):
+            try await approveSignatureRegistration(signatureId: signatureId, pending: pending, signer: signer)
+        case let .transaction(transactionId):
+            try await approveRegistrationTransaction(transactionId: transactionId, signer: signer)
+        case .notNeeded:
+            break
+        }
+    }
+
+    private enum PendingApproval {
+        case signature(id: String, pending: [ApprovalEntry])
+        case transaction(id: String)
+        case notNeeded
+    }
+
+    private func pendingApproval(in registration: AddDelegatedSignerResponse) -> PendingApproval {
         if let chainEntry = registration.chains?[chainName],
            chainEntry.status == "awaiting-approval",
            let signatureId = chainEntry.id,
            let pending = chainEntry.approvals?.pending, !pending.isEmpty {
-            try await approveSignatureRegistration(signatureId: signatureId, pending: pending, signer: signer)
-            return
+            return .signature(id: signatureId, pending: pending)
         }
-
         if let transaction = registration.transaction {
-            try await approveRegistrationTransaction(transactionId: transaction.id, signer: signer)
+            return .transaction(id: transaction.id)
         }
+        return .notNeeded
     }
 
     private func approveSignatureRegistration(

--- a/Sources/Wallet/Model/Wallet/SignerRegistrationService.swift
+++ b/Sources/Wallet/Model/Wallet/SignerRegistrationService.swift
@@ -47,8 +47,8 @@ final class SignerRegistrationService: Sendable {
             return
         }
 
-        if let transactionId = registration.transaction?.id {
-            try await approveRegistrationTransaction(transactionId: transactionId, signer: signer)
+        if let transaction = registration.transaction {
+            try await approveRegistrationTransaction(transactionId: transaction.id, signer: signer)
         }
     }
 
@@ -60,9 +60,11 @@ final class SignerRegistrationService: Sendable {
         do {
             try await signer.initialize(smartWalletService)
             for approval in pending {
-                let signRequest = try await makeSignRequest(signer: signer, message: approval.message)
                 try await smartWalletService.approveSignature(
-                    .init(transactionId: signatureId, apiRequest: signRequest, chainType: chainType)
+                    signatureId: signatureId,
+                    chainType: chainType,
+                    signer: signer,
+                    message: approval.message
                 )
             }
         } catch {
@@ -75,30 +77,19 @@ final class SignerRegistrationService: Sendable {
         signer: any Signer
     ) async throws(WalletError) {
         do {
-            let transactionModel = try await smartWalletService.fetchTransaction(
-                .init(transactionId: transactionId, chainType: chainType)
-            )
-            guard let transaction = transactionModel.toDomain(withService: smartWalletService) else {
-                throw TransactionError.transactionGeneric("Failed to decode signer registration transaction")
-            }
+            let transaction = try await smartWalletService.transaction(withId: transactionId, chainType: chainType)
             guard let pending = transaction.approvals?.pending, !pending.isEmpty else { return }
             try await signer.initialize(smartWalletService)
             for approval in pending {
-                let signRequest = try await makeSignRequest(signer: signer, message: approval.message)
-                _ = try await smartWalletService.signTransaction(
-                    .init(transactionId: transactionId, apiRequest: signRequest, chainType: chainType)
+                try await smartWalletService.signTransaction(
+                    transactionId: transactionId,
+                    chainType: chainType,
+                    signer: signer,
+                    message: approval.message
                 )
             }
         } catch {
             throw WalletError.walletGeneric("Failed to approve signer registration: \(error)")
         }
-    }
-
-    private func makeSignRequest(signer: any Signer, message: String) async throws(SignerError) -> SignRequestApi {
-        SignRequestApi(
-            approvals: try await signer.approvals(
-                withSignature: try await signer.sign(message: message)
-            )
-        )
     }
 }

--- a/Sources/Wallet/Model/Wallet/SignerRegistrationService.swift
+++ b/Sources/Wallet/Model/Wallet/SignerRegistrationService.swift
@@ -39,12 +39,26 @@ final class SignerRegistrationService: Sendable {
     }
 
     func approveIfNeeded(registration: AddDelegatedSignerResponse, signer: any Signer) async throws(WalletError) {
-        guard let chainEntry = registration.chains?[chainName],
-              chainEntry.status == "awaiting-approval",
-              let signatureId = chainEntry.id,
-              let pending = chainEntry.approvals?.pending, !pending.isEmpty
-        else { return }
+        if let chainEntry = registration.chains?[chainName],
+           chainEntry.status == "awaiting-approval",
+           let signatureId = chainEntry.id,
+           let pending = chainEntry.approvals?.pending, !pending.isEmpty {
+            try await approveSignatureRegistration(signatureId: signatureId, pending: pending, signer: signer)
+            return
+        }
 
+        // Solana and Stellar registrations carry a pending transaction instead of
+        // per-chain entries; its approvals must be fetched and signed to finish.
+        if let transactionId = registration.transaction?.id {
+            try await approveRegistrationTransaction(transactionId: transactionId, signer: signer)
+        }
+    }
+
+    private func approveSignatureRegistration(
+        signatureId: String,
+        pending: [ApprovalEntry],
+        signer: any Signer
+    ) async throws(WalletError) {
         do {
             try await signer.initialize(smartWalletService)
             for approval in pending {
@@ -55,6 +69,34 @@ final class SignerRegistrationService: Sendable {
                 )
                 try await smartWalletService.approveSignature(
                     .init(transactionId: signatureId, apiRequest: signRequest, chainType: chainType)
+                )
+            }
+        } catch {
+            throw WalletError.walletGeneric("Failed to approve signer registration: \(error)")
+        }
+    }
+
+    private func approveRegistrationTransaction(
+        transactionId: String,
+        signer: any Signer
+    ) async throws(WalletError) {
+        do {
+            let transactionModel = try await smartWalletService.fetchTransaction(
+                .init(transactionId: transactionId, chainType: chainType)
+            )
+            guard let transaction = transactionModel.toDomain(withService: smartWalletService) else {
+                throw TransactionError.transactionGeneric("Failed to decode signer registration transaction")
+            }
+            guard let pending = transaction.approvals?.pending, !pending.isEmpty else { return }
+            try await signer.initialize(smartWalletService)
+            for approval in pending {
+                let signRequest = SignRequestApi(
+                    approvals: try await signer.approvals(
+                        withSignature: try await signer.sign(message: approval.message)
+                    )
+                )
+                _ = try await smartWalletService.signTransaction(
+                    .init(transactionId: transactionId, apiRequest: signRequest, chainType: chainType)
                 )
             }
         } catch {

--- a/Sources/Wallet/Model/Wallet/SignerRegistrationService.swift
+++ b/Sources/Wallet/Model/Wallet/SignerRegistrationService.swift
@@ -47,8 +47,6 @@ final class SignerRegistrationService: Sendable {
             return
         }
 
-        // Solana and Stellar registrations carry a pending transaction instead of
-        // per-chain entries; its approvals must be fetched and signed to finish.
         if let transactionId = registration.transaction?.id {
             try await approveRegistrationTransaction(transactionId: transactionId, signer: signer)
         }

--- a/Sources/Wallet/Model/Wallet/SignerRegistrationService.swift
+++ b/Sources/Wallet/Model/Wallet/SignerRegistrationService.swift
@@ -62,11 +62,7 @@ final class SignerRegistrationService: Sendable {
         do {
             try await signer.initialize(smartWalletService)
             for approval in pending {
-                let signRequest = SignRequestApi(
-                    approvals: try await signer.approvals(
-                        withSignature: try await signer.sign(message: approval.message)
-                    )
-                )
+                let signRequest = try await makeSignRequest(signer: signer, message: approval.message)
                 try await smartWalletService.approveSignature(
                     .init(transactionId: signatureId, apiRequest: signRequest, chainType: chainType)
                 )
@@ -90,11 +86,7 @@ final class SignerRegistrationService: Sendable {
             guard let pending = transaction.approvals?.pending, !pending.isEmpty else { return }
             try await signer.initialize(smartWalletService)
             for approval in pending {
-                let signRequest = SignRequestApi(
-                    approvals: try await signer.approvals(
-                        withSignature: try await signer.sign(message: approval.message)
-                    )
-                )
+                let signRequest = try await makeSignRequest(signer: signer, message: approval.message)
                 _ = try await smartWalletService.signTransaction(
                     .init(transactionId: transactionId, apiRequest: signRequest, chainType: chainType)
                 )
@@ -102,5 +94,13 @@ final class SignerRegistrationService: Sendable {
         } catch {
             throw WalletError.walletGeneric("Failed to approve signer registration: \(error)")
         }
+    }
+
+    private func makeSignRequest(signer: any Signer, message: String) async throws(SignerError) -> SignRequestApi {
+        SignRequestApi(
+            approvals: try await signer.approvals(
+                withSignature: try await signer.sign(message: message)
+            )
+        )
     }
 }

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -64,8 +64,6 @@ extension Wallet {
         Logger.smartWallet.info(LogEvents.walletRecoverStart)
         await signerInitializationTask?.value
         if _deviceSignerUnsupported {
-            // The provider already rejected device signers for this wallet — there is
-            // nothing to recover; signing stays on the recovery signer.
             Logger.smartWallet.info(LogEvents.walletRecoverSkipped)
             _needsRecovery = false
             return
@@ -96,8 +94,6 @@ extension Wallet {
         }
     }
 
-    // Provider support is only known server-side, so the rejection is remembered to stop
-    // further registration attempts and the unusable local key is wiped.
     private func fallBackToRecoverySigner(storage: any DeviceSignerKeyStorage) async {
         Logger.smartWallet.info(LogEvents.walletRecoverDeviceSignerUnsupported)
         try? await storage.deleteKey(address: address)

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -55,10 +55,21 @@ extension Wallet {
     /// registered but the private key is missing on the current device. This generates a new key,
     /// registers it with Crossmint, and awaits approval from the existing admin signer.
     ///
+    /// If the wallet's provider does not support device signers (e.g. a Squads-backed Solana
+    /// wallet), this returns without error and signing stays on the recovery signer; the
+    /// rejection is remembered so registration is not retried for this wallet instance.
+    ///
     /// - Throws: ``WalletError`` if recovery fails or there is no device signer configured.
     public func recover() async throws(WalletError) {
         Logger.smartWallet.info(LogEvents.walletRecoverStart)
         await signerInitializationTask?.value
+        if _deviceSignerUnsupported {
+            // The provider already rejected device signers for this wallet — there is
+            // nothing to recover; signing stays on the recovery signer.
+            Logger.smartWallet.info(LogEvents.walletRecoverSkipped)
+            _needsRecovery = false
+            return
+        }
         guard _needsRecovery else {
             Logger.smartWallet.info(LogEvents.walletRecoverSkipped)
             return
@@ -76,9 +87,22 @@ extension Wallet {
             try await registerDeviceSigner(storage: storage)
             Logger.smartWallet.info(LogEvents.walletRecoverSuccess)
         } catch {
+            if case .deviceSignerNotSupported = error {
+                await fallBackToRecoverySigner(storage: storage)
+                return
+            }
             Logger.smartWallet.error(LogEvents.walletRecoverError, attributes: ["error": "\(error)"])
             throw error
         }
+    }
+
+    // Provider support is only known server-side, so the rejection is remembered to stop
+    // further registration attempts and the unusable local key is wiped.
+    private func fallBackToRecoverySigner(storage: any DeviceSignerKeyStorage) async {
+        Logger.smartWallet.info(LogEvents.walletRecoverDeviceSignerUnsupported)
+        try? await storage.deleteKey(address: address)
+        _deviceSignerUnsupported = true
+        _needsRecovery = false
     }
 
     /// Sets the active signer used for subsequent wallet operations.
@@ -88,7 +112,9 @@ extension Wallet {
     /// wallet — use ``addSigner(_:)`` to register a new one first.
     ///
     /// - Parameter config: The signer to activate.
-    /// - Throws: ``WalletError/signerNotRegistered(_:)`` if the signer is not registered on this wallet.
+    /// - Throws: ``WalletError/signerNotRegistered(_:)`` if the signer is not registered on this wallet,
+    ///   or ``WalletError/deviceSignerNotSupported(_:)`` when selecting `.device` on a wallet whose
+    ///   provider rejected device signers.
     public func useSigner(_ config: SignerConfig) async throws(WalletError) {
         switch config {
         case .device:
@@ -168,6 +194,11 @@ extension Wallet {
     // MARK: - Private helpers
 
     private func activateDeviceSigner() async throws(WalletError) {
+        if _deviceSignerUnsupported {
+            throw .deviceSignerNotSupported(
+                "This wallet's provider does not support device signers. Use the recovery signer or another registered signer instead."
+            )
+        }
         let storage = deviceSignerKeyStorage ?? makeDeviceSignerStorage()
         guard await storage.getKey(address: address) != nil else {
             throw .walletGeneric("No device key found for this wallet on this device. Call recover() first.")

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -45,6 +45,10 @@ extension Wallet {
             guard let walletError = error as? WalletError else {
                 throw WalletError.walletGeneric(error.localizedDescription)
             }
+            if case .deviceSignerNotSupported = walletError {
+                _deviceSignerUnsupported = true
+                _needsRecovery = false
+            }
             throw walletError
         }
     }

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -55,9 +55,9 @@ extension Wallet {
     /// registered but the private key is missing on the current device. This generates a new key,
     /// registers it with Crossmint, and awaits approval from the existing admin signer.
     ///
-    /// If the wallet's provider does not support device signers (e.g. a Squads-backed Solana
-    /// wallet), this returns without error and signing stays on the recovery signer; the
-    /// rejection is remembered so registration is not retried for this wallet instance.
+    /// If the wallet's provider does not support device signers, this returns without error
+    /// and signing stays on the recovery signer; the rejection is remembered so registration
+    /// is not retried for this wallet instance.
     ///
     /// - Throws: ``WalletError`` if recovery fails or there is no device signer configured.
     public func recover() async throws(WalletError) {

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -27,6 +27,7 @@ extension Wallet {
     /// - Throws: ``WalletError`` if registration fails.
     public func addSigner(_ config: SignerConfig) async throws(WalletError) {
         Logger.smartWallet.info(LogEvents.walletAddSignerStart)
+        await signerInitializationTask?.value
         do {
             switch config {
             case .device:

--- a/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
@@ -250,8 +250,19 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
             throw .transactionGeneric(error.message)
         }
         onTransactionStart?()
-        if let storage = deviceSignerKeyStorage {
-            await deviceSignerService.ensureRegistered(storage: storage, signer: await updateSignerIfRequired())
+        if let storage = deviceSignerKeyStorage, !_deviceSignerUnsupported {
+            do {
+                try await deviceSignerService.ensureRegistered(
+                    storage: storage,
+                    signer: await updateSignerIfRequired()
+                )
+            } catch {
+                if case .deviceSignerNotSupported = error {
+                    // The provider rejected the device signer; remember it and let the
+                    // transfer continue on the recovery signer.
+                    _deviceSignerUnsupported = true
+                }
+            }
         }
         let signerLocator: String?
         if let active = selectedSignerLocator {

--- a/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
@@ -258,8 +258,6 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
                 )
             } catch {
                 if case .deviceSignerNotSupported = error {
-                    // The provider rejected the device signer; remember it and let the
-                    // transfer continue on the recovery signer.
                     _deviceSignerUnsupported = true
                 }
             }

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -28,6 +28,9 @@ open class Wallet: @unchecked Sendable {
     var selectedSignerLocator: String?
     var _needsRecovery: Bool = false
     var _deviceSignerApproved: Bool = false
+    // Set when the backend rejects device-signer registration with DEVICE_SIGNER_NOT_SUPPORTED
+    // (e.g. Squads on Solana) so registration isn't retried; signing stays on the recovery signer.
+    var _deviceSignerUnsupported: Bool = false
     var initialDelegatedSigners: [WalletDelegatedSignerConfigApiModel] = []
     var signerInitializationTask: Task<Void, Never>?
 

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -28,8 +28,6 @@ open class Wallet: @unchecked Sendable {
     var selectedSignerLocator: String?
     var _needsRecovery: Bool = false
     var _deviceSignerApproved: Bool = false
-    // Set when the backend rejects device-signer registration with DEVICE_SIGNER_NOT_SUPPORTED
-    // (e.g. Squads on Solana) so registration isn't retried; signing stays on the recovery signer.
     var _deviceSignerUnsupported: Bool = false
     var initialDelegatedSigners: [WalletDelegatedSignerConfigApiModel] = []
     var signerInitializationTask: Task<Void, Never>?

--- a/Sources/Wallet/Model/Wallet/WalletError.swift
+++ b/Sources/Wallet/Model/Wallet/WalletError.swift
@@ -16,6 +16,11 @@ public enum WalletError: CrossmintError {
     case invalidChain(chain: Chain)
     case invalidToken(token: CryptoCurrency)
     case signerNotRegistered(String)
+    /// The wallet's underlying provider does not support device signers
+    /// (e.g. a Squads-backed Solana wallet). Surfaced from the backend's
+    /// stable `DEVICE_SIGNER_NOT_SUPPORTED` error code; ``Wallet/recover()``
+    /// catches it and falls back to the recovery signer.
+    case deviceSignerNotSupported(String)
 
     public var code: String {
         switch self {
@@ -32,6 +37,7 @@ public enum WalletError: CrossmintError {
         case .invalidChain: "INVALID_CHAIN"
         case .invalidToken: "INVALID_TOKEN"
         case .signerNotRegistered: "SIGNER_NOT_REGISTERED"
+        case .deviceSignerNotSupported: "DEVICE_SIGNER_NOT_SUPPORTED"
         }
     }
 
@@ -59,6 +65,8 @@ public enum WalletError: CrossmintError {
             "Invalid token: \(token.name)"
         case .signerNotRegistered(let locator):
             "Signer \"\(locator)\" is not registered on this wallet. Call addSigner first."
+        case .deviceSignerNotSupported(let message):
+            message
         }
     }
 
@@ -74,6 +82,8 @@ public enum WalletError: CrossmintError {
             "Check the list of supported chains for this environment."
         case .walletLocatorError:
             "Ensure the wallet locator is in the correct format."
+        case .deviceSignerNotSupported:
+            "Use the recovery signer or another registered signer for this wallet."
         default:
             nil
         }

--- a/Sources/Wallet/Model/Wallet/WalletError.swift
+++ b/Sources/Wallet/Model/Wallet/WalletError.swift
@@ -16,10 +16,10 @@ public enum WalletError: CrossmintError {
     case invalidChain(chain: Chain)
     case invalidToken(token: CryptoCurrency)
     case signerNotRegistered(String)
-    /// The wallet's underlying provider does not support device signers
-    /// (e.g. a Squads-backed Solana wallet). Surfaced from the backend's
-    /// stable `DEVICE_SIGNER_NOT_SUPPORTED` error code; ``Wallet/recover()``
-    /// catches it and falls back to the recovery signer.
+    /// The wallet's underlying provider does not support device signers,
+    /// surfaced from the backend's stable `DEVICE_SIGNER_NOT_SUPPORTED`
+    /// error code. ``Wallet/recover()`` catches it and falls back to the
+    /// recovery signer.
     case deviceSignerNotSupported(String)
 
     public var code: String {

--- a/Tests/WalletTests/Data/DefaultWalletServiceTests.swift
+++ b/Tests/WalletTests/Data/DefaultWalletServiceTests.swift
@@ -1,0 +1,99 @@
+import CrossmintService
+import Foundation
+import Testing
+
+@testable import Http
+@testable import Wallet
+
+@Suite("Signer Registration API Errors", .tags(.unit))
+struct DefaultWalletServiceTests {
+    private let entry = DelegatedSignerEntry(signer: "device:test-key")
+
+    private func makeService(httpClient: HTTPClient) throws -> DefaultWalletService {
+        let crossmintService = DefaultCrossmintService(
+            apiKey: try ApiKey(key: "ck_staging_test123"),
+            appIdentifier: "com.crossmint.tests",
+            httpClient: httpClient
+        )
+        return DefaultWalletService(crossmintService: crossmintService, jsonCoder: DefaultJSONCoder())
+    }
+
+    private func makeService(errorBody: Data) throws -> DefaultWalletService {
+        try makeService(
+            httpClient: HTTPClient(fetch: { _ throws(NetworkError) in
+                throw NetworkError.badRequest(errorBody)
+            })
+        )
+    }
+
+    @Test
+    func decodesChainsRegistrationResponse() async throws {
+        let body = Data(
+            """
+            {"chains": {"solana": {"id": "sig1", "status": "success"}}}
+            """.utf8
+        )
+        let service = try makeService(
+            httpClient: HTTPClient(fetch: { _ throws(NetworkError) in (body, URLResponse()) })
+        )
+
+        let response = try await service.addSigner(entry, chainType: .solana, chainName: "solana")
+
+        #expect(response.chains?["solana"]?.id == "sig1")
+    }
+
+    @Test
+    func decodesTransactionRegistrationResponse() async throws {
+        let body = Data(#"{"transaction": {"id": "tx-123", "status": "awaiting-approval"}}"#.utf8)
+        let service = try makeService(
+            httpClient: HTTPClient(fetch: { _ throws(NetworkError) in (body, URLResponse()) })
+        )
+
+        let response = try await service.addSigner(entry, chainType: .solana, chainName: "solana")
+
+        #expect(response.transaction?.id == "tx-123")
+    }
+
+    @Test
+    func throwsTypedErrorForDeviceSignerNotSupportedCode() async throws {
+        let body = Data(
+            """
+            {"error": true, "message": "Device signers are not supported for this provider", "code": "DEVICE_SIGNER_NOT_SUPPORTED"}
+            """.utf8
+        )
+        let service = try makeService(errorBody: body)
+
+        await #expect {
+            _ = try await service.addSigner(entry, chainType: .solana, chainName: "solana")
+        } throws: { error in
+            guard case .deviceSignerNotSupported(let message) = error as? WalletError else { return false }
+            return message == "Device signers are not supported for this provider"
+        }
+    }
+
+    @Test
+    func usesFallbackMessageWhenErrorBodyOmitsMessage() async throws {
+        let body = Data(#"{"error": true, "code": "DEVICE_SIGNER_NOT_SUPPORTED"}"#.utf8)
+        let service = try makeService(errorBody: body)
+
+        await #expect {
+            _ = try await service.addSigner(entry, chainType: .solana, chainName: "solana")
+        } throws: { error in
+            guard case .deviceSignerNotSupported(let message) = error as? WalletError else { return false }
+            return message == "Device signers are not supported for this wallet's provider."
+        }
+    }
+
+    @Test
+    func keepsGenericErrorForOtherCodes() async throws {
+        let body = Data(#"{"error": true, "message": "boom", "code": "SOMETHING_ELSE"}"#.utf8)
+        let service = try makeService(errorBody: body)
+
+        await #expect {
+            _ = try await service.addSigner(entry, chainType: .solana, chainName: "solana")
+        } throws: { error in
+            if case .deviceSignerNotSupported = error as? WalletError { return false }
+            return true
+        }
+    }
+}

--- a/Tests/WalletTests/DefaultCrossmintWalletsTests.swift
+++ b/Tests/WalletTests/DefaultCrossmintWalletsTests.swift
@@ -1,0 +1,41 @@
+import CrossmintCommonTypes
+import Foundation
+import SecureStorage
+import Testing
+import TestsUtils
+
+@testable import Wallet
+
+@Suite("Wallet Creation", .tags(.unit))
+struct DefaultCrossmintWalletsTests {
+    private final class StubSecureWalletStorage: SecureWalletStorage, @unchecked Sendable {
+        func savePrivateKey(_ privateKey: String, forEmail email: String) {}
+        func getPrivateKey(forEmail email: String) -> String? { nil }
+    }
+
+    // Solana must not include a device signer in the create request: provider support is
+    // only known server-side, so registration defers to the first recover().
+    @Test
+    func skipsEagerDeviceSignerAttachForSolanaWallets() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.createWalletResult = try GetFromFile.getModelFrom(
+            fileName: "WalletSolanaEmail",
+            bundle: Bundle.module
+        )
+        let wallets = DefaultCrossmintWallets(
+            service: walletService,
+            secureWalletStorage: StubSecureWalletStorage()
+        )
+
+        let wallet = try await wallets.createWallet(
+            chain: Chain("solana"),
+            recovery: MockSigner(),
+            options: WalletOptions(deviceSigner: true)
+        )
+
+        #expect(walletService.lastCreateWalletParams?.config.delegatedSigners == nil)
+        // The storage must still reach the wallet so the deferred registration can run.
+        #expect(wallet.deviceSignerKeyStorage != nil)
+        #expect(await wallet.needsRecovery())
+    }
+}

--- a/Tests/WalletTests/DefaultCrossmintWalletsTests.swift
+++ b/Tests/WalletTests/DefaultCrossmintWalletsTests.swift
@@ -13,8 +13,6 @@ struct DefaultCrossmintWalletsTests {
         func getPrivateKey(forEmail email: String) -> String? { nil }
     }
 
-    // Solana must not include a device signer in the create request: provider support is
-    // only known server-side, so registration defers to the first recover().
     @Test
     func skipsEagerDeviceSignerAttachForSolanaWallets() async throws {
         let walletService = MockSmartWalletService()

--- a/Tests/WalletTests/Mocks/MockDeviceSignerKeyStorage.swift
+++ b/Tests/WalletTests/Mocks/MockDeviceSignerKeyStorage.swift
@@ -1,8 +1,6 @@
 import DeviceSigner
 import Foundation
 
-/// In-memory `DeviceSignerKeyStorage` that tracks deletions, so tests can assert
-/// key-wipe behavior without touching the Keychain.
 final class MockDeviceSignerKeyStorage: DeviceSignerKeyStorage, @unchecked Sendable {
     private(set) var keysByAddress: [String: String] = [:]
     private(set) var pendingKeys: Set<String> = []

--- a/Tests/WalletTests/Mocks/MockDeviceSignerKeyStorage.swift
+++ b/Tests/WalletTests/Mocks/MockDeviceSignerKeyStorage.swift
@@ -1,0 +1,55 @@
+import DeviceSigner
+import Foundation
+
+/// In-memory `DeviceSignerKeyStorage` that tracks deletions, so tests can assert
+/// key-wipe behavior without touching the Keychain.
+final class MockDeviceSignerKeyStorage: DeviceSignerKeyStorage, @unchecked Sendable {
+    private(set) var keysByAddress: [String: String] = [:]
+    private(set) var pendingKeys: Set<String> = []
+    private(set) var deleteKeyCallCount = 0
+    private(set) var deletePendingKeyCallCount = 0
+
+    func isAvailable() -> Bool { true }
+
+    func generateKey(address: String?) async throws(DeviceSignerError) -> String {
+        var rawKey = Data([0x04])
+        rawKey.append(Data((0..<64).map { UInt8($0) }))
+        let publicKeyBase64 = rawKey.base64EncodedString()
+        if let address {
+            keysByAddress[address] = publicKeyBase64
+        } else {
+            pendingKeys.insert(publicKeyBase64)
+        }
+        return publicKeyBase64
+    }
+
+    func mapAddressToKey(address: String, publicKeyBase64: String) async throws(DeviceSignerError) {
+        pendingKeys.remove(publicKeyBase64)
+        keysByAddress[address] = publicKeyBase64
+    }
+
+    func getKey(address: String) async -> String? {
+        keysByAddress[address]
+    }
+
+    func signMessage(
+        address: String,
+        message: String
+    ) async throws(DeviceSignerError) -> (r: String, s: String) {
+        ("0xr", "0xs")
+    }
+
+    func deleteKey(address: String) async throws(DeviceSignerError) {
+        deleteKeyCallCount += 1
+        keysByAddress[address] = nil
+    }
+
+    func deletePendingKey(publicKeyBase64: String) async throws(DeviceSignerError) {
+        deletePendingKeyCallCount += 1
+        pendingKeys.remove(publicKeyBase64)
+    }
+
+    func hasKey(publicKeyBase64: String) -> Bool {
+        pendingKeys.contains(publicKeyBase64) || keysByAddress.values.contains(publicKeyBase64)
+    }
+}

--- a/Tests/WalletTests/Mocks/MockSmartWalletService.swift
+++ b/Tests/WalletTests/Mocks/MockSmartWalletService.swift
@@ -7,7 +7,7 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
 
     // MARK: - addSigner
 
-    var addSignerResult: AddDelegatedSignerResponse = AddDelegatedSignerResponse(chains: nil)
+    var addSignerResult: AddDelegatedSignerResponse = AddDelegatedSignerResponse(chains: nil, transaction: nil)
     var addSignerError: WalletError?
     var addSignerCallCount = 0
     var lastAddSignerEntry: DelegatedSignerEntry?
@@ -27,7 +27,7 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
 
     // MARK: - registerTypedSigner
 
-    var registerTypedSignerResult: AddDelegatedSignerResponse = AddDelegatedSignerResponse(chains: nil)
+    var registerTypedSignerResult: AddDelegatedSignerResponse = AddDelegatedSignerResponse(chains: nil, transaction: nil)
 
     func registerTypedSigner(
         _ signer: any AdminSignerData,

--- a/Tests/WalletTests/Mocks/MockSmartWalletService.swift
+++ b/Tests/WalletTests/Mocks/MockSmartWalletService.swift
@@ -8,6 +8,7 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
     // MARK: - addSigner
 
     var addSignerResult: AddDelegatedSignerResponse = AddDelegatedSignerResponse(chains: nil)
+    var addSignerError: WalletError?
     var addSignerCallCount = 0
     var lastAddSignerEntry: DelegatedSignerEntry?
 
@@ -18,6 +19,9 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
     ) async throws(WalletError) -> AddDelegatedSignerResponse {
         addSignerCallCount += 1
         lastAddSignerEntry = entry
+        if let addSignerError {
+            throw addSignerError
+        }
         return addSignerResult
     }
 
@@ -43,13 +47,48 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
         lastApproveSignatureRequest = request
     }
 
+    // MARK: - createWallet
+
+    var createWalletResult: WalletApiModel?
+    var lastCreateWalletParams: CreateWalletParams?
+
+    func createWallet(_ request: CreateWalletParams) async throws(WalletError) -> WalletApiModel {
+        lastCreateWalletParams = request
+        guard let createWalletResult else {
+            throw WalletError.walletGeneric("not implemented")
+        }
+        return createWalletResult
+    }
+
+    // MARK: - fetchTransaction / signTransaction
+
+    var fetchTransactionResult: (any TransactionApiModel)?
+    var lastFetchTransactionRequest: FetchTransactionRequest?
+    var signTransactionCallCount = 0
+    var lastSignTransactionRequest: SignRequest?
+
+    func fetchTransaction(
+        _ fetchTransactionRequest: FetchTransactionRequest
+    ) async throws(TransactionError) -> any TransactionApiModel {
+        lastFetchTransactionRequest = fetchTransactionRequest
+        guard let fetchTransactionResult else {
+            throw TransactionError.transactionGeneric("not implemented")
+        }
+        return fetchTransactionResult
+    }
+
+    func signTransaction(_ request: SignRequest) async throws(TransactionError) -> any TransactionApiModel {
+        signTransactionCallCount += 1
+        lastSignTransactionRequest = request
+        guard let fetchTransactionResult else {
+            throw TransactionError.transactionGeneric("not implemented")
+        }
+        return fetchTransactionResult
+    }
+
     // MARK: - Unused stubs
 
     func getWallet(_ request: GetMeWalletRequest) async throws(WalletError) -> WalletApiModel {
-        throw WalletError.walletGeneric("not implemented")
-    }
-
-    func createWallet(_ request: CreateWalletParams) async throws(WalletError) -> WalletApiModel {
         throw WalletError.walletGeneric("not implemented")
     }
 
@@ -63,16 +102,6 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
 
     func createTransaction(
         _ request: CreateTransactionRequest
-    ) async throws(TransactionError) -> any TransactionApiModel {
-        throw TransactionError.transactionGeneric("not implemented")
-    }
-
-    func signTransaction(_ request: SignRequest) async throws(TransactionError) -> any TransactionApiModel {
-        throw TransactionError.transactionGeneric("not implemented")
-    }
-
-    func fetchTransaction(
-        _ fetchTransactionRequest: FetchTransactionRequest
     ) async throws(TransactionError) -> any TransactionApiModel {
         throw TransactionError.transactionGeneric("not implemented")
     }

--- a/Tests/WalletTests/Model/DeviceSignerServiceTests.swift
+++ b/Tests/WalletTests/Model/DeviceSignerServiceTests.swift
@@ -1,0 +1,59 @@
+import CrossmintCommonTypes
+import Foundation
+import Testing
+import TestsUtils
+
+@testable import Wallet
+
+@Suite("Device Signer Registration", .tags(.unit))
+struct DeviceSignerServiceTests {
+    private let walletAddress = "7ZN9rAofFVVP1WKqfKozsVWQYcDj2u9juYyRkrKUVR8Y"
+
+    private func makeSolanaService(walletService: MockSmartWalletService) -> DeviceSignerService {
+        DeviceSignerService(
+            smartWalletService: walletService,
+            chainType: .solana,
+            chainName: "solana",
+            address: walletAddress
+        )
+    }
+
+    @Test
+    func approvesTransactionShapedRegistrationAndMapsTheKey() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.addSignerResult = AddDelegatedSignerResponse(
+            chains: nil,
+            transaction: RegistrationTransaction(id: "registration-tx-1")
+        )
+        let registrationTransaction: SolanaTransactionApiModel = try GetFromFile.getModelFrom(
+            fileName: "SolanaSignerRegistrationAwaitingApproval",
+            bundle: Bundle.module
+        )
+        walletService.fetchTransactionResult = registrationTransaction
+        let storage = MockDeviceSignerKeyStorage()
+        let service = makeSolanaService(walletService: walletService)
+
+        try await service.register(storage: storage, signer: MockSigner())
+
+        #expect(walletService.signTransactionCallCount == 1)
+        #expect(walletService.lastSignTransactionRequest?.transactionId == "registration-tx-1")
+        #expect(await storage.getKey(address: walletAddress) != nil)
+    }
+
+    @Test
+    func wipesThePendingKeyWhenTheTransactionApprovalFails() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.addSignerResult = AddDelegatedSignerResponse(
+            chains: nil,
+            transaction: RegistrationTransaction(id: "registration-tx-1")
+        )
+        let storage = MockDeviceSignerKeyStorage()
+        let service = makeSolanaService(walletService: walletService)
+
+        await #expect(throws: WalletError.self) {
+            try await service.register(storage: storage, signer: MockSigner())
+        }
+        #expect(storage.deletePendingKeyCallCount == 1)
+        #expect(await storage.getKey(address: walletAddress) == nil)
+    }
+}

--- a/Tests/WalletTests/Model/SignerRegistrationServiceTests.swift
+++ b/Tests/WalletTests/Model/SignerRegistrationServiceTests.swift
@@ -35,7 +35,7 @@ struct SignerRegistrationServiceTests {
         let walletService = MockSmartWalletService()
         walletService.addSignerResult = AddDelegatedSignerResponse(chains: [
             chainName: ChainRegistrationEntry(id: "sig1", status: "success", approvals: nil)
-        ])
+        ], transaction: nil)
         let signer = MockSigner()
         let service = makeService(walletService: walletService)
 
@@ -56,7 +56,7 @@ struct SignerRegistrationServiceTests {
                     ApprovalEntry(signer: SignerApiModel(locator: "email:admin@example.com"), message: "0xdef")
                 ])
             )
-        ])
+        ], transaction: nil)
         let signer = MockSigner()
         let service = makeService(walletService: walletService)
 
@@ -74,7 +74,7 @@ struct SignerRegistrationServiceTests {
         let signer = MockSigner()
         let service = makeService(walletService: walletService)
 
-        let registration = AddDelegatedSignerResponse(chains: nil)
+        let registration = AddDelegatedSignerResponse(chains: nil, transaction: nil)
         try await service.approveIfNeeded(registration: registration, signer: signer)
 
         #expect(walletService.approveSignatureCallCount == 0)
@@ -94,7 +94,7 @@ struct SignerRegistrationServiceTests {
                     ApprovalEntry(signer: SignerApiModel(locator: "email:admin@example.com"), message: "0xabc")
                 ])
             )
-        ])
+        ], transaction: nil)
         try await service.approveIfNeeded(registration: registration, signer: signer)
 
         #expect(walletService.approveSignatureCallCount == 0)
@@ -108,7 +108,7 @@ struct SignerRegistrationServiceTests {
 
         let registration = AddDelegatedSignerResponse(chains: [
             chainName: ChainRegistrationEntry(id: "sig1", status: "success", approvals: nil)
-        ])
+        ], transaction: nil)
         try await service.approveIfNeeded(registration: registration, signer: signer)
 
         #expect(walletService.approveSignatureCallCount == 0)
@@ -126,7 +126,7 @@ struct SignerRegistrationServiceTests {
                 status: "awaiting-approval",
                 approvals: RegistrationApprovals(pending: [])
             )
-        ])
+        ], transaction: nil)
         try await service.approveIfNeeded(registration: registration, signer: signer)
 
         #expect(walletService.approveSignatureCallCount == 0)
@@ -146,7 +146,7 @@ struct SignerRegistrationServiceTests {
                     ApprovalEntry(signer: SignerApiModel(locator: "email:admin@example.com"), message: "0xabc")
                 ])
             )
-        ])
+        ], transaction: nil)
         try await service.approveIfNeeded(registration: registration, signer: signer)
 
         #expect(walletService.lastApproveSignatureRequest?.transactionId == "expected-sig-id")

--- a/Tests/WalletTests/Model/SignerRegistrationServiceTests.swift
+++ b/Tests/WalletTests/Model/SignerRegistrationServiceTests.swift
@@ -1,5 +1,7 @@
 import CrossmintCommonTypes
+import Foundation
 import Testing
+import TestsUtils
 @testable import Wallet
 
 struct SignerRegistrationServiceTests {
@@ -148,5 +150,70 @@ struct SignerRegistrationServiceTests {
         try await service.approveIfNeeded(registration: registration, signer: signer)
 
         #expect(walletService.lastApproveSignatureRequest?.transactionId == "expected-sig-id")
+    }
+
+}
+
+@Suite("Signer Registration Transaction Approval", .tags(.unit))
+struct SignerRegistrationTransactionApprovalTests {
+    private func makeSolanaService(walletService: MockSmartWalletService) -> SignerRegistrationService {
+        SignerRegistrationService(
+            smartWalletService: walletService,
+            chainType: .solana,
+            chainName: "solana"
+        )
+    }
+
+    @Test
+    func fetchesAndApprovesPendingApprovalsFromTheRegistrationTransaction() async throws {
+        let walletService = MockSmartWalletService()
+        let registrationTransaction: SolanaTransactionApiModel = try GetFromFile.getModelFrom(
+            fileName: "SolanaSignerRegistrationAwaitingApproval",
+            bundle: Bundle.module
+        )
+        walletService.fetchTransactionResult = registrationTransaction
+        let signer = MockSigner()
+        let service = makeSolanaService(walletService: walletService)
+
+        let registration = AddDelegatedSignerResponse(
+            chains: nil,
+            transaction: RegistrationTransaction(id: "registration-tx-1")
+        )
+        try await service.approveIfNeeded(registration: registration, signer: signer)
+
+        #expect(walletService.lastFetchTransactionRequest?.transactionId == "registration-tx-1")
+        #expect(walletService.signTransactionCallCount == 1)
+        #expect(walletService.lastSignTransactionRequest?.transactionId == "registration-tx-1")
+        #expect(signer.initializeCallCount == 1)
+        #expect(walletService.approveSignatureCallCount == 0)
+    }
+
+    @Test
+    func throwsWalletErrorWhenTheTransactionFetchFails() async throws {
+        let walletService = MockSmartWalletService()
+        let signer = MockSigner()
+        let service = makeSolanaService(walletService: walletService)
+
+        let registration = AddDelegatedSignerResponse(
+            chains: nil,
+            transaction: RegistrationTransaction(id: "registration-tx-1")
+        )
+
+        await #expect(throws: WalletError.self) {
+            try await service.approveIfNeeded(registration: registration, signer: signer)
+        }
+    }
+
+    @Test
+    func skipsApprovalWhenRegistrationHasNoChainsAndNoTransaction() async throws {
+        let walletService = MockSmartWalletService()
+        let signer = MockSigner()
+        let service = makeSolanaService(walletService: walletService)
+
+        let registration = AddDelegatedSignerResponse(chains: nil, transaction: nil)
+        try await service.approveIfNeeded(registration: registration, signer: signer)
+
+        #expect(walletService.signTransactionCallCount == 0)
+        #expect(walletService.approveSignatureCallCount == 0)
     }
 }

--- a/Tests/WalletTests/Model/WalletDeviceSignerRecoveryTests.swift
+++ b/Tests/WalletTests/Model/WalletDeviceSignerRecoveryTests.swift
@@ -91,6 +91,24 @@ struct WalletDeviceSignerRecoveryTests {
         }
 
         @Test
+        func remembersTheRejectionFromAnExplicitAddSigner() async throws {
+            let walletService = MockSmartWalletService()
+            let storage = MockDeviceSignerKeyStorage()
+            let wallet = try makeRejectedSolanaWallet(walletService: walletService, storage: storage)
+
+            await #expect {
+                try await wallet.addSigner(.device)
+            } throws: { error in
+                guard case .deviceSignerNotSupported = error as? WalletError else { return false }
+                return true
+            }
+
+            #expect(await wallet.needsRecovery() == false)
+            try await wallet.recover()
+            #expect(walletService.addSignerCallCount == 1)
+        }
+
+        @Test
         func throwsTypedErrorWhenSelectingTheDeviceSigner() async throws {
             let walletService = MockSmartWalletService()
             let storage = MockDeviceSignerKeyStorage()

--- a/Tests/WalletTests/Model/WalletDeviceSignerRecoveryTests.swift
+++ b/Tests/WalletTests/Model/WalletDeviceSignerRecoveryTests.swift
@@ -1,0 +1,109 @@
+import CrossmintCommonTypes
+import Foundation
+import Testing
+import TestsUtils
+
+@testable import Wallet
+
+private func makeSolanaWallet(
+    walletService: MockSmartWalletService,
+    storage: MockDeviceSignerKeyStorage
+) throws -> SolanaWallet {
+    let baseModel: WalletApiModel = try GetFromFile.getModelFrom(
+        fileName: "WalletSolanaEmail",
+        bundle: Bundle.module
+    )
+    return try SolanaWallet(
+        smartWalletService: walletService,
+        signer: MockSigner(),
+        baseModel: baseModel,
+        solanaChain: .solana,
+        onTransactionStart: nil,
+        deviceSignerKeyStorage: storage
+    )
+}
+
+@Suite("Wallet Device Signer Recovery", .tags(.unit))
+struct WalletDeviceSignerRecoveryTests {
+
+    @Test
+    func mapsKeyAndClearsRecoveryAfterSuccessfulRegistration() async throws {
+        let walletService = MockSmartWalletService()
+        let storage = MockDeviceSignerKeyStorage()
+        let wallet = try makeSolanaWallet(walletService: walletService, storage: storage)
+
+        try await wallet.recover()
+
+        #expect(await wallet.needsRecovery() == false)
+        #expect(await storage.getKey(address: wallet.address) != nil)
+    }
+
+    @Test
+    func rethrowsRegistrationErrorsOtherThanProviderRejection() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.addSignerError = .walletGeneric("registration exploded")
+        let storage = MockDeviceSignerKeyStorage()
+        let wallet = try makeSolanaWallet(walletService: walletService, storage: storage)
+
+        await #expect(throws: WalletError.self) {
+            try await wallet.recover()
+        }
+        #expect(await wallet.needsRecovery())
+    }
+
+    @Suite("when the provider rejects device signers", .tags(.unit))
+    struct ProviderRejectionTests {
+        private func makeRejectedSolanaWallet(
+            walletService: MockSmartWalletService,
+            storage: MockDeviceSignerKeyStorage
+        ) throws -> SolanaWallet {
+            walletService.addSignerError = .deviceSignerNotSupported("Device signers are not supported")
+            return try makeSolanaWallet(walletService: walletService, storage: storage)
+        }
+
+        @Test
+        func fallsBackToTheRecoverySignerWithoutThrowing() async throws {
+            let walletService = MockSmartWalletService()
+            let storage = MockDeviceSignerKeyStorage()
+            let wallet = try makeRejectedSolanaWallet(walletService: walletService, storage: storage)
+
+            #expect(await wallet.needsRecovery())
+
+            try await wallet.recover()
+
+            #expect(await wallet.needsRecovery() == false)
+            #expect(walletService.addSignerCallCount == 1)
+            #expect(storage.deletePendingKeyCallCount == 1)
+            #expect(storage.pendingKeys.isEmpty)
+            #expect(await storage.getKey(address: wallet.address) == nil)
+        }
+
+        @Test
+        func skipsRegistrationOnLaterRecoverCalls() async throws {
+            let walletService = MockSmartWalletService()
+            let storage = MockDeviceSignerKeyStorage()
+            let wallet = try makeRejectedSolanaWallet(walletService: walletService, storage: storage)
+
+            try await wallet.recover()
+            try await wallet.recover()
+
+            #expect(walletService.addSignerCallCount == 1)
+        }
+
+        @Test
+        func throwsTypedErrorWhenSelectingTheDeviceSigner() async throws {
+            let walletService = MockSmartWalletService()
+            let storage = MockDeviceSignerKeyStorage()
+            let wallet = try makeRejectedSolanaWallet(walletService: walletService, storage: storage)
+
+            try await wallet.recover()
+
+            await #expect {
+                try await wallet.useSigner(.device)
+            } throws: { error in
+                guard case .deviceSignerNotSupported = error as? WalletError else { return false }
+                return true
+            }
+        }
+    }
+}

--- a/Tests/WalletTests/Resources/Transaction/SolanaSignerRegistrationAwaitingApproval.json
+++ b/Tests/WalletTests/Resources/Transaction/SolanaSignerRegistrationAwaitingApproval.json
@@ -1,0 +1,35 @@
+{
+  "id": "registration-tx-1",
+  "chainType": "solana",
+  "walletType": "smart",
+  "status": "awaiting-approval",
+  "createdAt": "2026-06-10T10:00:00.000Z",
+  "params": {
+    "transaction": "AXGuKpKt4zxavCq2dHNexivchTXKoEQMBmqr6ipcF4QPfTXJRJcBLhsCgcLRjBsfV44G4atgoq9NWffk27AvpPf17SMGx1iUcy5jcjJoB6s3oK89gBDibnS1KX4qt4MxF6u3aNc5V3V7TiPNPgNDpg2MWH4fwmAp2qwhswdXjvQqwU6iPfT5sPrH5uGVCjBuVbfT9Qrm24u7yw5jCoMEqBtFp1CbZQYYaNQGJuXpo1Tkqnru2uFESE6KVRYQ4UproQPEuJcdnXh7DPd6GNcEdeCf997cC1ZYZYUcSy19usTvPpYmrFGiRacwPQ8GfNYZES6rxgQMRxaiNem5nuzVH9841e39wpzbCw4FkZ1LnrNM9A8QaR7JMVRsbXZFLJB",
+    "signer": {
+      "type": "email",
+      "locator": "email:admin@example.com"
+    },
+    "feeConfig": {
+      "feePayer": "crossmint",
+      "amount": "15001"
+    }
+  },
+  "onChain": {
+    "transaction": "ezQaZ2VQ3KixhCSkSoYB6hNNeQtHQe3hKMz7iDPUZjgeYgFug4ZKumULiuH9KSXCyYZH7wjm8v1gjhgoVuG4u2uL3sAv6CWkTt91UJEy4qJswoewHkL8teS4d85SfkZzzUx72nczVA1vPALp4n9KP5aLou6pKk2gqn7Rr6PmUXM9ui4zyU75jxCrfNnZxrgCLzEoQ1Z6tsJua3ZKtcEPDir6cHxvNtPGAoWRY3pV3GH4YTfoT2eEiVoME9Wv4G9zPBXzRu8Pzggb",
+    "lastValidBlockHeight": 351468290
+  },
+  "approvals": {
+    "required": 1,
+    "pending": [
+      {
+        "signer": {
+          "type": "email",
+          "locator": "email:admin@example.com"
+        },
+        "message": "registration-approval-message"
+      }
+    ],
+    "submitted": []
+  }
+}


### PR DESCRIPTION
Solana wallet creation included the device signer in the create-wallet request, but device-signer support on Solana depends on the wallet's provider and is only validated server-side. On providers that reject it the backend returns a 400 and the whole wallet creation fails.

Signer registration on Solana and Stellar also returns a pending transaction instead of the per-chain entries EVM returns under `chains`, which `approveIfNeeded` didn't handle. A device signer registered through that path would map its key locally but never get approved server-side.

## Changes

- `Wallet`: `createWalletApiModel` no longer attaches a device signer on Solana; the first `recover()` registers it instead, and a `DEVICE_SIGNER_NOT_SUPPORTED` rejection wipes the local key, keeps signing on the recovery signer, and stops retrying for that wallet instance
- `Wallet`: added `WalletError.deviceSignerNotSupported`, mapped from the backend's stable `DEVICE_SIGNER_NOT_SUPPORTED` code; new public enum case, so exhaustive switches over `WalletError` need a new case
- `Wallet`: `useSigner(.device)` throws `deviceSignerNotSupported` once the provider rejected device signers, and explicit `addSigner(.device)` surfaces the typed error instead of `walletGeneric`
- `Wallet`: `SignerRegistrationService` approves transaction-shaped registrations by fetching the transaction and signing its pending approvals; `AddDelegatedSignerResponse` gains the `transaction` field
- `Http`: added `NetworkError.serviceErrorCode`, exposing the body's stable `code` field the same way `serviceErrorMessage` exposes the message
- Added `WalletDeviceSignerRecoveryTests`, `DefaultWalletServiceTests`, `SignerRegistrationTransactionApprovalTests`, and a wallet-creation test covering the typed-error contract, the recover fallback, the transaction-shaped approval, and the Solana deferral
