### PR TITLE
Add CrossmintError protocol and retrofit SDK error types

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/OTPSignInView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Login/OTPSignInView.swift
@@ -82,7 +82,7 @@ struct OTPSignInView: View {
                 pendingOTPRequest = otpRequest
             } catch let authError as AuthError {
                 isSigningIn = false
-                alertMessage = authError.errorMessage
+                alertMessage = authError.message
                 showAlert = true
             }
         }

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/AppState.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/AppState.swift
@@ -8,9 +8,9 @@ import Observation
 
 extension Error {
     var userMessage: String {
-        if let e = self as? WalletError { return e.errorMessage }
-        if let e = self as? TransactionError { return e.errorMessage }
-        if let e = self as? SignatureError { return e.errorMessage }
+        if let e = self as? WalletError { return e.message }
+        if let e = self as? TransactionError { return e.message }
+        if let e = self as? SignatureError { return e.message }
         return localizedDescription
     }
 }

--- a/Sources/CrossmintAuth/AuthManager.swift
+++ b/Sources/CrossmintAuth/AuthManager.swift
@@ -1,3 +1,4 @@
+import CrossmintService
 import Foundation
 import Logger
 
@@ -7,21 +8,42 @@ public protocol AuthManager: Sendable {
     func setJWT(_ jwt: String) async
 }
 
-public enum AuthManagerError: Swift.Error, Equatable {
+public enum AuthManagerError: CrossmintError, Equatable {
     case unknown(String)
     case serviceError(String)
     case invalidInput(String)
     case invalidEmail
     case noPendingOTP
 
-    public var errorMessage: String {
-        return switch self {
-        case .unknown(let message), .serviceError(let message), .invalidInput(let message):
-            message
+    public var code: String {
+        switch self {
+        case .unknown: "AUTH_MANAGER_ERROR"
+        case .serviceError: "AUTH_SERVICE_ERROR"
+        case .invalidInput: "INVALID_INPUT"
+        case .invalidEmail: "INVALID_EMAIL"
+        case .noPendingOTP: "NO_PENDING_OTP"
+        }
+    }
+
+    public var message: String {
+        switch self {
+        case .unknown(let detail), .serviceError(let detail), .invalidInput(let detail):
+            detail
         case .invalidEmail:
             "Invalid email address"
         case .noPendingOTP:
             "No OTP email has been sent. Call sendEmailOtp first."
+        }
+    }
+
+    public var recoverySuggestion: String? {
+        switch self {
+        case .invalidEmail:
+            "Provide a valid email address in the correct format."
+        case .noPendingOTP:
+            "Call sendEmailOTP(to:) before attempting to verify an OTP."
+        default:
+            nil
         }
     }
 }

--- a/Sources/CrossmintAuth/Data/AuthError.swift
+++ b/Sources/CrossmintAuth/Data/AuthError.swift
@@ -1,13 +1,47 @@
 import CrossmintService
 import Http
 
-public enum AuthError: ServiceError {
+public enum AuthError: CrossmintError {
     case serviceError(CrossmintServiceError)
     case signInRequired
     case generic(String)
 
-    public static func fromServiceError(_ error: CrossmintServiceError)
-        -> AuthError {
+    public var code: String {
+        switch self {
+        case .serviceError: "SERVICE_ERROR"
+        case .signInRequired: "SIGN_IN_REQUIRED"
+        case .generic: "AUTH_ERROR"
+        }
+    }
+
+    public var message: String {
+        switch self {
+        case .serviceError(let error):
+            error.message
+        case .generic(let detail):
+            detail
+        case .signInRequired:
+            "Sign in is required as the operation was unauthorized"
+        }
+    }
+
+    public var recoverySuggestion: String? {
+        switch self {
+        case .signInRequired:
+            "Call sendEmailOTP(to:) to begin authentication."
+        default:
+            nil
+        }
+    }
+
+    public var underlyingError: Swift.Error? {
+        guard case .serviceError(let error) = self else { return nil }
+        return error
+    }
+}
+
+extension AuthError: CrossmintMappableError {
+    public static func fromServiceError(_ error: CrossmintServiceError) -> AuthError {
         .serviceError(error)
     }
 
@@ -20,17 +54,6 @@ public enum AuthError: ServiceError {
             .serviceError(.invalidApiKey(message))
         default:
             .generic(message)
-        }
-    }
-
-    public var errorMessage: String {
-        switch self {
-        case .serviceError(let crossmintServiceError):
-            return crossmintServiceError.errorMessage
-        case .generic(let message):
-            return message
-        case .signInRequired:
-            return "Sign in is required as the operation was unauthorized"
         }
     }
 }

--- a/Sources/CrossmintAuth/DefaultAuthManager.swift
+++ b/Sources/CrossmintAuth/DefaultAuthManager.swift
@@ -83,7 +83,7 @@ public actor CrossmintAuthManager: AuthManager {
             jwtRefreshTimer?.invalidate()
             otpAuthenticationStatus = newStatus
         } catch {
-            throw AuthManagerError.serviceError(error.errorMessage)
+            throw AuthManagerError.serviceError(error.message)
         }
     }
 
@@ -104,7 +104,7 @@ public actor CrossmintAuthManager: AuthManager {
             )
             return otpAuthenticationStatus
         } catch {
-            throw AuthManagerError.serviceError(error.errorMessage)
+            throw AuthManagerError.serviceError(error.message)
         }
     }
 
@@ -124,7 +124,7 @@ public actor CrossmintAuthManager: AuthManager {
             return otpAuthenticationStatus
         } catch {
             Logger.auth.error("Error while logging out: \(error.localizedDescription)")
-            throw AuthManagerError.serviceError(error.errorMessage)
+            throw AuthManagerError.serviceError(error.message)
         }
     }
 

--- a/Sources/CrossmintService/CrossmintError.swift
+++ b/Sources/CrossmintService/CrossmintError.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Http
+
+public protocol CrossmintError: Swift.Error, Sendable, CustomStringConvertible {
+    var code: String { get }
+    var message: String { get }
+    var recoverySuggestion: String? { get }
+    var underlyingError: Swift.Error? { get }
+}
+
+extension CrossmintError {
+    public var description: String {
+        var result = "[\(code)] \(message)"
+        if let suggestion = recoverySuggestion {
+            result += "\nRecovery: \(suggestion)"
+        }
+        return result
+    }
+
+    public var recoverySuggestion: String? { nil }
+    public var underlyingError: Swift.Error? { nil }
+}
+
+/// SDK-internal protocol. Conformance is managed by the SDK — do not adopt this in app code.
+public protocol CrossmintMappableError: CrossmintError {
+    static func fromServiceError(_ error: CrossmintServiceError) -> Self
+    static func fromNetworkError(_ error: NetworkError) -> Self
+}

--- a/Sources/CrossmintService/CrossmintError.swift
+++ b/Sources/CrossmintService/CrossmintError.swift
@@ -1,6 +1,7 @@
+import Foundation
 import Http
 
-public protocol CrossmintError: Swift.Error, Sendable, CustomStringConvertible {
+public protocol CrossmintError: Swift.Error, Sendable, LocalizedError, CustomStringConvertible {
     var code: String { get }
     var message: String { get }
     var recoverySuggestion: String? { get }
@@ -8,6 +9,8 @@ public protocol CrossmintError: Swift.Error, Sendable, CustomStringConvertible {
 }
 
 extension CrossmintError {
+    public var errorDescription: String? { message }
+
     public var description: String {
         var result = "[\(code)] \(message)"
         if let suggestion = recoverySuggestion {

--- a/Sources/CrossmintService/CrossmintError.swift
+++ b/Sources/CrossmintService/CrossmintError.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Http
 
 public protocol CrossmintError: Swift.Error, Sendable, CustomStringConvertible {

--- a/Sources/CrossmintService/CrossmintService.swift
+++ b/Sources/CrossmintService/CrossmintService.swift
@@ -1,32 +1,46 @@
 import Foundation
 import Http
 
-public protocol ServiceError: Swift.Error {
-    static func fromServiceError(_ error: CrossmintServiceError) -> Self
-    static func fromNetworkError(_ error: NetworkError) -> Self
-
-    var errorMessage: String { get }
-}
-
-public enum CrossmintServiceError: Swift.Error {
+public enum CrossmintServiceError: CrossmintError {
     case unknown
     case invalidData(String)
     case invalidApiKey(String)
     case timeout
     case invalidURL
 
-    public var errorMessage: String {
+    public var code: String {
+        switch self {
+        case .unknown: "SERVICE_ERROR"
+        case .invalidData: "INVALID_DATA"
+        case .invalidApiKey: "INVALID_API_KEY"
+        case .timeout: "TIMEOUT"
+        case .invalidURL: "INVALID_URL"
+        }
+    }
+
+    public var message: String {
         switch self {
         case .unknown:
             "Unknown error"
-        case .invalidData(let message):
-            "Invalid data: \(message)"
-        case .invalidApiKey(let message):
-            "Invalid API key: \(message)"
+        case .invalidData(let detail):
+            "Invalid data: \(detail)"
+        case .invalidApiKey(let detail):
+            "Invalid API key: \(detail)"
         case .invalidURL:
             "Invalid URL"
         case .timeout:
             "Timeout"
+        }
+    }
+
+    public var recoverySuggestion: String? {
+        switch self {
+        case .invalidApiKey:
+            "Verify your API key in the Crossmint developer console."
+        case .timeout:
+            "Check your network connection and retry the request."
+        default:
+            nil
         }
     }
 }
@@ -36,19 +50,19 @@ public protocol CrossmintService: Sendable {
         _ endpoint: Endpoint,
         errorType: E.Type,
         _ transform: (NetworkError) -> E?
-    ) async throws(E) -> T where T: Decodable, E: ServiceError
+    ) async throws(E) -> T where T: Decodable, E: CrossmintMappableError
 
     func executeRequest<E>(
         _ endpoint: Endpoint,
         errorType: E.Type,
         _ transform: (NetworkError) -> E?
-    ) async throws(E) where E: ServiceError
+    ) async throws(E) where E: CrossmintMappableError
 
     func executeRequestForRawData<E>(
         _ endpoint: Endpoint,
         errorType: E.Type,
         _ transform: (NetworkError) -> E?
-    ) async throws(E) -> Data where E: ServiceError
+    ) async throws(E) -> Data where E: CrossmintMappableError
 
     func getApiBaseURL() throws(CrossmintServiceError) -> URL
 
@@ -59,21 +73,21 @@ public extension CrossmintService {
     func executeRequest<T, E>(
         _ endpoint: Endpoint,
         errorType: E.Type
-    ) async throws(E) -> T where T: Decodable, E: ServiceError {
+    ) async throws(E) -> T where T: Decodable, E: CrossmintMappableError {
         try await self.executeRequest(endpoint, errorType: errorType, { _ in nil })
     }
 
     func executeRequest<E>(
         _ endpoint: Endpoint,
         errorType: E.Type
-    ) async throws(E) where E: ServiceError {
+    ) async throws(E) where E: CrossmintMappableError {
         let _: Void = try await self.executeRequest(endpoint, errorType: errorType, { _ in nil })
     }
 
     func executeRequestForRawData<E>(
         _ endpoint: Endpoint,
         errorType: E.Type
-    ) async throws(E) -> Data where E: ServiceError {
+    ) async throws(E) -> Data where E: CrossmintMappableError {
         try await self.executeRequestForRawData(endpoint, errorType: errorType, { _ in nil })
     }
 }

--- a/Sources/CrossmintService/DefaultCrossmintService.swift
+++ b/Sources/CrossmintService/DefaultCrossmintService.swift
@@ -30,7 +30,7 @@ public struct DefaultCrossmintService: CrossmintService {
         _ endpoint: Endpoint,
         errorType: E.Type,
         _ transform: (NetworkError) -> E? = { _ in nil }
-    ) async throws(E) -> T where T: Decodable, E: ServiceError {
+    ) async throws(E) -> T where T: Decodable, E: CrossmintMappableError {
         do {
             let (data, _) = try await httpClient.fetch(try getRequest(endpoint))
             return try jsonCoder.decode(T.self, from: data)
@@ -52,7 +52,7 @@ public struct DefaultCrossmintService: CrossmintService {
         _ endpoint: Endpoint,
         errorType: E.Type,
         _ transform: (NetworkError) -> E? = { _ in nil }
-    ) async throws(E) where E: ServiceError {
+    ) async throws(E) where E: CrossmintMappableError {
         do {
             _ = try await httpClient.fetch(try getRequest(endpoint))
         } catch {
@@ -68,7 +68,7 @@ public struct DefaultCrossmintService: CrossmintService {
         _ endpoint: Endpoint,
         errorType: E.Type,
         _ transform: (NetworkError) -> E? = { _ in nil }
-    ) async throws(E) -> Data where E: ServiceError {
+    ) async throws(E) -> Data where E: CrossmintMappableError {
         do {
             let (data, _) = try await httpClient.fetch(try getRequest(endpoint))
             return data

--- a/Sources/CrossmintService/JSONCoder.swift
+++ b/Sources/CrossmintService/JSONCoder.swift
@@ -12,7 +12,7 @@ public protocol JSONCoder: Sendable {
 }
 
 public extension JSONCoder {
-    func encodeRequest<T: Encodable, E: ServiceError>(
+    func encodeRequest<T: Encodable, E: CrossmintMappableError>(
         _ request: T,
         errorType: E.Type
     ) throws(E) -> Data {

--- a/Sources/CrossmintService/RequestEncodingUtility.swift
+++ b/Sources/CrossmintService/RequestEncodingUtility.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum RequestEncodingUtility {
-    static func encodeRequest<T: Encodable, E: ServiceError>(
+    static func encodeRequest<T: Encodable, E: CrossmintMappableError>(
         _ request: T,
         using jsonCoder: JSONCoder,
         errorType: E.Type

--- a/Sources/DeviceSigner/DeviceSignerError.swift
+++ b/Sources/DeviceSigner/DeviceSignerError.swift
@@ -20,8 +20,6 @@ public enum DeviceSignerError: Error, Sendable {
     /// The message to sign could not be decoded.
     case invalidMessage
 
-    /// A machine-readable code identifying the error.
-    /// Intended to conform to `CrossmintError.code` when that protocol is introduced.
     public var code: String {
         switch self {
         case .keyNotFound:          "DEVICE_SIGNER_KEY_NOT_FOUND"
@@ -32,16 +30,29 @@ public enum DeviceSignerError: Error, Sendable {
         }
     }
 
-    /// Human-readable guidance on how to recover from the error, if applicable.
-    /// Intended to conform to `CrossmintError.recoverySuggestion` when that protocol is introduced.
+    public var message: String {
+        switch self {
+        case .keyNotFound:
+            "No device signer key found for this wallet."
+        case .keyGenerationFailed:
+            "Failed to generate a device signer key."
+        case .signingFailed:
+            "Failed to sign the message with the device signer key."
+        case .storageError(let status):
+            "Keychain operation failed with status \(status)."
+        case .invalidMessage:
+            "The message to sign could not be decoded."
+        }
+    }
+
     public var recoverySuggestion: String? {
         switch self {
         case .keyNotFound:
-            "The device signer key for this wallet was not found. The wallet may need to re-register a device signer."
+            "The wallet may need to re-register a device signer."
         case .keyGenerationFailed:
-            "Key generation failed. Ensure the device has sufficient storage and the app has Keychain access."
+            "Ensure the device has sufficient storage and the app has Keychain access."
         case .storageError:
-            "A Keychain error occurred. Ensure the app has Keychain entitlements and the device is unlocked."
+            "Ensure the app has Keychain entitlements and the device is unlocked."
         case .signingFailed, .invalidMessage:
             nil
         }

--- a/Sources/Wallet/Data/AuthenticatedCrossmintService.swift
+++ b/Sources/Wallet/Data/AuthenticatedCrossmintService.swift
@@ -13,7 +13,7 @@ struct AuthenticatedCrossmintService: CrossmintService {
         _ endpoint: Endpoint,
         errorType: E.Type,
         _ transform: (NetworkError) -> E?
-    ) async throws(E) -> T where T: Decodable, E: ServiceError {
+    ) async throws(E) -> T where T: Decodable, E: CrossmintMappableError {
         try await base.executeRequest(await withAuth(endpoint), errorType: errorType, transform)
     }
 
@@ -21,7 +21,7 @@ struct AuthenticatedCrossmintService: CrossmintService {
         _ endpoint: Endpoint,
         errorType: E.Type,
         _ transform: (NetworkError) -> E?
-    ) async throws(E) where E: ServiceError {
+    ) async throws(E) where E: CrossmintMappableError {
         try await base.executeRequest(await withAuth(endpoint), errorType: errorType, transform)
     }
 
@@ -29,7 +29,7 @@ struct AuthenticatedCrossmintService: CrossmintService {
         _ endpoint: Endpoint,
         errorType: E.Type,
         _ transform: (NetworkError) -> E?
-    ) async throws(E) -> Data where E: ServiceError {
+    ) async throws(E) -> Data where E: CrossmintMappableError {
         try await base.executeRequestForRawData(await withAuth(endpoint), errorType: errorType, transform)
     }
 

--- a/Sources/Wallet/Model/Transaction/TransactionError.swift
+++ b/Sources/Wallet/Model/Transaction/TransactionError.swift
@@ -1,7 +1,7 @@
 import CrossmintService
 import Http
 
-public enum TransactionError: ServiceError {
+public enum TransactionError: CrossmintError {
     case serviceError(CrossmintServiceError)
     case transactionNotFound
     case transactionCreationFailed
@@ -14,33 +14,70 @@ public enum TransactionError: ServiceError {
     case transactionSigningFailed(Error)
     case transactionGeneric(String)
 
-    public var errorMessage: String {
+    public var code: String {
         switch self {
-        case .serviceError(let error):
-            return error.errorMessage
-        case .invalidApprovals(let expected, let actual):
-            return "Invalid approvals. Expected: \(expected), Actual: \(actual)"
-        case .transactionNotFound:
-            return "Transaction not found"
-        case .transactionCreationFailed:
-            return "Transaction creation failed"
-        case .transactionCreationFailedNoSigner:
-            return "Transaction creation failed: no signer"
-        case .transactionGeneric(let error):
-            return error
-        case .transactionSigningFailed:
-            return "Transaction signing failed"
-        case .transactionSigningFailedNoSigner:
-            return "Transaction signing failed: no signer"
-        case .transactionSigningFailedNoMessage:
-            return "Transaction signing failed: no message"
-        case .transactionSigningFailedInvalidKey:
-            return "Transaction signing failed: invalid key"
-        case .userCancelled:
-            return "The user cancelled the signing"
+        case .serviceError: "SERVICE_ERROR"
+        case .transactionNotFound: "TRANSACTION_NOT_FOUND"
+        case .transactionCreationFailed: "TRANSACTION_CREATION_FAILED"
+        case .userCancelled: "USER_CANCELLED"
+        case .invalidApprovals: "INVALID_APPROVALS"
+        case .transactionCreationFailedNoSigner: "TRANSACTION_CREATION_FAILED_NO_SIGNER"
+        case .transactionSigningFailedNoSigner: "TRANSACTION_SIGNING_FAILED_NO_SIGNER"
+        case .transactionSigningFailedNoMessage: "TRANSACTION_SIGNING_FAILED_NO_MESSAGE"
+        case .transactionSigningFailedInvalidKey: "TRANSACTION_SIGNING_FAILED_INVALID_KEY"
+        case .transactionSigningFailed: "TRANSACTION_SIGNING_FAILED"
+        case .transactionGeneric: "TRANSACTION_ERROR"
         }
     }
 
+    public var message: String {
+        switch self {
+        case .serviceError(let error):
+            error.message
+        case .invalidApprovals(let expected, let actual):
+            "Invalid approvals. Expected: \(expected), Actual: \(actual)"
+        case .transactionNotFound:
+            "Transaction not found"
+        case .transactionCreationFailed:
+            "Transaction creation failed"
+        case .transactionCreationFailedNoSigner:
+            "Transaction creation failed: no signer"
+        case .transactionGeneric(let detail):
+            detail
+        case .transactionSigningFailed:
+            "Transaction signing failed"
+        case .transactionSigningFailedNoSigner:
+            "Transaction signing failed: no signer"
+        case .transactionSigningFailedNoMessage:
+            "Transaction signing failed: no message"
+        case .transactionSigningFailedInvalidKey:
+            "Transaction signing failed: invalid key"
+        case .userCancelled:
+            "The user cancelled the signing"
+        }
+    }
+
+    public var recoverySuggestion: String? {
+        switch self {
+        case .transactionCreationFailedNoSigner, .transactionSigningFailedNoSigner:
+            "Ensure a signer is configured before initiating a transaction."
+        case .transactionSigningFailedInvalidKey:
+            "Verify that the signing key is valid and has not been revoked."
+        default:
+            nil
+        }
+    }
+
+    public var underlyingError: Swift.Error? {
+        switch self {
+        case .serviceError(let error): error
+        case .transactionSigningFailed(let error): error
+        default: nil
+        }
+    }
+}
+
+extension TransactionError: CrossmintMappableError {
     public static func fromServiceError(_ error: CrossmintServiceError) -> TransactionError {
         .serviceError(error)
     }
@@ -49,11 +86,11 @@ public enum TransactionError: ServiceError {
         let message = error.serviceErrorMessage ?? error.localizedDescription
         return switch error {
         case .forbidden:
-                .serviceError(.invalidApiKey(message))
+            .serviceError(.invalidApiKey(message))
         case .timeout:
-                .serviceError(.timeout)
+            .serviceError(.timeout)
         default:
-                .transactionGeneric(message)
+            .transactionGeneric(message)
         }
     }
 }

--- a/Sources/Wallet/Model/Wallet/SignatureError.swift
+++ b/Sources/Wallet/Model/Wallet/SignatureError.swift
@@ -1,7 +1,7 @@
 import CrossmintService
 import Http
 
-public enum SignatureError: ServiceError {
+public enum SignatureError: CrossmintError {
     case creationFailed
     case approvalFailed
     case userCancelled
@@ -10,25 +10,44 @@ public enum SignatureError: ServiceError {
     case unknown
     case decodingError
 
-    public var errorMessage: String {
+    public var code: String {
         switch self {
-        case let .serviceError(error):
-            return error.errorMessage
-        case .approvalFailed:
-            return "There was an error while approving the message"
-        case .userCancelled:
-            return "User cancelled this action"
-        case .creationFailed:
-            return "The creation failed"
-        case .networkError:
-            return "There was a backend error."
-        case .unknown:
-            return "Unknown signature type"
-        case .decodingError:
-            return "Failed to decode signature response"
+        case .creationFailed: "SIGNATURE_CREATION_FAILED"
+        case .approvalFailed: "SIGNATURE_APPROVAL_FAILED"
+        case .userCancelled: "USER_CANCELLED"
+        case .serviceError: "SERVICE_ERROR"
+        case .networkError: "NETWORK_ERROR"
+        case .unknown: "SIGNATURE_UNKNOWN"
+        case .decodingError: "SIGNATURE_DECODING_ERROR"
         }
     }
 
+    public var message: String {
+        switch self {
+        case .serviceError(let error):
+            error.message
+        case .approvalFailed:
+            "There was an error while approving the message"
+        case .userCancelled:
+            "User cancelled this action"
+        case .creationFailed:
+            "The creation failed"
+        case .networkError:
+            "There was a backend error."
+        case .unknown:
+            "Unknown signature type"
+        case .decodingError:
+            "Failed to decode signature response"
+        }
+    }
+
+    public var underlyingError: Swift.Error? {
+        guard case .serviceError(let error) = self else { return nil }
+        return error
+    }
+}
+
+extension SignatureError: CrossmintMappableError {
     public static func fromServiceError(_ error: CrossmintServiceError) -> SignatureError {
         .serviceError(error)
     }

--- a/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
@@ -15,7 +15,7 @@ extension Wallet {
         do {
             try await preAuthIfNeeded()
         } catch {
-            throw .transactionGeneric(error.errorMessage)
+            throw .transactionGeneric(error.message)
         }
 
         do {
@@ -171,7 +171,7 @@ extension Wallet {
         _ transactionRequest: any TransactionRequest
     ) async throws(TransactionError) -> Transaction? {
         do { try await preAuthIfNeeded() } catch {
-            throw .transactionGeneric(error.errorMessage)
+            throw .transactionGeneric(error.message)
         }
         onTransactionStart?()
         let createdTransaction = try await createTransaction(transactionRequest)
@@ -207,7 +207,7 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
         idempotencyKey: String? = nil
     ) async throws(TransactionError) -> Transaction? {
         do { try await preAuthIfNeeded() } catch {
-            throw .transactionGeneric(error.errorMessage)
+            throw .transactionGeneric(error.message)
         }
         onTransactionStart?()
         if let storage = deviceSignerKeyStorage {

--- a/Sources/Wallet/Model/Wallet/WalletError.swift
+++ b/Sources/Wallet/Model/Wallet/WalletError.swift
@@ -2,7 +2,7 @@ import CrossmintCommonTypes
 import CrossmintService
 import Http
 
-public enum WalletError: ServiceError {
+public enum WalletError: CrossmintError {
     case serviceError(CrossmintServiceError)
     case walletInvalidType(String)
     case walletNotFound
@@ -17,34 +17,75 @@ public enum WalletError: ServiceError {
     case invalidToken(token: CryptoCurrency)
     case signerNotRegistered(String)
 
-    public var errorMessage: String {
+    public var code: String {
         switch self {
-        case let .serviceError(error):
-            return error.errorMessage
-        case .walletInvalidType(let message), .walletGeneric(let message),
-            .walletCreationFailed(let message):
-            return message
-        case .walletNotFound:
-            return "Wallet not found"
-        case .walletInvalidCredentials:
-            return "The credentials provided are invalid for this wallet."
-        case .walletLocatorError(let locator):
-            return "Invalid wallet locator: \(locator)"
-        case .transactionNotFound:
-            return "Transaction not found"
-        case .walletInvalidSignerProvided:
-            return "The provided admin signer and the received one do not match"
-        case .walletCreationCancelled:
-            return "Creation cancelled."
-        case .invalidChain(let chain):
-            return "Invalid chain: \(chain.name)"
-        case .invalidToken(let token):
-            return "Invalid token: \(token.name)"
-        case .signerNotRegistered(let locator):
-            return "Signer \"\(locator)\" is not registered on this wallet. Call addSigner first."
+        case .serviceError: "SERVICE_ERROR"
+        case .walletInvalidType: "WALLET_INVALID_TYPE"
+        case .walletNotFound: "WALLET_NOT_FOUND"
+        case .walletCreationFailed: "WALLET_CREATION_FAILED"
+        case .walletCreationCancelled: "WALLET_CREATION_CANCELLED"
+        case .walletGeneric: "WALLET_ERROR"
+        case .walletInvalidCredentials: "WALLET_INVALID_CREDENTIALS"
+        case .walletLocatorError: "WALLET_LOCATOR_ERROR"
+        case .walletInvalidSignerProvided: "WALLET_INVALID_SIGNER"
+        case .transactionNotFound: "TRANSACTION_NOT_FOUND"
+        case .invalidChain: "INVALID_CHAIN"
+        case .invalidToken: "INVALID_TOKEN"
+        case .signerNotRegistered: "SIGNER_NOT_REGISTERED"
         }
     }
 
+    public var message: String {
+        switch self {
+        case .serviceError(let error):
+            error.message
+        case .walletInvalidType(let detail), .walletGeneric(let detail), .walletCreationFailed(let detail):
+            detail
+        case .walletNotFound:
+            "Wallet not found"
+        case .walletInvalidCredentials:
+            "The credentials provided are invalid for this wallet."
+        case .walletLocatorError(let locator):
+            "Invalid wallet locator: \(locator)"
+        case .transactionNotFound:
+            "Transaction not found"
+        case .walletInvalidSignerProvided:
+            "The provided admin signer and the received one do not match"
+        case .walletCreationCancelled:
+            "Creation cancelled."
+        case .invalidChain(let chain):
+            "Invalid chain: \(chain.name)"
+        case .invalidToken(let token):
+            "Invalid token: \(token.name)"
+        case .signerNotRegistered(let locator):
+            "Signer \"\(locator)\" is not registered on this wallet. Call addSigner first."
+        }
+    }
+
+    public var recoverySuggestion: String? {
+        switch self {
+        case .walletNotFound:
+            "Create a wallet using wallets.getOrCreate(chain:signer:)"
+        case .walletInvalidCredentials:
+            "Verify your signer configuration matches the wallet's registered signer."
+        case .signerNotRegistered:
+            "Call addSigner before attempting operations that require this signer."
+        case .invalidChain:
+            "Check the list of supported chains for this environment."
+        case .walletLocatorError:
+            "Ensure the wallet locator is in the correct format."
+        default:
+            nil
+        }
+    }
+
+    public var underlyingError: Swift.Error? {
+        guard case .serviceError(let error) = self else { return nil }
+        return error
+    }
+}
+
+extension WalletError: CrossmintMappableError {
     public static func fromServiceError(_ error: CrossmintServiceError) -> WalletError {
         .serviceError(error)
     }

--- a/Tests/CrossmintServiceTests/CrossmintErrorTests.swift
+++ b/Tests/CrossmintServiceTests/CrossmintErrorTests.swift
@@ -1,0 +1,67 @@
+import Testing
+@testable import CrossmintService
+
+struct CrossmintErrorTests {
+
+    // MARK: - CrossmintServiceError
+
+    @Test("CrossmintServiceError.unknown has expected code and message")
+    func crossmintServiceErrorUnknown() {
+        let error = CrossmintServiceError.unknown
+        #expect(error.code == "SERVICE_ERROR")
+        #expect(error.message == "Unknown error")
+        #expect(error.recoverySuggestion == nil)
+        #expect(error.underlyingError == nil)
+    }
+
+    @Test("CrossmintServiceError.invalidData carries detail in message")
+    func crossmintServiceErrorInvalidData() {
+        let error = CrossmintServiceError.invalidData("bad JSON")
+        #expect(error.code == "INVALID_DATA")
+        #expect(error.message == "Invalid data: bad JSON")
+    }
+
+    @Test("CrossmintServiceError.invalidApiKey has recovery suggestion")
+    func crossmintServiceErrorInvalidApiKey() {
+        let error = CrossmintServiceError.invalidApiKey("key123")
+        #expect(error.code == "INVALID_API_KEY")
+        #expect(error.recoverySuggestion != nil)
+    }
+
+    @Test("CrossmintServiceError.timeout has recovery suggestion")
+    func crossmintServiceErrorTimeout() {
+        let error = CrossmintServiceError.timeout
+        #expect(error.code == "TIMEOUT")
+        #expect(error.recoverySuggestion != nil)
+    }
+
+    @Test("CrossmintServiceError.invalidURL has expected code")
+    func crossmintServiceErrorInvalidURL() {
+        let error = CrossmintServiceError.invalidURL
+        #expect(error.code == "INVALID_URL")
+        #expect(error.message == "Invalid URL")
+    }
+
+    // MARK: - description format
+
+    @Test("CrossmintError description includes code and message")
+    func descriptionIncludesCodeAndMessage() {
+        let error = CrossmintServiceError.unknown
+        let desc = error.description
+        #expect(desc.contains("[SERVICE_ERROR]"))
+        #expect(desc.contains("Unknown error"))
+    }
+
+    @Test("CrossmintError description includes recovery suggestion when present")
+    func descriptionIncludesRecoverySuggestion() {
+        let error = CrossmintServiceError.invalidApiKey("bad-key")
+        let desc = error.description
+        #expect(desc.contains("Recovery:"))
+    }
+
+    @Test("CrossmintError description omits recovery section when nil")
+    func descriptionOmitsRecoveryWhenNil() {
+        let error = CrossmintServiceError.unknown
+        #expect(!error.description.contains("Recovery:"))
+    }
+}

--- a/Tests/CrossmintServiceTests/CrossmintErrorTests.swift
+++ b/Tests/CrossmintServiceTests/CrossmintErrorTests.swift
@@ -25,14 +25,14 @@ struct CrossmintErrorTests {
     func crossmintServiceErrorInvalidApiKey() {
         let error = CrossmintServiceError.invalidApiKey("key123")
         #expect(error.code == "INVALID_API_KEY")
-        #expect(error.recoverySuggestion != nil)
+        #expect(error.recoverySuggestion == "Verify your API key in the Crossmint developer console.")
     }
 
     @Test("CrossmintServiceError.timeout has recovery suggestion")
     func crossmintServiceErrorTimeout() {
         let error = CrossmintServiceError.timeout
         #expect(error.code == "TIMEOUT")
-        #expect(error.recoverySuggestion != nil)
+        #expect(error.recoverySuggestion == "Check your network connection and retry the request.")
     }
 
     @Test("CrossmintServiceError.invalidURL has expected code")
@@ -62,6 +62,6 @@ struct CrossmintErrorTests {
     @Test("CrossmintError description omits recovery section when nil")
     func descriptionOmitsRecoveryWhenNil() {
         let error = CrossmintServiceError.unknown
-        #expect(!error.description.contains("Recovery:"))
+        #expect(error.description == "[SERVICE_ERROR] Unknown error")
     }
 }

--- a/Tests/CrossmintServiceTests/RequestEncodingUtilityTests.swift
+++ b/Tests/CrossmintServiceTests/RequestEncodingUtilityTests.swift
@@ -25,7 +25,7 @@ struct RequestEncodingUtilityTest {
         }
     }
 
-    enum MockServiceError: ServiceError {
+    enum MockServiceError: CrossmintMappableError {
         case serviceError(CrossmintServiceError)
         case customError(String)
 
@@ -37,17 +37,22 @@ struct RequestEncodingUtilityTest {
             .customError(error.localizedDescription)
         }
 
-        var errorMessage: String {
+        var code: String {
             switch self {
-            case .serviceError(let error):
-                return error.errorMessage
-            case .customError(let message):
-                return message
+            case .serviceError(let error): error.code
+            case .customError: "CUSTOM_ERROR"
+            }
+        }
+
+        var message: String {
+            switch self {
+            case .serviceError(let error): error.message
+            case .customError(let detail): detail
             }
         }
     }
 
-    enum AnotherMockServiceError: ServiceError {
+    enum AnotherMockServiceError: CrossmintMappableError {
         case wrapped(CrossmintServiceError)
         case other(String)
 
@@ -59,12 +64,17 @@ struct RequestEncodingUtilityTest {
             .other(error.localizedDescription)
         }
 
-        var errorMessage: String {
+        var code: String {
             switch self {
-            case .wrapped(let error):
-                return "Wrapped: \(error.errorMessage)"
-            case .other(let message):
-                return "Other: \(message)"
+            case .wrapped(let error): error.code
+            case .other: "OTHER_ERROR"
+            }
+        }
+
+        var message: String {
+            switch self {
+            case .wrapped(let error): "Wrapped: \(error.message)"
+            case .other(let detail): "Other: \(detail)"
             }
         }
     }
@@ -142,10 +152,8 @@ struct RequestEncodingUtilityTest {
             errorType: MockServiceError.self
         )
 
-        // Verify we got valid JSON data
         #expect(result.count > 0)
 
-        // Verify it's valid JSON by decoding
         let json = try JSONSerialization.jsonObject(with: result) as? [String: Any]
         #expect(json?["name"] as? String == "real_test")
         #expect(json?["value"] as? Int == 999)
@@ -271,8 +279,8 @@ struct RequestEncodingUtilityTest {
         }
     }
 
-    @Test("Works with different ServiceError types")
-    func worksWithDifferentServiceErrorTypes() {
+    @Test("Works with different CrossmintMappableError types")
+    func worksWithDifferentCrossmintMappableErrorTypes() {
         let expectedData = Data("type_test".utf8)
         let mockCoder = MockSuccessJSONCoder(expectedData: expectedData)
         let testRequest = TestRequest(name: "type_test", value: 1)
@@ -294,8 +302,8 @@ struct RequestEncodingUtilityTest {
         #expect(result2 == expectedData)
     }
 
-    @Test("Error type mapping works correctly for different ServiceError implementations")
-    func errorTypeMappingWorksCorrectlyForDifferentServiceErrorImplementations() {
+    @Test("Error type mapping works correctly for different CrossmintMappableError implementations")
+    func errorTypeMappingWorksCorrectlyForDifferentCrossmintMappableErrorImplementations() {
         let mockCoder = MockFailingJSONCoder(errorToThrow: .invalidData("Mapping test"))
         let testRequest = TestRequest(name: "test", value: 42)
 
@@ -307,7 +315,7 @@ struct RequestEncodingUtilityTest {
             )
         } throws: { error in
             if case .serviceError(let serviceError) = error as? MockServiceError {
-                return serviceError.errorMessage == "Invalid data: Mapping test"
+                return serviceError.message == "Invalid data: Mapping test"
             }
             return false
         }
@@ -320,7 +328,7 @@ struct RequestEncodingUtilityTest {
             )
         } throws: { error in
             if case .wrapped(let serviceError) = error as? AnotherMockServiceError {
-                return serviceError.errorMessage == "Invalid data: Mapping test"
+                return serviceError.message == "Invalid data: Mapping test"
             }
             return false
         }
@@ -380,14 +388,12 @@ struct RequestEncodingUtilityTest {
         let mockCoder = MockSuccessJSONCoder(expectedData: expectedData)
         let testRequest = TestRequest(name: "consistency", value: 789)
 
-        // Test with RequestEncodingUtility
         let utilityResult = try RequestEncodingUtility.encodeRequest(
             testRequest,
             using: mockCoder,
             errorType: MockServiceError.self
         )
 
-        // Test with JSONCoder extension
         let extensionResult = try mockCoder.encodeRequest(
             testRequest,
             errorType: MockServiceError.self
@@ -409,7 +415,6 @@ struct RequestEncodingUtilityTest {
 
         #expect(result.count > 0)
 
-        // Verify it's valid JSON
         let json = try JSONSerialization.jsonObject(with: result) as? [String: Any]
         #expect(json?["name"] as? String == "real_extension_test")
         #expect(json?["value"] as? Int == 321)

--- a/Tests/WalletTests/Model/WalletErrorTests.swift
+++ b/Tests/WalletTests/Model/WalletErrorTests.swift
@@ -13,7 +13,7 @@ struct WalletErrorTests {
         let error = WalletError.walletNotFound
         #expect(error.code == "WALLET_NOT_FOUND")
         #expect(error.message == "Wallet not found")
-        #expect(error.recoverySuggestion != nil)
+        #expect(error.recoverySuggestion == "Create a wallet using wallets.getOrCreate(chain:signer:)")
         #expect(error.underlyingError == nil)
     }
 
@@ -29,7 +29,7 @@ struct WalletErrorTests {
     func signerNotRegistered() {
         let error = WalletError.signerNotRegistered("0xabc")
         #expect(error.code == "SIGNER_NOT_REGISTERED")
-        #expect(error.recoverySuggestion != nil)
+        #expect(error.recoverySuggestion == "Call addSigner before attempting operations that require this signer.")
         #expect(error.underlyingError == nil)
     }
 

--- a/Tests/WalletTests/Model/WalletErrorTests.swift
+++ b/Tests/WalletTests/Model/WalletErrorTests.swift
@@ -1,0 +1,101 @@
+import CrossmintCommonTypes
+import CrossmintService
+import Testing
+
+@testable import Wallet
+
+struct WalletErrorTests {
+
+    // MARK: - WalletError
+
+    @Test("WalletError.walletNotFound has expected code and recovery suggestion")
+    func walletNotFound() {
+        let error = WalletError.walletNotFound
+        #expect(error.code == "WALLET_NOT_FOUND")
+        #expect(error.message == "Wallet not found")
+        #expect(error.recoverySuggestion != nil)
+        #expect(error.underlyingError == nil)
+    }
+
+    @Test("WalletError.walletCreationFailed carries reason in message")
+    func walletCreationFailed() {
+        let error = WalletError.walletCreationFailed("timeout")
+        #expect(error.code == "WALLET_CREATION_FAILED")
+        #expect(error.message == "timeout")
+        #expect(error.recoverySuggestion == nil)
+    }
+
+    @Test("WalletError.signerNotRegistered has recovery suggestion")
+    func signerNotRegistered() {
+        let error = WalletError.signerNotRegistered("0xabc")
+        #expect(error.code == "SIGNER_NOT_REGISTERED")
+        #expect(error.recoverySuggestion != nil)
+        #expect(error.underlyingError == nil)
+    }
+
+    @Test("WalletError.serviceError wraps underlying error")
+    func serviceError() {
+        let inner = CrossmintServiceError.invalidApiKey("bad-key")
+        let error = WalletError.serviceError(inner)
+        #expect(error.code == "SERVICE_ERROR")
+        #expect(error.message == inner.message)
+        #expect(error.underlyingError != nil)
+    }
+
+    @Test("WalletError conforms to CrossmintError and description is formatted")
+    func descriptionFormat() {
+        let error = WalletError.walletNotFound
+        let desc = error.description
+        #expect(desc.contains("[WALLET_NOT_FOUND]"))
+        #expect(desc.contains("Wallet not found"))
+        #expect(desc.contains("Recovery:"))
+    }
+
+    // MARK: - TransactionError
+
+    @Test("TransactionError.transactionNotFound has expected code")
+    func transactionNotFound() {
+        let error = TransactionError.transactionNotFound
+        #expect(error.code == "TRANSACTION_NOT_FOUND")
+        #expect(error.message == "Transaction not found")
+    }
+
+    @Test("TransactionError.userCancelled has no recovery suggestion")
+    func userCancelled() {
+        let error = TransactionError.userCancelled
+        #expect(error.code == "USER_CANCELLED")
+        #expect(error.recoverySuggestion == nil)
+    }
+
+    @Test("TransactionError.transactionSigningFailed exposes underlying error")
+    func transactionSigningFailed() {
+        let inner = CrossmintServiceError.timeout
+        let error = TransactionError.transactionSigningFailed(inner)
+        #expect(error.code == "TRANSACTION_SIGNING_FAILED")
+        #expect(error.underlyingError != nil)
+    }
+
+    @Test("TransactionError.invalidApprovals includes counts in message")
+    func invalidApprovals() {
+        let error = TransactionError.invalidApprovals(expected: 2, actual: 1)
+        #expect(error.code == "INVALID_APPROVALS")
+        #expect(error.message.contains("2"))
+        #expect(error.message.contains("1"))
+    }
+
+    // MARK: - SignatureError
+
+    @Test("SignatureError.creationFailed has expected code")
+    func signatureCreationFailed() {
+        let error = SignatureError.creationFailed
+        #expect(error.code == "SIGNATURE_CREATION_FAILED")
+        #expect(error.recoverySuggestion == nil)
+    }
+
+    @Test("SignatureError.serviceError exposes underlying error")
+    func signatureServiceError() {
+        let inner = CrossmintServiceError.unknown
+        let error = SignatureError.serviceError(inner)
+        #expect(error.underlyingError != nil)
+    }
+}


### PR DESCRIPTION
This PR introduces `CrossmintError`, a public protocol that gives every SDK error a consistent shape: `code`, `message`, `recoverySuggestion`, and `underlyingError`. Before this, each error type had its own surface with no shared contract.

There's also `CrossmintMappableError`, which extends it with factory methods the HTTP layer uses internally. It's public due to a Swift limitation around `package` access in protocol requirements, but app code shouldn't adopt it directly.

## Changes

- Adds `CrossmintError` and `CrossmintMappableError` to `Sources/CrossmintService/CrossmintError.swift`
- Removes `ServiceError` from `CrossmintService.swift`; all `E: ServiceError` generic constraints across `DefaultCrossmintService`, `AuthenticatedCrossmintService`, `RequestEncodingUtility`, and `JSONCoder` are now `E: CrossmintMappableError`
- Retrofits `WalletError`, `TransactionError`, `SignatureError`, `AuthError`, and `AuthManagerError` with `code`, `message`, `recoverySuggestion`, and `underlyingError`
- `CrossmintServiceError` conforms to `CrossmintError` directly (it's the source type, not a consumer of the mapping layer)
- Adds `message` to `DeviceSignerError` and cleans up placeholder comments that were waiting for this protocol to land
- Renames `error.errorMessage` to `error.message` across `DefaultAuthManager`, `Wallet.swift`, and `Wallet+Transactions.swift`
- Adds `CrossmintErrorTests` and `WalletErrorTests` covering codes, messages, recovery suggestions, and description format