### PR TITLE
Restore SoftwareDeviceSignerKeyStorage as an alias for KeychainKeyStorage

### DIFF
--- a/CrossmintDeviceSigner.podspec
+++ b/CrossmintDeviceSigner.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CrossmintDeviceSigner'
-  s.version          = '0.12.1'
+  s.version          = '0.12.2'
   s.summary          = 'Hardware-backed device signer key storage for Crossmint wallets (iOS).'
   s.homepage         = 'https://github.com/Crossmint/crossmint-swift-sdk'
   s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/Sources/DeviceSigner/Storage/SoftwareDeviceSignerKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SoftwareDeviceSignerKeyStorage.swift
@@ -1,7 +1,9 @@
+//
+//  SoftwareDeviceSignerKeyStorage.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 22/6/26.
+//
+
 /// Backwards-compatible alias for ``KeychainKeyStorage``.
-///
-/// The software-backed key storage was renamed from `SoftwareDeviceSignerKeyStorage`
-/// to ``KeychainKeyStorage`` in 0.12.0. This alias keeps the old name resolving so
-/// React Native SDK releases that still reference `SoftwareDeviceSignerKeyStorage`
-/// continue to build against the 0.12 line.
 public typealias SoftwareDeviceSignerKeyStorage = KeychainKeyStorage

--- a/Sources/DeviceSigner/Storage/SoftwareDeviceSignerKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SoftwareDeviceSignerKeyStorage.swift
@@ -1,0 +1,7 @@
+/// Backwards-compatible alias for ``KeychainKeyStorage``.
+///
+/// The software-backed key storage was renamed from `SoftwareDeviceSignerKeyStorage`
+/// to ``KeychainKeyStorage`` in 0.12.0. This alias keeps the old name resolving so
+/// React Native SDK releases that still reference `SoftwareDeviceSignerKeyStorage`
+/// continue to build against the 0.12 line.
+public typealias SoftwareDeviceSignerKeyStorage = KeychainKeyStorage

--- a/Tests/DeviceSignerTests/DeviceSignerKeyStorageTests.swift
+++ b/Tests/DeviceSignerTests/DeviceSignerKeyStorageTests.swift
@@ -35,6 +35,12 @@ struct DeviceSignerKeychainStorageTests {
         "\(DeviceSignerKeychainStorage.walletKeyPrefix)\(address)"
     }
 
+    @Test("SoftwareDeviceSignerKeyStorage stays available as an alias for KeychainKeyStorage")
+    func softwareDeviceSignerKeyStorageAliasIsAvailable() {
+        let storage: any DeviceSignerKeyStorage = SoftwareDeviceSignerKeyStorage()
+        #expect(storage is KeychainKeyStorage)
+    }
+
     @Test("rename moves a pending key to the wallet-address tag")
     func renameMovesPendingToWallet() throws {
         let keychain = DeviceSignerKeychainStorage(store: InMemoryKeychainItemStore())


### PR DESCRIPTION
Restores `SoftwareDeviceSignerKeyStorage` as an alias for `KeychainKeyStorage` so the `0.12` pod line builds for consumers on either name.

The type was renamed to `KeychainKeyStorage` in 0.12.0, but the released React Native SDK still references the old name. It pins `CrossmintDeviceSigner ~> 0.11`, which resolves to any `0.x`, so publishing `0.12.1` broke those builds with `cannot find 'SoftwareDeviceSignerKeyStorage' in scope`.

The storage type itself is unchanged.

## Changes
- Add `public typealias SoftwareDeviceSignerKeyStorage = KeychainKeyStorage`.
- Bump the pod to `0.12.2`.
- Add a test asserting the alias resolves to `KeychainKeyStorage`.

Publishing `0.12.2` restores the build for released SDKs. A fresh `pod install` picks it up through `~> 0.11`, and projects pinned to `0.12.1` recover with `pod update CrossmintDeviceSigner`.

<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-swift-sdk/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->