### PR TITLE
Fix signatures failing when the signer frame reloads mid-onboarding

### DIFF
--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -52,6 +52,9 @@ public enum LogEvents {
     /// OTP validation failed
     public static let onboardingCompleteError = "signer.onboarding.complete.error"
 
+    /// A fresh OTP was issued after onboarding could not be completed (e.g. the signer frame was reloaded mid-onboarding)
+    public static let onboardingReissued = "signer.onboarding.reissued"
+
     // MARK: - Sign Events
 
     /// Starting signature request

--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -53,7 +53,7 @@ public enum LogEvents {
     public static let onboardingCompleteError = "signer.onboarding.complete.error"
 
     /// A fresh OTP was issued after onboarding could not be completed (e.g. the signer frame was reloaded mid-onboarding)
-    public static let onboardingReissued = "signer.onboarding.reissued"
+    public static let onboardingReissued = "tee.signer.onboarding.reissued"
 
     // MARK: - Sign Events
 

--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -192,8 +192,9 @@ public final class CrossmintTEE: ObservableObject {
                 guard attempt < Self.maxOnboardingAttempts else {
                     throw error
                 }
-                Logger.tee.warn(LogEvents.onboardingCompleteError, attributes: [
-                    "error": "Verification failed, reloading frame and re-onboarding (attempt \(attempt))"
+                Logger.tee.warn(LogEvents.onboardingReissued, attributes: [
+                    "attempt": "\(attempt)",
+                    "reason": "Onboarding could not be completed, reloading the frame and re-issuing the OTP"
                 ])
                 try await reloadFrameForReonboarding()
                 attempt += 1

--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -142,29 +142,12 @@ public final class CrossmintTEE: ObservableObject {
             }
             switch signerStatus {
             case .newDevice:
-                let onboardingResponse = try await startOnboarding(
+                return try await onboardThenSign(
                     jwt: jwt,
-                    authId: try getAuthId()
+                    transaction: transaction,
+                    keyType: keyType,
+                    encoding: encoding
                 )
-
-                guard onboardingResponse.status == .success else {
-                    Logger.tee.error(LogEvents.onboardingError, attributes: [
-                        "error": onboardingResponse.errorMessage ?? "Unknown error"
-                    ])
-                    throw .generic("Invalid NCS status")
-                }
-
-                let otpCode: String = try await waitForOTP()
-                _ = try await validate(otpCode: otpCode, jwt: jwt)
-
-                return try await sign(
-                    .init(
-                        jwt: jwt,
-                        apiKey: apiKey,
-                        messageBytes: transaction,
-                        keyType: keyType,
-                        encoding: encoding)
-                ).stringValue
             case .ready:
                 return try await sign(
                     .init(
@@ -181,6 +164,74 @@ public final class CrossmintTEE: ObservableObject {
             ])
             throw .generic(response.errorMessage ?? "Unknown error")
         }
+    }
+
+    /// Number of times onboarding is attempted within a single signature before giving up. One retry
+    /// covers the case where the signer frame is reloaded between sending and verifying the OTP.
+    private static let maxOnboardingAttempts = 2
+
+    /// Onboard a new device and sign. If completing onboarding fails because the signer frame lost its
+    /// in-memory state (e.g. the web content process was terminated while waiting for the OTP), reload
+    /// the frame and re-onboard so the user gets a fresh code instead of the signature dead-ending.
+    private func onboardThenSign(
+        jwt: String,
+        transaction: String,
+        keyType: String,
+        encoding: String
+    ) async throws(Error) -> String {
+        var attempt = 1
+        while true {
+            let onboardingResponse = try await startOnboarding(jwt: jwt, authId: try getAuthId())
+            guard onboardingResponse.status == .success else {
+                Logger.tee.error(LogEvents.onboardingError, attributes: [
+                    "error": onboardingResponse.errorMessage ?? "Unknown error"
+                ])
+                throw .generic("Invalid NCS status")
+            }
+
+            let otpCode: String = try await waitForOTP()
+
+            do {
+                _ = try await validate(otpCode: otpCode, jwt: jwt)
+            } catch {
+                guard attempt < Self.maxOnboardingAttempts else {
+                    throw error
+                }
+                Logger.tee.warn(LogEvents.onboardingCompleteError, attributes: [
+                    "error": "Verification failed, reloading frame and re-onboarding (attempt \(attempt))"
+                ])
+                try await reloadFrameForReonboarding()
+                attempt += 1
+                continue
+            }
+
+            return try await sign(
+                .init(
+                    jwt: jwt,
+                    apiKey: apiKey,
+                    messageBytes: transaction,
+                    keyType: keyType,
+                    encoding: encoding)
+            ).stringValue
+        }
+    }
+
+    /// Reload the signer frame and re-establish the handshake without disturbing the queue, so a fresh
+    /// onboarding can be started on a clean frame.
+    private func reloadFrameForReonboarding() async throws(Error) {
+        await signerStorage.clear()
+        webProxy.resetLoadedContent()
+
+        do {
+            try await webProxy.loadURL(url)
+        } catch {
+            Logger.tee.error(LogEvents.loadError, attributes: [
+                "error": "Failed to reload TEE URL: \(error)"
+            ])
+            throw Error.urlNotAvailable
+        }
+
+        try await tryHandshake(maxAttempts: 3)
     }
 
     public func resetState() {

--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -166,13 +166,8 @@ public final class CrossmintTEE: ObservableObject {
         }
     }
 
-    /// Number of times onboarding is attempted within a single signature before giving up. One retry
-    /// covers the case where the signer frame is reloaded between sending and verifying the OTP.
     private static let maxOnboardingAttempts = 2
 
-    /// Onboard a new device and sign. If completing onboarding fails because the signer frame lost its
-    /// in-memory state (e.g. the web content process was terminated while waiting for the OTP), reload
-    /// the frame and re-onboard so the user gets a fresh code instead of the signature dead-ending.
     private func onboardThenSign(
         jwt: String,
         transaction: String,
@@ -216,8 +211,6 @@ public final class CrossmintTEE: ObservableObject {
         }
     }
 
-    /// Reload the signer frame and re-establish the handshake without disturbing the queue, so a fresh
-    /// onboarding can be started on a clean frame.
     private func reloadFrameForReonboarding() async throws(Error) {
         await signerStorage.clear()
         webProxy.resetLoadedContent()

--- a/Tests/WebTests/CrossmintTEETests.swift
+++ b/Tests/WebTests/CrossmintTEETests.swift
@@ -76,6 +76,17 @@ struct CrossmintTEETests {
             webProxy.configureResponse(for: GetStatusResponse.self, response: statusResponse)
         }
 
+        /// Polls until the OTP prompt is requested, up to ~5s, so timing-sensitive assertions don't
+        /// flake under load.
+        func waitForOTPRequired() async throws {
+            for _ in 0..<100 {
+                if tee.isOTPRequired {
+                    return
+                }
+                try await Task.sleep(nanoseconds: 50_000_000)
+            }
+        }
+
         func verifyHandshakeCompleted(verificationId: String) {
             let sentHandshakeRequest = webProxy.lastSentMessage(ofType: HandshakeRequest.self)
             #expect(sentHandshakeRequest != nil)
@@ -446,5 +457,48 @@ struct CrossmintTEETests {
         }
 
         #expect(successCount == 3)
+    }
+
+    @Test("Re-onboards with a fresh OTP when the frame reloads mid-onboarding")
+    func testReonboardsWhenFrameReloadsMidOnboarding() async throws {
+        let fixture = TestFixture()
+        await fixture.setupAuthentication()
+        try await fixture.setupHandshake()
+
+        fixture.configureNewDevice()
+        // Start-onboarding succeeds, but complete-onboarding is left unconfigured so the first
+        // verification times out — simulating the signer frame being terminated while waiting for
+        // the OTP, which loses the in-memory onboarding.
+        let startOnboardingResponse = CrossmintTEETestHelpers.createStartOnboardingResponse()
+        fixture.webProxy.configureResponse(for: StartOnboardingResponse.self, response: startOnboardingResponse)
+        fixture.configureSignResponse(signature: "0xsignature_reonboard")
+
+        let signTask = Task {
+            try await fixture.tee.signTransaction(
+                transaction: CrossmintTEETestHelpers.createTestTransaction(),
+                keyType: "keyType",
+                encoding: "encoding"
+            )
+        }
+
+        // First OTP prompt.
+        try await fixture.waitForOTPRequired()
+        #expect(fixture.tee.isOTPRequired == true)
+        fixture.tee.provideOTP("stale-otp")
+
+        // Verification fails, the frame reloads, and a fresh OTP is requested.
+        try await fixture.waitForOTPRequired()
+        #expect(fixture.tee.isOTPRequired == true)
+
+        // The new code now completes onboarding.
+        let completeOnboardingResponse = CrossmintTEETestHelpers.createCompleteOnboardingResponse()
+        fixture.webProxy.configureResponse(for: CompleteOnboardingResponse.self, response: completeOnboardingResponse)
+        fixture.tee.provideOTP("fresh-otp")
+
+        let signature = try await signTask.value
+        #expect(signature == "0xsignature_reonboard")
+        #expect(fixture.tee.isOTPRequired == false)
+        // Onboarding was completed twice: the stale attempt and the fresh one after the reload.
+        #expect(fixture.webProxy.completeOnboardingRequestCount == 2)
     }
 }

--- a/Tests/WebTests/CrossmintTEETests.swift
+++ b/Tests/WebTests/CrossmintTEETests.swift
@@ -85,6 +85,7 @@ struct CrossmintTEETests {
                 }
                 try await Task.sleep(nanoseconds: 50_000_000)
             }
+            throw CrossmintTEE.Error.generic("Timed out waiting for the OTP prompt")
         }
 
         func verifyHandshakeCompleted(verificationId: String) {

--- a/Tests/WebTests/CrossmintTEETests.swift
+++ b/Tests/WebTests/CrossmintTEETests.swift
@@ -76,8 +76,6 @@ struct CrossmintTEETests {
             webProxy.configureResponse(for: GetStatusResponse.self, response: statusResponse)
         }
 
-        /// Polls until the OTP prompt is requested, up to ~5s, so timing-sensitive assertions don't
-        /// flake under load.
         func waitForOTPRequired() async throws {
             for _ in 0..<100 {
                 if tee.isOTPRequired {
@@ -467,9 +465,6 @@ struct CrossmintTEETests {
         try await fixture.setupHandshake()
 
         fixture.configureNewDevice()
-        // Start-onboarding succeeds, but complete-onboarding is left unconfigured so the first
-        // verification times out — simulating the signer frame being terminated while waiting for
-        // the OTP, which loses the in-memory onboarding.
         let startOnboardingResponse = CrossmintTEETestHelpers.createStartOnboardingResponse()
         fixture.webProxy.configureResponse(for: StartOnboardingResponse.self, response: startOnboardingResponse)
         fixture.configureSignResponse(signature: "0xsignature_reonboard")
@@ -482,16 +477,13 @@ struct CrossmintTEETests {
             )
         }
 
-        // First OTP prompt.
         try await fixture.waitForOTPRequired()
         #expect(fixture.tee.isOTPRequired == true)
         fixture.tee.provideOTP("stale-otp")
 
-        // Verification fails, the frame reloads, and a fresh OTP is requested.
         try await fixture.waitForOTPRequired()
         #expect(fixture.tee.isOTPRequired == true)
 
-        // The new code now completes onboarding.
         let completeOnboardingResponse = CrossmintTEETestHelpers.createCompleteOnboardingResponse()
         fixture.webProxy.configureResponse(for: CompleteOnboardingResponse.self, response: completeOnboardingResponse)
         fixture.tee.provideOTP("fresh-otp")
@@ -499,7 +491,6 @@ struct CrossmintTEETests {
         let signature = try await signTask.value
         #expect(signature == "0xsignature_reonboard")
         #expect(fixture.tee.isOTPRequired == false)
-        // Onboarding was completed twice: the stale attempt and the fresh one after the reload.
         #expect(fixture.webProxy.completeOnboardingRequestCount == 2)
     }
 }

--- a/Tests/WebTests/Mocks/MockWebViewCommunicationProxy.swift
+++ b/Tests/WebTests/Mocks/MockWebViewCommunicationProxy.swift
@@ -12,6 +12,9 @@ final class MockWebViewCommunicationProxy: NSObject, WebViewCommunicationProxy {
     var loadedURLs: [URL] = []
     var sentMessages: [any WebViewMessage] = []
     var resetCount = 0
+    // Cumulative count of complete-onboarding requests, not cleared by resetLoadedContent, so tests
+    // can assert that onboarding was retried across a frame reload.
+    var completeOnboardingRequestCount = 0
 
     var shouldThrowOnLoad = false
     var loadError: WebViewError?
@@ -39,6 +42,9 @@ final class MockWebViewCommunicationProxy: NSObject, WebViewCommunicationProxy {
     func sendMessage<T: WebViewMessage>(_ message: T) async throws(WebViewError) -> Any? {
         if shouldThrowOnSend {
             throw sendError ?? .javascriptEvaluationError
+        }
+        if message is CompleteOnboardingRequest {
+            completeOnboardingRequestCount += 1
         }
         sentMessages.append(message)
 

--- a/Tests/WebTests/Mocks/MockWebViewCommunicationProxy.swift
+++ b/Tests/WebTests/Mocks/MockWebViewCommunicationProxy.swift
@@ -12,8 +12,6 @@ final class MockWebViewCommunicationProxy: NSObject, WebViewCommunicationProxy {
     var loadedURLs: [URL] = []
     var sentMessages: [any WebViewMessage] = []
     var resetCount = 0
-    // Cumulative count of complete-onboarding requests, not cleared by resetLoadedContent, so tests
-    // can assert that onboarding was retried across a frame reload.
     var completeOnboardingRequestCount = 0
 
     var shouldThrowOnLoad = false


### PR DESCRIPTION
Fixes a signature failing when the signer frame reloads mid-onboarding. With the ephemeral frame the device lives only in the web content process, so if that process is terminated while waiting for the OTP, completing onboarding fails and the signature fails with it.

Now when completing onboarding throws, the frame reloads and onboarding restarts so the user gets a fresh code. A wrong OTP comes back as an error response rather than a throw, so it stays unaffected.

## Changes
- Pull the new-device path in `executeSignTransaction` into `onboardThenSign`, which retries onboarding once when completing it throws.
- Add `reloadFrameForReonboarding` to reload the frame and re-handshake without disturbing the sign queue.
- Add a test that the signer re-onboards with a fresh OTP after the frame reloads mid-onboarding.