### PR TITLE
Recover the signer web view when its content process is terminated

### DIFF
--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -126,6 +126,23 @@ public enum LogEvents {
     /// Missing email for authId
     public static let getAuthIdError = "signer.getAuthId.error"
 
+    // MARK: - Web Content Process Events
+
+    /// The web view's content process was terminated by the system
+    public static let webProcessTerminated = "signer.webProcess.terminated"
+
+    /// Starting recovery after a content process termination
+    public static let webProcessRecoveryStart = "signer.webProcess.recovery.start"
+
+    /// Recovery after a content process termination succeeded
+    public static let webProcessRecoverySuccess = "signer.webProcess.recovery.success"
+
+    /// Recovery after a content process termination failed
+    public static let webProcessRecoveryError = "signer.webProcess.recovery.error"
+
+    /// Gave up recovering after repeated content process terminations
+    public static let webProcessRecoveryGivenUp = "signer.webProcess.recovery.givenUp"
+
     // MARK: - Wallet Factory Events
 
     /// Getting wallet

--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -183,6 +183,9 @@ public final class CrossmintTEE: ObservableObject {
 
     public func resetState() {
         Logger.tee.debug(LogEvents.resetStateStart)
+        recoveryTask?.cancel()
+        recoveryTask = nil
+        isRecovering = false
         handshakeState = .idle
         processTerminationRecoveryAttempts = 0
         failAllQueuedRequests(with: .generic("State was reset"))
@@ -203,7 +206,7 @@ public final class CrossmintTEE: ObservableObject {
     }
 
     private func runWebContentProcessRecovery() async {
-        defer { isRecovering = false }
+        defer { if !Task.isCancelled { isRecovering = false } }
         Logger.tee.info(LogEvents.webProcessRecoveryStart)
 
         while processTerminationRecoveryAttempts < maxProcessTerminationRecoveryAttempts {
@@ -213,6 +216,7 @@ public final class CrossmintTEE: ObservableObject {
                 Logger.tee.info(LogEvents.webProcessRecoverySuccess)
                 return
             } catch {
+                if Task.isCancelled { return }
                 Logger.tee.error(LogEvents.webProcessRecoveryError, attributes: [
                     "recovery.attempt": "\(processTerminationRecoveryAttempts)",
                     "recovery.maxAttempts": "\(maxProcessTerminationRecoveryAttempts)",

--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -53,6 +53,10 @@ public final class CrossmintTEE: ObservableObject {
     private let apiKey: String
     public var email: String?
 
+    private var processTerminationRecoveryAttempts = 0
+    private let maxProcessTerminationRecoveryAttempts = 3
+    private var isRecovering = false
+
     private var otpContinuation: CheckedContinuation<String, Swift.Error>?
     @Published public var isOTPRequired = false
 
@@ -75,6 +79,12 @@ public final class CrossmintTEE: ObservableObject {
         // swiftlint:enable force_unwrapping
         self.auth = auth
         self.apiKey = apiKey
+
+        webProxy.onWebContentProcessTerminated = { [weak self] in
+            Task { @MainActor in
+                self?.recoverFromWebContentProcessTermination()
+            }
+        }
     }
 
     deinit {
@@ -175,9 +185,47 @@ public final class CrossmintTEE: ObservableObject {
     public func resetState() {
         Logger.tee.debug(LogEvents.resetStateStart)
         handshakeState = .idle
+        processTerminationRecoveryAttempts = 0
         failAllQueuedRequests(with: .generic("State was reset"))
         webProxy.resetLoadedContent()
         Logger.tee.debug(LogEvents.resetStateSuccess)
+    }
+
+    private func recoverFromWebContentProcessTermination() {
+        Logger.tee.warn(LogEvents.webProcessTerminated, attributes: [
+            "queue.size": "\(signRequestQueue.count)"
+        ])
+
+        guard !isRecovering else { return }
+        isRecovering = true
+        Task { [weak self] in
+            await self?.runWebContentProcessRecovery()
+        }
+    }
+
+    private func runWebContentProcessRecovery() async {
+        defer { isRecovering = false }
+        Logger.tee.info(LogEvents.webProcessRecoveryStart)
+
+        while processTerminationRecoveryAttempts < maxProcessTerminationRecoveryAttempts {
+            processTerminationRecoveryAttempts += 1
+            do {
+                try await establishSession()
+                Logger.tee.info(LogEvents.webProcessRecoverySuccess)
+                return
+            } catch {
+                Logger.tee.error(LogEvents.webProcessRecoveryError, attributes: [
+                    "recovery.attempt": "\(processTerminationRecoveryAttempts)",
+                    "recovery.maxAttempts": "\(maxProcessTerminationRecoveryAttempts)",
+                    "error": "\(error)"
+                ])
+            }
+        }
+
+        Logger.tee.error(LogEvents.webProcessRecoveryGivenUp)
+        let error = CrossmintTEE.Error.generic("Web content process repeatedly terminated")
+        handshakeState = .failed(error)
+        failAllQueuedRequests(with: error)
     }
 
     public func load() async throws(Error) {
@@ -203,31 +251,29 @@ public final class CrossmintTEE: ObservableObject {
             break
         }
 
-        handshakeState = .inProgress
-
         do {
-            do {
-                try await webProxy.loadURL(url)
-            } catch {
-                Logger.tee.error(LogEvents.loadError, attributes: [
-                    "error": "Failed to load TEE URL: \(error)"
-                ])
-                throw Error.urlNotAvailable
-            }
-
-            try await tryHandshake(maxAttempts: 3)
-            handshakeState = .completed
-            await processNextQueuedRequest()
-        } catch let teeError as CrossmintTEE.Error {
-            handshakeState = .failed(teeError)
-            failAllQueuedRequests(with: teeError)
-            throw teeError
+            try await establishSession()
         } catch {
-            let genericError = Error.generic("Handshake failed: \(error.localizedDescription)")
-            handshakeState = .failed(genericError)
-            failAllQueuedRequests(with: genericError)
-            throw genericError
+            handshakeState = .failed(error)
+            failAllQueuedRequests(with: error)
+            throw error
         }
+    }
+
+    private func establishSession() async throws(Error) {
+        handshakeState = .inProgress
+        do {
+            try await webProxy.loadURL(url)
+        } catch {
+            Logger.tee.error(LogEvents.loadError, attributes: [
+                "error": "Failed to load TEE URL: \(error)"
+            ])
+            throw Error.urlNotAvailable
+        }
+        try await tryHandshake(maxAttempts: 3)
+        handshakeState = .completed
+        processTerminationRecoveryAttempts = 0
+        await processNextQueuedRequest()
     }
 
     private func tryHandshake(maxAttempts: Int) async throws(Error) {

--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -56,6 +56,7 @@ public final class CrossmintTEE: ObservableObject {
     private var processTerminationRecoveryAttempts = 0
     private let maxProcessTerminationRecoveryAttempts = 3
     private var isRecovering = false
+    private(set) var recoveryTask: Task<Void, Never>?
 
     private var otpContinuation: CheckedContinuation<String, Swift.Error>?
     @Published public var isOTPRequired = false
@@ -81,9 +82,7 @@ public final class CrossmintTEE: ObservableObject {
         self.apiKey = apiKey
 
         webProxy.onWebContentProcessTerminated = { [weak self] in
-            Task { @MainActor in
-                self?.recoverFromWebContentProcessTermination()
-            }
+            self?.recoverFromWebContentProcessTermination()
         }
     }
 
@@ -198,7 +197,7 @@ public final class CrossmintTEE: ObservableObject {
 
         guard !isRecovering else { return }
         isRecovering = true
-        Task { [weak self] in
+        recoveryTask = Task { [weak self] in
             await self?.runWebContentProcessRecovery()
         }
     }

--- a/Sources/Web/WebViewCommunicationProxy.swift
+++ b/Sources/Web/WebViewCommunicationProxy.swift
@@ -8,6 +8,7 @@ public protocol WebViewCommunicationProxy: AnyObject, WKNavigationDelegate, WKSc
     var webView: WKWebView? { get set }
     var onWebViewMessage: (any WebViewMessage) -> Void { get set }
     var onUnknownMessage: (String, Data) -> Void { get set }
+    var onWebContentProcessTerminated: () -> Void { get set }
 
     func loadURL(_ url: URL) async throws
     func resetLoadedContent()
@@ -36,6 +37,7 @@ public class DefaultWebViewCommunicationProxy: NSObject, ObservableObject, WKScr
     public weak var webView: WKWebView?
     public var onWebViewMessage: (any WebViewMessage) -> Void = { _ in }
     public var onUnknownMessage: (String, Data) -> Void = { _, _ in }
+    public var onWebContentProcessTerminated: () -> Void = {}
 
     private var loadedContent: URL?
     private var isPageLoaded = false
@@ -250,6 +252,20 @@ extension DefaultWebViewCommunicationProxy: WKNavigationDelegate {
         // Resume any waiting navigation continuation with error
         navigationContinuation?.resume(throwing: WebViewError.navigationFailed(error))
         navigationContinuation = nil
+    }
+
+    public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        Logger.web.error("Web content process terminated; resetting state for recovery")
+        isPageLoaded = false
+        loadedContent = nil
+        Task { @MainActor in
+            messageHandler.reset()
+        }
+
+        navigationContinuation?.resume(throwing: WebViewError.webContentProcessTerminated)
+        navigationContinuation = nil
+
+        onWebContentProcessTerminated()
     }
 }
 

--- a/Sources/Web/WebViewCommunicationProxy.swift
+++ b/Sources/Web/WebViewCommunicationProxy.swift
@@ -8,7 +8,7 @@ public protocol WebViewCommunicationProxy: AnyObject, WKNavigationDelegate, WKSc
     var webView: WKWebView? { get set }
     var onWebViewMessage: (any WebViewMessage) -> Void { get set }
     var onUnknownMessage: (String, Data) -> Void { get set }
-    var onWebContentProcessTerminated: () -> Void { get set }
+    var onWebContentProcessTerminated: @MainActor () -> Void { get set }
 
     func loadURL(_ url: URL) async throws
     func resetLoadedContent()
@@ -37,7 +37,7 @@ public class DefaultWebViewCommunicationProxy: NSObject, ObservableObject, WKScr
     public weak var webView: WKWebView?
     public var onWebViewMessage: (any WebViewMessage) -> Void = { _ in }
     public var onUnknownMessage: (String, Data) -> Void = { _, _ in }
-    public var onWebContentProcessTerminated: () -> Void = {}
+    public var onWebContentProcessTerminated: @MainActor () -> Void = {}
 
     private var loadedContent: URL?
     private var isPageLoaded = false

--- a/Sources/Web/WebViewError.swift
+++ b/Sources/Web/WebViewError.swift
@@ -7,6 +7,7 @@ public enum WebViewError: Error, Equatable {
     case decodingError
     case navigationFailed(Error)
     case javascriptEvaluationError
+    case webContentProcessTerminated
 
     public static func == (lhs: WebViewError, rhs: WebViewError) -> Bool {
         switch (lhs, rhs) {
@@ -14,7 +15,8 @@ public enum WebViewError: Error, Equatable {
              (.timeout, .timeout),
              (.encodingError, .encodingError),
              (.decodingError, .decodingError),
-             (.javascriptEvaluationError, .javascriptEvaluationError):
+             (.javascriptEvaluationError, .javascriptEvaluationError),
+             (.webContentProcessTerminated, .webContentProcessTerminated):
             return true
         case (.navigationFailed(let lhsError), .navigationFailed(let rhsError)):
             return (lhsError as NSError) == (rhsError as NSError)

--- a/Tests/WebTests/CrossmintTEETests.swift
+++ b/Tests/WebTests/CrossmintTEETests.swift
@@ -420,6 +420,22 @@ struct CrossmintTEETests {
         #expect(signature == "0xrecovered")
     }
 
+    @Test("resetState cancels an in-flight recovery and frees it to start again")
+    func testResetStateCancelsInFlightRecovery() async throws {
+        let fixture = TestFixture()
+        await fixture.setupAuthentication()
+        try await fixture.setupHandshake(verificationId: "test123")
+
+        fixture.webProxy.onWebContentProcessTerminated()
+        #expect(fixture.tee.recoveryTask != nil)
+
+        fixture.tee.resetState()
+        #expect(fixture.tee.recoveryTask == nil)
+
+        fixture.webProxy.onWebContentProcessTerminated()
+        #expect(fixture.tee.recoveryTask != nil)
+    }
+
     @Test("Multiple identical requests process independently")
     func testMultipleIdenticalRequestsProcessIndependently() async throws {
         let fixture = TestFixture()

--- a/Tests/WebTests/CrossmintTEETests.swift
+++ b/Tests/WebTests/CrossmintTEETests.swift
@@ -402,10 +402,7 @@ struct CrossmintTEETests {
         #expect(fixture.webProxy.sentMessages(ofType: HandshakeRequest.self).count == 1)
 
         fixture.webProxy.onWebContentProcessTerminated()
-
-        for _ in 0..<200 where fixture.webProxy.sentMessages(ofType: HandshakeRequest.self).count < 2 {
-            try await Task.sleep(nanoseconds: 10_000_000)
-        }
+        await fixture.tee.recoveryTask?.value
 
         #expect(fixture.webProxy.loadedURLs.count == 2)
         #expect(fixture.webProxy.sentMessages(ofType: HandshakeRequest.self).count == 2)

--- a/Tests/WebTests/CrossmintTEETests.swift
+++ b/Tests/WebTests/CrossmintTEETests.swift
@@ -392,6 +392,37 @@ struct CrossmintTEETests {
         }
     }
 
+    @Test("Recovers and re-handshakes after web content process termination")
+    func testRecoversAfterWebContentProcessTermination() async throws {
+        let fixture = TestFixture()
+        await fixture.setupAuthentication()
+        try await fixture.setupHandshake(verificationId: "test123")
+
+        #expect(fixture.webProxy.loadedURLs.count == 1)
+        #expect(fixture.webProxy.sentMessages(ofType: HandshakeRequest.self).count == 1)
+
+        fixture.webProxy.onWebContentProcessTerminated()
+
+        for _ in 0..<200 where fixture.webProxy.sentMessages(ofType: HandshakeRequest.self).count < 2 {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(fixture.webProxy.loadedURLs.count == 2)
+        #expect(fixture.webProxy.sentMessages(ofType: HandshakeRequest.self).count == 2)
+
+        fixture.configureReadyDevice()
+        fixture.configureSignResponse(signature: "0xrecovered")
+
+        let transaction = CrossmintTEETestHelpers.createTestTransaction()
+        let signature = try await fixture.tee.signTransaction(
+            transaction: transaction,
+            keyType: "keyType",
+            encoding: "encoding"
+        )
+
+        #expect(signature == "0xrecovered")
+    }
+
     @Test("Multiple identical requests process independently")
     func testMultipleIdenticalRequestsProcessIndependently() async throws {
         let fixture = TestFixture()

--- a/Tests/WebTests/Mocks/MockWebViewCommunicationProxy.swift
+++ b/Tests/WebTests/Mocks/MockWebViewCommunicationProxy.swift
@@ -8,6 +8,7 @@ final class MockWebViewCommunicationProxy: NSObject, WebViewCommunicationProxy {
     public weak var webView: WKWebView?
     public var onWebViewMessage: (any WebViewMessage) -> Void = { _ in }
     public var onUnknownMessage: (String, Data) -> Void = { _, _ in }
+    public var onWebContentProcessTerminated: () -> Void = {}
 
     var loadedURLs: [URL] = []
     var sentMessages: [any WebViewMessage] = []

--- a/Tests/WebTests/Mocks/MockWebViewCommunicationProxy.swift
+++ b/Tests/WebTests/Mocks/MockWebViewCommunicationProxy.swift
@@ -8,7 +8,7 @@ final class MockWebViewCommunicationProxy: NSObject, WebViewCommunicationProxy {
     public weak var webView: WKWebView?
     public var onWebViewMessage: (any WebViewMessage) -> Void = { _ in }
     public var onUnknownMessage: (String, Data) -> Void = { _, _ in }
-    public var onWebContentProcessTerminated: () -> Void = {}
+    public var onWebContentProcessTerminated: @MainActor () -> Void = {}
 
     var loadedURLs: [URL] = []
     var sentMessages: [any WebViewMessage] = []


### PR DESCRIPTION
The non-custodial signer runs in a hidden `WKWebView`, and iOS can kill that web view's content process in the background to free memory. When it does, the signer silently stops working until the app is fully restarted.

WebKit reports this through the [`webViewWebContentProcessDidTerminate(_:)`](https://developer.apple.com/documentation/webkit/wknavigationdelegate/webviewwebcontentprocessdidterminate%28_%3A%29) delegate method, which we weren't handling. This PR implements it and recovers automatically by reloading the signer and running a fresh handshake.

## Changes
- Implement `webViewWebContentProcessDidTerminate` in `DefaultWebViewCommunicationProxy`. It clears the loaded state, fails any in-flight navigation, and notifies the owner through a new `onWebContentProcessTerminated` callback.
- Recover in `CrossmintTEE` when that callback fires. It drops the handshake back to `.idle`, reloads the signer, re-runs the handshake, and drains any queued sign requests.
- Cap recovery at three consecutive attempts without a successful handshake, reset on success, so a web view that keeps crashing on load fails fast instead of looping forever.
- Add a `WebViewError.webContentProcessTerminated` case and structured `signer.webProcess.*` log events covering the termination and recovery flow.
- Add a `CrossmintTEE` test that simulates a termination and verifies the signer re-handshakes and can sign again.

Confirmed on a simulator by killing the web content process while the app was backgrounded ([script here](https://gist.github.com/jasonbekolay/dad7c446ae1b02f174dc3eb3a5ea70ee)): on `main` the signer stays broken and `get-status` times out repeatedly, on this branch it re-handshakes in a few seconds and recovers.
