### PR TITLE
Re-onboard the signer per signature with ephemeral webview storage

### DIFF
--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -2,7 +2,6 @@
 import CrossmintAuth
 import Combine
 import Logger
-import WebKit
 
 extension Logger {
     static let tee = Logger(category: "TEE")
@@ -47,11 +46,7 @@ public final class CrossmintTEE: ObservableObject {
 
     public let webProxy: WebViewCommunicationProxy
 
-    // Non-persistent (in-memory) data store for the signer web view. iOS doesn't
-    // guarantee cross-launch persistence for this embedded, non-interactive WKWebView,
-    // so rather than relying on it we re-run OTP onboarding once per cold start. Held as
-    // one reused instance so the credential survives view re-creation within a session.
-    let signerDataStore: WKWebsiteDataStore = .nonPersistent()
+    let signerStorage = SignerWebStorage()
 
     private let url: URL
     private var handshakeState: HandshakeState = .idle
@@ -62,6 +57,8 @@ public final class CrossmintTEE: ObservableObject {
 
     private var otpContinuation: CheckedContinuation<String, Swift.Error>?
     @Published public var isOTPRequired = false
+
+    private static let ephemeralDeviceStorageQuery = "deviceStorage=memory"
 
     init(
         auth: AuthManager,
@@ -78,11 +75,8 @@ public final class CrossmintTEE: ObservableObject {
         let signerBaseURL = isProductionEnvironment
             ? "https://signers.crossmint.com"
             : "https://staging.signers.crossmint.com"
-        // deviceStorage=memory tells the signer to treat each frame load as a fresh
-        // device. Paired with the per-signature reset below, that means a fresh OTP
-        // onboarding on every signature.
         // swiftlint:disable:next force_unwrapping
-        self.url = URL(string: "\(signerBaseURL)?deviceStorage=memory")!
+        self.url = URL(string: "\(signerBaseURL)?\(Self.ephemeralDeviceStorageQuery)")!
         self.auth = auth
         self.apiKey = apiKey
     }
@@ -98,9 +92,8 @@ public final class CrossmintTEE: ObservableObject {
         keyType: String,
         encoding: String
     ) async throws(Error) -> String {
-        // Force an OTP on every signature: reset the session and reload so the signer
-        // comes up as a brand-new device and re-runs the OTP onboarding.
-        await clearSignerStorageForReonboarding()
+        // Re-onboard on every signature.
+        await signerStorage.clear()
         resetState()
 
         if case .completed = handshakeState {
@@ -193,16 +186,6 @@ public final class CrossmintTEE: ObservableObject {
         failAllQueuedRequests(with: .generic("State was reset"))
         webProxy.resetLoadedContent()
         Logger.tee.debug(LogEvents.resetStateSuccess)
-    }
-
-    /// Clears all signer web storage so the next handshake comes up as a brand-new
-    /// device. Used to force the OTP onboarding to run again on every signature.
-    private func clearSignerStorageForReonboarding() async {
-        Logger.tee.debug("Clearing signer web storage to force re-onboarding for this signature")
-        await signerDataStore.removeData(
-            ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
-            modifiedSince: .distantPast
-        )
     }
 
     public func load() async throws(Error) {

--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -75,11 +75,14 @@ public final class CrossmintTEE: ObservableObject {
         }
 
         self.webProxy = webProxy
-        // swiftlint:disable force_unwrapping
-        self.url = isProductionEnvironment
-            ? URL(string: "https://signers.crossmint.com")!
-            : URL(string: "https://staging.signers.crossmint.com")!
-        // swiftlint:enable force_unwrapping
+        let signerBaseURL = isProductionEnvironment
+            ? "https://signers.crossmint.com"
+            : "https://staging.signers.crossmint.com"
+        // deviceStorage=memory tells the signer to treat each frame load as a fresh
+        // device. Paired with the per-signature reset below, that means a fresh OTP
+        // onboarding on every signature.
+        // swiftlint:disable:next force_unwrapping
+        self.url = URL(string: "\(signerBaseURL)?deviceStorage=memory")!
         self.auth = auth
         self.apiKey = apiKey
     }
@@ -95,9 +98,8 @@ public final class CrossmintTEE: ObservableObject {
         keyType: String,
         encoding: String
     ) async throws(Error) -> String {
-        // Force an OTP on every signature: wipe the signer's in-memory storage (the
-        // frame's device identity key lives in IndexedDB) and reset the session, so the
-        // web app reloads as a brand-new device and re-runs the OTP onboarding.
+        // Force an OTP on every signature: reset the session and reload so the signer
+        // comes up as a brand-new device and re-runs the OTP onboarding.
         await clearSignerStorageForReonboarding()
         resetState()
 
@@ -193,9 +195,8 @@ public final class CrossmintTEE: ObservableObject {
         Logger.tee.debug(LogEvents.resetStateSuccess)
     }
 
-    /// Clears all signer web storage (including the frame's device identity key in
-    /// IndexedDB) so the next handshake comes up as a brand-new device. Used to force
-    /// the OTP onboarding to run again on every signature.
+    /// Clears all signer web storage so the next handshake comes up as a brand-new
+    /// device. Used to force the OTP onboarding to run again on every signature.
     private func clearSignerStorageForReonboarding() async {
         Logger.tee.debug("Clearing signer web storage to force re-onboarding for this signature")
         await signerDataStore.removeData(

--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -95,6 +95,12 @@ public final class CrossmintTEE: ObservableObject {
         keyType: String,
         encoding: String
     ) async throws(Error) -> String {
+        // Force an OTP on every signature: wipe the signer's in-memory storage (the
+        // frame's device identity key lives in IndexedDB) and reset the session, so the
+        // web app reloads as a brand-new device and re-runs the OTP onboarding.
+        await clearSignerStorageForReonboarding()
+        resetState()
+
         if case .completed = handshakeState {
             return try await executeSignTransaction(
                 transaction: transaction,
@@ -185,6 +191,17 @@ public final class CrossmintTEE: ObservableObject {
         failAllQueuedRequests(with: .generic("State was reset"))
         webProxy.resetLoadedContent()
         Logger.tee.debug(LogEvents.resetStateSuccess)
+    }
+
+    /// Clears all signer web storage (including the frame's device identity key in
+    /// IndexedDB) so the next handshake comes up as a brand-new device. Used to force
+    /// the OTP onboarding to run again on every signature.
+    private func clearSignerStorageForReonboarding() async {
+        Logger.tee.debug("Clearing signer web storage to force re-onboarding for this signature")
+        await signerDataStore.removeData(
+            ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
+            modifiedSince: .distantPast
+        )
     }
 
     public func load() async throws(Error) {

--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -2,6 +2,7 @@
 import CrossmintAuth
 import Combine
 import Logger
+import WebKit
 
 extension Logger {
     static let tee = Logger(category: "TEE")
@@ -46,7 +47,9 @@ public final class CrossmintTEE: ObservableObject {
 
     public let webProxy: WebViewCommunicationProxy
 
-    let signerStorage = SignerWebStorage()
+    private let signerStorage = SignerWebStorage()
+
+    var signerWebsiteDataStore: WKWebsiteDataStore { signerStorage.dataStore }
 
     private let url: URL
     private var handshakeState: HandshakeState = .idle
@@ -58,7 +61,7 @@ public final class CrossmintTEE: ObservableObject {
     private var otpContinuation: CheckedContinuation<String, Swift.Error>?
     @Published public var isOTPRequired = false
 
-    private let usesEphemeralDeviceStorage = true
+    private static let ephemeralDeviceStorageQuery = "deviceStorage=memory"
 
     init(
         auth: AuthManager,
@@ -75,11 +78,8 @@ public final class CrossmintTEE: ObservableObject {
         let signerBaseURL = isProductionEnvironment
             ? "https://signers.crossmint.com"
             : "https://staging.signers.crossmint.com"
-        let signerURL = usesEphemeralDeviceStorage
-            ? "\(signerBaseURL)?deviceStorage=memory"
-            : signerBaseURL
         // swiftlint:disable:next force_unwrapping
-        self.url = URL(string: signerURL)!
+        self.url = URL(string: "\(signerBaseURL)?\(Self.ephemeralDeviceStorageQuery)")!
         self.auth = auth
         self.apiKey = apiKey
     }
@@ -95,11 +95,9 @@ public final class CrossmintTEE: ObservableObject {
         keyType: String,
         encoding: String
     ) async throws(Error) -> String {
-        if usesEphemeralDeviceStorage {
-            // Re-onboard on every signature.
-            await signerStorage.clear()
-            resetState()
-        }
+        // Re-onboard on every signature.
+        await signerStorage.clear()
+        resetState()
 
         if case .completed = handshakeState {
             return try await executeSignTransaction(

--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -2,6 +2,7 @@
 import CrossmintAuth
 import Combine
 import Logger
+import WebKit
 
 extension Logger {
     static let tee = Logger(category: "TEE")
@@ -45,6 +46,12 @@ public final class CrossmintTEE: ObservableObject {
     }
 
     public let webProxy: WebViewCommunicationProxy
+
+    // Non-persistent (in-memory) data store for the signer web view. iOS doesn't
+    // guarantee cross-launch persistence for this embedded, non-interactive WKWebView,
+    // so rather than relying on it we re-run OTP onboarding once per cold start. Held as
+    // one reused instance so the credential survives view re-creation within a session.
+    let signerDataStore: WKWebsiteDataStore = .nonPersistent()
 
     private let url: URL
     private var handshakeState: HandshakeState = .idle

--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -58,7 +58,7 @@ public final class CrossmintTEE: ObservableObject {
     private var otpContinuation: CheckedContinuation<String, Swift.Error>?
     @Published public var isOTPRequired = false
 
-    private static let ephemeralDeviceStorageQuery = "deviceStorage=memory"
+    private let usesEphemeralDeviceStorage = true
 
     init(
         auth: AuthManager,
@@ -75,8 +75,11 @@ public final class CrossmintTEE: ObservableObject {
         let signerBaseURL = isProductionEnvironment
             ? "https://signers.crossmint.com"
             : "https://staging.signers.crossmint.com"
+        let signerURL = usesEphemeralDeviceStorage
+            ? "\(signerBaseURL)?deviceStorage=memory"
+            : signerBaseURL
         // swiftlint:disable:next force_unwrapping
-        self.url = URL(string: "\(signerBaseURL)?\(Self.ephemeralDeviceStorageQuery)")!
+        self.url = URL(string: signerURL)!
         self.auth = auth
         self.apiKey = apiKey
     }
@@ -92,9 +95,11 @@ public final class CrossmintTEE: ObservableObject {
         keyType: String,
         encoding: String
     ) async throws(Error) -> String {
-        // Re-onboard on every signature.
-        await signerStorage.clear()
-        resetState()
+        if usesEphemeralDeviceStorage {
+            // Re-onboard on every signature.
+            await signerStorage.clear()
+            resetState()
+        }
 
         if case .completed = handshakeState {
             return try await executeSignTransaction(

--- a/Sources/Web/CrossmintWebView.swift
+++ b/Sources/Web/CrossmintWebView.swift
@@ -30,7 +30,7 @@ public struct CrossmintWebView: UIViewRepresentable {
         Task { @MainActor in try? await tee.load() }
 
         let configuration = WKWebViewConfiguration()
-        configuration.websiteDataStore = tee.signerStorage.dataStore
+        configuration.websiteDataStore = tee.signerWebsiteDataStore
         let userContentController = WKUserContentController()
 
         let communicationScript = WKUserScript(

--- a/Sources/Web/CrossmintWebView.swift
+++ b/Sources/Web/CrossmintWebView.swift
@@ -30,9 +30,7 @@ public struct CrossmintWebView: UIViewRepresentable {
         Task { @MainActor in try? await tee.load() }
 
         let configuration = WKWebViewConfiguration()
-        // Force the signer web view onto the TEE's non-persistent store so no signer
-        // state is written to disk and each cold start re-runs OTP onboarding.
-        configuration.websiteDataStore = tee.signerDataStore
+        configuration.websiteDataStore = tee.signerStorage.dataStore
         let userContentController = WKUserContentController()
 
         let communicationScript = WKUserScript(

--- a/Sources/Web/CrossmintWebView.swift
+++ b/Sources/Web/CrossmintWebView.swift
@@ -30,6 +30,9 @@ public struct CrossmintWebView: UIViewRepresentable {
         Task { @MainActor in try? await tee.load() }
 
         let configuration = WKWebViewConfiguration()
+        // Force the signer web view onto the TEE's non-persistent store so no signer
+        // state is written to disk and each cold start re-runs OTP onboarding.
+        configuration.websiteDataStore = tee.signerDataStore
         let userContentController = WKUserContentController()
 
         let communicationScript = WKUserScript(

--- a/Sources/Web/SignerWebStorage.swift
+++ b/Sources/Web/SignerWebStorage.swift
@@ -1,0 +1,14 @@
+import WebKit
+
+/// Non-persistent storage for the signer web view.
+@MainActor
+struct SignerWebStorage {
+    let dataStore: WKWebsiteDataStore = .nonPersistent()
+
+    func clear() async {
+        await dataStore.removeData(
+            ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
+            modifiedSince: .distantPast
+        )
+    }
+}

--- a/Tests/WebTests/CrossmintTEETests.swift
+++ b/Tests/WebTests/CrossmintTEETests.swift
@@ -1,6 +1,7 @@
 import CrossmintAuth
 import Foundation
 import Testing
+import WebKit
 @testable import Web
 
 @Suite("CrossmintTEE Tests", .tags(.unit))
@@ -104,6 +105,12 @@ struct CrossmintTEETests {
             #expect(completeOnboardingRequest != nil)
             #expect(completeOnboardingRequest?.data.data.onboardingAuthentication.encryptedOtp == otp)
         }
+    }
+
+    @Test("Signer data store is non-persistent so no signer state is written to disk")
+    func testSignerDataStoreIsNonPersistent() {
+        let fixture = TestFixture()
+        #expect(fixture.tee.signerDataStore.isPersistent == false)
     }
 
     @Test("Successfully completes handshake on first attempt")

--- a/Tests/WebTests/CrossmintTEETests.swift
+++ b/Tests/WebTests/CrossmintTEETests.swift
@@ -1,7 +1,6 @@
 import CrossmintAuth
 import Foundation
 import Testing
-import WebKit
 @testable import Web
 
 @Suite("CrossmintTEE Tests", .tags(.unit))
@@ -105,12 +104,6 @@ struct CrossmintTEETests {
             #expect(completeOnboardingRequest != nil)
             #expect(completeOnboardingRequest?.data.data.onboardingAuthentication.encryptedOtp == otp)
         }
-    }
-
-    @Test("Signer data store is non-persistent so no signer state is written to disk")
-    func testSignerDataStoreIsNonPersistent() {
-        let fixture = TestFixture()
-        #expect(fixture.tee.signerDataStore.isPersistent == false)
     }
 
     @Test("Successfully completes handshake on first attempt")

--- a/Tests/WebTests/SignerWebStorageTests.swift
+++ b/Tests/WebTests/SignerWebStorageTests.swift
@@ -1,0 +1,12 @@
+import Testing
+import WebKit
+@testable import Web
+
+@Suite("SignerWebStorage", .tags(.unit))
+@MainActor
+struct SignerWebStorageTests {
+    @Test("uses a non-persistent store so no signer state is written to disk")
+    func usesNonPersistentStore() {
+        #expect(SignerWebStorage().dataStore.isPersistent == false)
+    }
+}


### PR DESCRIPTION
On iOS the non-custodial signer runs in a hidden WKWebView, and that webview's storage isn't reliable across launches, so the device identity can disappear and break signing.

This stops relying on that persistence. The signer webview uses a non-persistent, in-memory data store, and the SDK resets and reloads the frame before each signature so it re-onboards with a fresh OTP every time.

## Changes
- Add `SignerWebStorage`, a non-persistent `WKWebsiteDataStore` for the signer webview, and set it as the webview's data store so no signer state is written to disk.
- Reset and reload the frame before each signature so the signer comes up as a new device and re-runs OTP onboarding.
- Add `deviceStorage=memory` to the signer URL so the frame uses in-memory device storage.
- Gate the query and the per-signature reset behind a private `usesEphemeralDeviceStorage` flag; when off, the frame uses its default storage.
- Add a unit test that the data store is non-persistent.
