### PR TITLE
Stop device key mapping from erroring when the key is already mapped

### DIFF
--- a/CrossmintDeviceSigner.podspec
+++ b/CrossmintDeviceSigner.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CrossmintDeviceSigner'
-  s.version          = '0.11.1'
+  s.version          = '0.12.1'
   s.summary          = 'Hardware-backed device signer key storage for Crossmint wallets (iOS).'
   s.homepage         = 'https://github.com/Crossmint/crossmint-swift-sdk'
   s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/CrossmintSDK.xctestplan
+++ b/CrossmintSDK.xctestplan
@@ -57,6 +57,13 @@
         "identifier" : "UtilsTests",
         "name" : "UtilsTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "DeviceSignerTests",
+        "name" : "DeviceSignerTests"
+      }
     }
   ],
   "version" : 1

--- a/Package.swift
+++ b/Package.swift
@@ -185,6 +185,13 @@ let package = Package(
             ],
             plugins: basePlugins
         ),
+        .testTarget(
+            name: "DeviceSignerTests",
+            dependencies: [
+                "DeviceSigner"
+            ],
+            plugins: basePlugins
+        ),
         .target(
             name: "TestsUtils",
             dependencies: [

--- a/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
+++ b/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
@@ -16,22 +16,13 @@ struct SystemKeychainItemStore: KeychainItemStore {
     private let service = "com.crossmint.devicesigner"
 
     func save(_ data: Data, tag: String, accessControl: SecAccessControl?) throws(DeviceSignerError) {
-        let deleteQuery: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: tag
-        ]
-        let deleteStatus = SecItemDelete(deleteQuery as CFDictionary)
+        let deleteStatus = SecItemDelete(itemQuery(tag: tag) as CFDictionary)
         guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
             throw DeviceSignerError.storageError(deleteStatus)
         }
 
-        var addQuery: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: tag,
-            kSecValueData: data
-        ]
+        var addQuery = itemQuery(tag: tag)
+        addQuery[kSecValueData] = data
         if let accessControl {
             addQuery[kSecAttrAccessControl] = accessControl
         } else {
@@ -44,13 +35,9 @@ struct SystemKeychainItemStore: KeychainItemStore {
     }
 
     func load(tag: String, prompt: String?, authContext: LAContext?) -> Data? {
-        var query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: tag,
-            kSecReturnData: true,
-            kSecMatchLimit: kSecMatchLimitOne
-        ]
+        var query = itemQuery(tag: tag)
+        query[kSecReturnData] = true
+        query[kSecMatchLimit] = kSecMatchLimitOne
         if let authContext {
             query[kSecUseAuthenticationContext] = authContext
         } else if let prompt {
@@ -65,15 +52,18 @@ struct SystemKeychainItemStore: KeychainItemStore {
     }
 
     func delete(tag: String) throws(DeviceSignerError) {
-        let query: [CFString: Any] = [
+        let status = SecItemDelete(itemQuery(tag: tag) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw DeviceSignerError.storageError(status)
+        }
+    }
+
+    private func itemQuery(tag: String) -> [CFString: Any] {
+        [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
             kSecAttrAccount: tag
         ]
-        let status = SecItemDelete(query as CFDictionary)
-        guard status == errSecSuccess || status == errSecItemNotFound else {
-            throw DeviceSignerError.storageError(status)
-        }
     }
 
     func allTags(prefix: String) -> [String] {

--- a/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
+++ b/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
@@ -5,11 +5,6 @@ import Security
 
 private let logger = Logger(subsystem: "com.crossmint.devicesigner", category: "KeychainStorage")
 
-/// Low-level item operations backing ``DeviceSignerKeychainStorage``.
-///
-/// Abstracted behind a protocol so the storage logic (rename, key lookup) can be
-/// exercised against an in-memory store in tests, where Keychain access is
-/// unavailable without app entitlements.
 protocol KeychainItemStore: Sendable {
     func save(_ data: Data, tag: String, accessControl: SecAccessControl?) throws(DeviceSignerError)
     func load(tag: String, prompt: String?, authContext: LAContext?) -> Data?
@@ -17,7 +12,6 @@ protocol KeychainItemStore: Sendable {
     func allTags(prefix: String) -> [String]
 }
 
-/// `KeychainItemStore` backed by the system Keychain via `SecItem*`.
 struct SystemKeychainItemStore: KeychainItemStore {
     private let service = "com.crossmint.devicesigner"
 
@@ -132,9 +126,6 @@ struct DeviceSignerKeychainStorage {
 
     func rename(from oldTag: String, to newTag: String) throws(DeviceSignerError) {
         guard let data = load(tag: oldTag) else {
-            // The source item is gone. If the destination already holds a key, the
-            // mapping is effectively done, so a repeated rename is a no-op rather than
-            // a failure. Only when neither item exists is the key genuinely missing.
             if load(tag: newTag) != nil { return }
             throw DeviceSignerError.keyNotFound
         }

--- a/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
+++ b/Sources/DeviceSigner/Keychain/DeviceSignerKeychainStorage.swift
@@ -5,13 +5,23 @@ import Security
 
 private let logger = Logger(subsystem: "com.crossmint.devicesigner", category: "KeychainStorage")
 
-private let service = "com.crossmint.devicesigner"
+/// Low-level item operations backing ``DeviceSignerKeychainStorage``.
+///
+/// Abstracted behind a protocol so the storage logic (rename, key lookup) can be
+/// exercised against an in-memory store in tests, where Keychain access is
+/// unavailable without app entitlements.
+protocol KeychainItemStore: Sendable {
+    func save(_ data: Data, tag: String, accessControl: SecAccessControl?) throws(DeviceSignerError)
+    func load(tag: String, prompt: String?, authContext: LAContext?) -> Data?
+    func delete(tag: String) throws(DeviceSignerError)
+    func allTags(prefix: String) -> [String]
+}
 
-struct DeviceSignerKeychainStorage {
-    private static let pendingKeyPrefix = "crossmint.device.pending."
-    private static let walletKeyPrefix = "crossmint.device.wallet."
+/// `KeychainItemStore` backed by the system Keychain via `SecItem*`.
+struct SystemKeychainItemStore: KeychainItemStore {
+    private let service = "com.crossmint.devicesigner"
 
-    func save(_ data: Data, tag: String, accessControl: SecAccessControl? = nil) throws(DeviceSignerError) {
+    func save(_ data: Data, tag: String, accessControl: SecAccessControl?) throws(DeviceSignerError) {
         let deleteQuery: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
@@ -39,7 +49,7 @@ struct DeviceSignerKeychainStorage {
         }
     }
 
-    func load(tag: String, prompt: String? = nil, authContext: LAContext? = nil) -> Data? {
+    func load(tag: String, prompt: String?, authContext: LAContext?) -> Data? {
         var query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
@@ -60,19 +70,15 @@ struct DeviceSignerKeychainStorage {
         return result as? Data
     }
 
-    func rename(from oldTag: String, to newTag: String) throws(DeviceSignerError) {
-        guard let data = load(tag: oldTag) else {
-            throw DeviceSignerError.keyNotFound
-        }
-        try delete(tag: oldTag)
-        try save(data, tag: newTag)
-    }
-
-    func hasMatchingKey(publicKeyBase64: String, reconstructPublicKey: (Data) -> String?) -> Bool {
-        if load(tag: "\(Self.pendingKeyPrefix)\(publicKeyBase64)") != nil { return true }
-        return allTags(prefix: Self.walletKeyPrefix).contains { tag in
-            guard let keyData = load(tag: tag) else { return false }
-            return reconstructPublicKey(keyData) == publicKeyBase64
+    func delete(tag: String) throws(DeviceSignerError) {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: tag
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw DeviceSignerError.storageError(status)
         }
     }
 
@@ -96,16 +102,51 @@ struct DeviceSignerKeychainStorage {
         }
         return items.compactMap { $0[kSecAttrAccount] as? String }.filter { $0.hasPrefix(prefix) }
     }
+}
+
+struct DeviceSignerKeychainStorage {
+    static let pendingKeyPrefix = "crossmint.device.pending."
+    static let walletKeyPrefix = "crossmint.device.wallet."
+
+    private let store: KeychainItemStore
+
+    init(store: KeychainItemStore = SystemKeychainItemStore()) {
+        self.store = store
+    }
+
+    func save(_ data: Data, tag: String, accessControl: SecAccessControl? = nil) throws(DeviceSignerError) {
+        try store.save(data, tag: tag, accessControl: accessControl)
+    }
+
+    func load(tag: String, prompt: String? = nil, authContext: LAContext? = nil) -> Data? {
+        store.load(tag: tag, prompt: prompt, authContext: authContext)
+    }
 
     func delete(tag: String) throws(DeviceSignerError) {
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: tag
-        ]
-        let status = SecItemDelete(query as CFDictionary)
-        guard status == errSecSuccess || status == errSecItemNotFound else {
-            throw DeviceSignerError.storageError(status)
+        try store.delete(tag: tag)
+    }
+
+    func allTags(prefix: String) -> [String] {
+        store.allTags(prefix: prefix)
+    }
+
+    func rename(from oldTag: String, to newTag: String) throws(DeviceSignerError) {
+        guard let data = load(tag: oldTag) else {
+            // The source item is gone. If the destination already holds a key, the
+            // mapping is effectively done, so a repeated rename is a no-op rather than
+            // a failure. Only when neither item exists is the key genuinely missing.
+            if load(tag: newTag) != nil { return }
+            throw DeviceSignerError.keyNotFound
+        }
+        try delete(tag: oldTag)
+        try save(data, tag: newTag)
+    }
+
+    func hasMatchingKey(publicKeyBase64: String, reconstructPublicKey: (Data) -> String?) -> Bool {
+        if load(tag: "\(Self.pendingKeyPrefix)\(publicKeyBase64)") != nil { return true }
+        return allTags(prefix: Self.walletKeyPrefix).contains { tag in
+            guard let keyData = load(tag: tag) else { return false }
+            return reconstructPublicKey(keyData) == publicKeyBase64
         }
     }
 }

--- a/Tests/DeviceSignerTests/DeviceSignerKeyStorageTests.swift
+++ b/Tests/DeviceSignerTests/DeviceSignerKeyStorageTests.swift
@@ -74,12 +74,6 @@ struct DeviceSignerKeychainStorageTests {
         }
     }
 
-    @Test("hasMatchingKey is false when no key material is present")
-    func hasMatchingKeyFalseWhenAbsent() {
-        let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
-        #expect(keychain.hasMatchingKey(publicKeyBase64: "PUB") { _ in nil } == false)
-    }
-
     @Test("hasMatchingKey is true for a pending key")
     func hasMatchingKeyTrueForPending() throws {
         let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
@@ -93,6 +87,12 @@ struct DeviceSignerKeychainStorageTests {
         let keyData = Data("mapped".utf8)
         try keychain.save(keyData, tag: walletTag("0xabc"))
         #expect(keychain.hasMatchingKey(publicKeyBase64: "PUB") { $0 == keyData ? "PUB" : nil } == true)
+    }
+
+    @Test("hasMatchingKey is false when no key material is present")
+    func hasMatchingKeyFalseWhenAbsent() {
+        let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
+        #expect(keychain.hasMatchingKey(publicKeyBase64: "PUB") { _ in nil } == false)
     }
 
     @Test("hasMatchingKey reflects real presence, not generation history")

--- a/Tests/DeviceSignerTests/DeviceSignerKeyStorageTests.swift
+++ b/Tests/DeviceSignerTests/DeviceSignerKeyStorageTests.swift
@@ -1,0 +1,134 @@
+//
+//  DeviceSignerKeyStorageTests.swift
+//  CrossmintSDK
+//
+//  Regression coverage for WAL-10734. The device signer fails with `keyNotFound`
+//  on devices where the private key is no longer present (for example after a
+//  restore onto new hardware, where the `ThisDeviceOnly` key does not survive).
+//
+//  These tests drive the keychain layer through an in-memory store so the
+//  rename/lookup logic is exercised without Keychain entitlements.
+//
+
+import Foundation
+import LocalAuthentication
+import Security
+import Testing
+@testable import DeviceSigner
+
+/// In-memory `KeychainItemStore` for tests. Each test gets its own instance, so no
+/// locking is needed; access within a test is sequential.
+final class InMemoryKeychainItemStore: KeychainItemStore, @unchecked Sendable {
+    private var items: [String: Data] = [:]
+
+    func save(_ data: Data, tag: String, accessControl: SecAccessControl?) throws(DeviceSignerError) {
+        items[tag] = data
+    }
+
+    func load(tag: String, prompt: String?, authContext: LAContext?) -> Data? {
+        items[tag]
+    }
+
+    func delete(tag: String) throws(DeviceSignerError) {
+        items[tag] = nil
+    }
+
+    func allTags(prefix: String) -> [String] {
+        items.keys.filter { $0.hasPrefix(prefix) }
+    }
+}
+
+@Suite("DeviceSigner keychain storage")
+struct DeviceSignerKeychainStorageTests {
+
+    private func pendingTag(_ publicKey: String) -> String {
+        "\(DeviceSignerKeychainStorage.pendingKeyPrefix)\(publicKey)"
+    }
+
+    private func walletTag(_ address: String) -> String {
+        "\(DeviceSignerKeychainStorage.walletKeyPrefix)\(address)"
+    }
+
+    // MARK: - rename / mapAddressToKey
+
+    @Test("rename moves a pending key to the wallet-address tag")
+    func renameMovesPendingToWallet() throws {
+        let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
+        let data = Data("private-key".utf8)
+        try keychain.save(data, tag: pendingTag("PUB"))
+
+        try keychain.rename(from: pendingTag("PUB"), to: walletTag("0xabc"))
+
+        #expect(keychain.load(tag: pendingTag("PUB")) == nil)
+        #expect(keychain.load(tag: walletTag("0xabc")) == data)
+    }
+
+    /// The defense-in-depth half of the fix: when the pending key is gone but the
+    /// address is already keyed, a repeated rename is a no-op rather than a failure.
+    @Test("rename is a no-op when the destination already holds a key")
+    func renameIdempotentWhenDestinationExists() throws {
+        let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
+        let data = Data("already-mapped".utf8)
+        try keychain.save(data, tag: walletTag("0xabc"))
+
+        // No pending item exists, but the wallet-address tag does: must not throw.
+        try keychain.rename(from: pendingTag("PUB"), to: walletTag("0xabc"))
+
+        #expect(keychain.load(tag: walletTag("0xabc")) == data)
+    }
+
+    /// When neither a pending nor a wallet-address item exists, the failure is a
+    /// typed `keyNotFound` the orchestration can branch on to trigger re-registration.
+    @Test("rename throws keyNotFound when no key exists anywhere")
+    func renameThrowsKeyNotFoundWhenNothingPresent() {
+        let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
+
+        var caught: DeviceSignerError?
+        do {
+            try keychain.rename(from: pendingTag("PUB"), to: walletTag("0xabc"))
+        } catch {
+            caught = error
+        }
+        guard case .keyNotFound = caught else {
+            Issue.record("expected keyNotFound, got \(String(describing: caught))")
+            return
+        }
+    }
+
+    // MARK: - hasMatchingKey (the honest hasKey primitive)
+
+    @Test("hasMatchingKey is false when no key material is present")
+    func hasMatchingKeyFalseWhenAbsent() {
+        let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
+        #expect(keychain.hasMatchingKey(publicKeyBase64: "PUB") { _ in nil } == false)
+    }
+
+    @Test("hasMatchingKey is true for a pending key")
+    func hasMatchingKeyTrueForPending() throws {
+        let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
+        try keychain.save(Data("k".utf8), tag: pendingTag("PUB"))
+        #expect(keychain.hasMatchingKey(publicKeyBase64: "PUB") { _ in nil } == true)
+    }
+
+    @Test("hasMatchingKey is true for a key already mapped to an address")
+    func hasMatchingKeyTrueForMappedWallet() throws {
+        let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
+        let keyData = Data("mapped".utf8)
+        try keychain.save(keyData, tag: walletTag("0xabc"))
+        #expect(keychain.hasMatchingKey(publicKeyBase64: "PUB") { $0 == keyData ? "PUB" : nil } == true)
+    }
+
+    /// The core of the production bug: once the key material is gone, `hasMatchingKey`
+    /// must report false. An index that only records "was this key ever generated
+    /// here" returns true and sends the SDK into a rename/sign loop that can never
+    /// succeed.
+    @Test("hasMatchingKey reflects real presence, not generation history")
+    func hasMatchingKeyFalseAfterDeletion() throws {
+        let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
+        try keychain.save(Data("k".utf8), tag: pendingTag("PUB"))
+        #expect(keychain.hasMatchingKey(publicKeyBase64: "PUB") { _ in nil } == true)
+
+        try keychain.delete(tag: pendingTag("PUB"))
+        #expect(keychain.hasMatchingKey(publicKeyBase64: "PUB") { _ in nil } == false)
+    }
+}

--- a/Tests/DeviceSignerTests/DeviceSignerKeyStorageTests.swift
+++ b/Tests/DeviceSignerTests/DeviceSignerKeyStorageTests.swift
@@ -1,23 +1,9 @@
-//
-//  DeviceSignerKeyStorageTests.swift
-//  CrossmintSDK
-//
-//  Regression coverage for WAL-10734. The device signer fails with `keyNotFound`
-//  on devices where the private key is no longer present (for example after a
-//  restore onto new hardware, where the `ThisDeviceOnly` key does not survive).
-//
-//  These tests drive the keychain layer through an in-memory store so the
-//  rename/lookup logic is exercised without Keychain entitlements.
-//
-
 import Foundation
 import LocalAuthentication
 import Security
 import Testing
 @testable import DeviceSigner
 
-/// In-memory `KeychainItemStore` for tests. Each test gets its own instance, so no
-/// locking is needed; access within a test is sequential.
 final class InMemoryKeychainItemStore: KeychainItemStore, @unchecked Sendable {
     private var items: [String: Data] = [:]
 
@@ -49,8 +35,6 @@ struct DeviceSignerKeychainStorageTests {
         "\(DeviceSignerKeychainStorage.walletKeyPrefix)\(address)"
     }
 
-    // MARK: - rename / mapAddressToKey
-
     @Test("rename moves a pending key to the wallet-address tag")
     func renameMovesPendingToWallet() throws {
         let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
@@ -63,22 +47,17 @@ struct DeviceSignerKeychainStorageTests {
         #expect(keychain.load(tag: walletTag("0xabc")) == data)
     }
 
-    /// The defense-in-depth half of the fix: when the pending key is gone but the
-    /// address is already keyed, a repeated rename is a no-op rather than a failure.
     @Test("rename is a no-op when the destination already holds a key")
     func renameIdempotentWhenDestinationExists() throws {
         let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
         let data = Data("already-mapped".utf8)
         try keychain.save(data, tag: walletTag("0xabc"))
 
-        // No pending item exists, but the wallet-address tag does: must not throw.
         try keychain.rename(from: pendingTag("PUB"), to: walletTag("0xabc"))
 
         #expect(keychain.load(tag: walletTag("0xabc")) == data)
     }
 
-    /// When neither a pending nor a wallet-address item exists, the failure is a
-    /// typed `keyNotFound` the orchestration can branch on to trigger re-registration.
     @Test("rename throws keyNotFound when no key exists anywhere")
     func renameThrowsKeyNotFoundWhenNothingPresent() {
         let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())
@@ -94,8 +73,6 @@ struct DeviceSignerKeychainStorageTests {
             return
         }
     }
-
-    // MARK: - hasMatchingKey (the honest hasKey primitive)
 
     @Test("hasMatchingKey is false when no key material is present")
     func hasMatchingKeyFalseWhenAbsent() {
@@ -118,10 +95,6 @@ struct DeviceSignerKeychainStorageTests {
         #expect(keychain.hasMatchingKey(publicKeyBase64: "PUB") { $0 == keyData ? "PUB" : nil } == true)
     }
 
-    /// The core of the production bug: once the key material is gone, `hasMatchingKey`
-    /// must report false. An index that only records "was this key ever generated
-    /// here" returns true and sends the SDK into a rename/sign loop that can never
-    /// succeed.
     @Test("hasMatchingKey reflects real presence, not generation history")
     func hasMatchingKeyFalseAfterDeletion() throws {
         let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())


### PR DESCRIPTION
Attaching a device key to its wallet address (`mapAddressToKey`) could fail with a confusing Keychain error if the key was already attached. Now it just returns when the key is already in place, and only throws a clear `keyNotFound` when there is genuinely no key to attach.

It also separates the raw Keychain calls from the lookup logic, so tests can swap in an in-memory store and run without device entitlements. This area had no tests before.

## Changes
- `mapAddressToKey` (`rename`) returns instead of failing when the pending key is gone but the wallet address already has a key. A genuine miss, with nothing under either tag, throws a typed `keyNotFound` rather than a raw `storageError`.
- Moved the `SecItem` calls behind a `KeychainItemStore` (the real Keychain is the default), so `rename` and `hasMatchingKey` can be tested against an in-memory store.
- Added `DeviceSignerTests` covering the mapping behavior and that `hasMatchingKey` reflects the real key, not a record of keys generated in the past.
- Bumped the pod to `0.12.1`, the version the React Native SDK pins to.
