### PR TITLE
Add DocC documentation to the public SDK surface

### DIFF
--- a/Sources/CrossmintAuth/AuthClient.swift
+++ b/Sources/CrossmintAuth/AuthClient.swift
@@ -1,12 +1,31 @@
-//
-//  AuthClient.swift
-//  CrossmintSDK
-//
-//  Created by Tomas Martins on 6/1/26.
-//
-
+/// Standalone authentication client for apps that manage auth independently of wallet operations.
+///
+/// Access via ``CrossmintSDK/authClient``. For most apps the built-in email OTP flow through
+/// ``CrossmintAuthManager`` is sufficient; use `AuthClient` when you need explicit control over
+/// the OTP lifecycle (e.g. custom UI, headless flows).
+///
+/// ## Example
+/// ```swift
+/// let client = CrossmintSDK.shared.authClient
+///
+/// let request = try await client.sendOTP(to: "user@example.com")
+/// // ... show OTP input to user ...
+/// let session = try await client.verifyOTP(code: userInput, requestId: request.requestId)
+/// print("Signed in:", session.user.email)
+/// ```
 public protocol AuthClient: Sendable {
+    /// Sends an OTP to the given email address.
+    ///
+    /// - Returns: An ``OTPRequest`` whose ``OTPRequest/requestId`` is required by ``verifyOTP(code:requestId:)``.
     func sendOTP(to email: String) async throws(AuthError) -> OTPRequest
+
+    /// Validates the OTP and establishes a session.
+    ///
+    /// - Parameters:
+    ///   - code: The code the user entered.
+    ///   - requestId: The value from the ``OTPRequest`` returned by ``sendOTP(to:)``.
     func verifyOTP(code: String, requestId: String) async throws(AuthError) -> AuthSession
+
+    /// Invalidates the current session.
     func logout() async
 }

--- a/Sources/CrossmintAuth/AuthClient.swift
+++ b/Sources/CrossmintAuth/AuthClient.swift
@@ -1,3 +1,10 @@
+//
+//  AuthClient.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 6/1/26.
+//
+
 /// Standalone authentication client for apps that manage auth independently of wallet operations.
 ///
 /// Access via ``CrossmintSDK/authClient``. For most apps the built-in email OTP flow through

--- a/Sources/CrossmintAuth/AuthManager.swift
+++ b/Sources/CrossmintAuth/AuthManager.swift
@@ -2,17 +2,27 @@ import CrossmintService
 import Foundation
 import Logger
 
+/// Provides the current user's JWT to the SDK for authenticated requests.
+///
+/// The built-in implementation is ``CrossmintAuthManager``, which handles email OTP sessions.
+/// Provide a custom conformance to integrate an existing auth system — only ``jwt`` and
+/// ``setJWT(_:)`` are required.
 public protocol AuthManager: Sendable {
+    /// The current session JWT, or `nil` when the user is not authenticated.
     var jwt: String? { get async }
 
+    /// Injects an externally-obtained JWT into the SDK session.
     func setJWT(_ jwt: String) async
 }
 
 public enum AuthManagerError: CrossmintError, Equatable {
     case unknown(String)
     case serviceError(String)
+    /// The caller supplied a value that failed validation (e.g. an empty OTP code).
     case invalidInput(String)
+    /// The email address is not a valid format.
     case invalidEmail
+    /// ``CrossmintAuthManager/confirmEmailOtp(email:code:)`` was called before ``CrossmintAuthManager/sendEmailOtp(email:)``.
     case noPendingOTP
 
     public var code: String {
@@ -48,9 +58,13 @@ public enum AuthManagerError: CrossmintError, Equatable {
     }
 }
 
+/// The authentication state of the current session.
 public enum AuthenticationStatus: Sendable, Equatable {
+    /// No session exists.
     case nonAuthenticated
+    /// A stored refresh token is being exchanged for a JWT (transient state at startup).
     case authenticating
+    /// The user has a valid JWT. The `secret` is an opaque refresh token managed by the SDK.
     case authenticated(email: String, jwt: String, secret: String)
 
     public var isAuthenticated: Bool {
@@ -61,8 +75,11 @@ public enum AuthenticationStatus: Sendable, Equatable {
     }
 }
 
+/// Returned by OTP flow methods to indicate either session state or a pending email.
 public enum OTPAuthenticationStatus: Sendable, Equatable {
+    /// Wraps the underlying ``AuthenticationStatus``.
     case authenticationStatus(AuthenticationStatus)
+    /// An OTP email has been sent; ``CrossmintAuthManager/confirmEmailOtp(email:code:)`` is now expected.
     case emailSent(email: String, emailId: String)
 
     var isAuthenticating: Bool {

--- a/Sources/CrossmintAuth/AuthSession.swift
+++ b/Sources/CrossmintAuth/AuthSession.swift
@@ -1,11 +1,7 @@
-//
-//  AuthSession.swift
-//  CrossmintSDK
-//
-//  Created by Tomas Martins on 6/1/26.
-//
-
+/// The authenticated session returned after a successful OTP verification.
 public struct AuthSession: Sendable {
+    /// A short-lived JWT for authorizing requests to Crossmint APIs.
     public let jwt: String
+    /// Details about the authenticated user.
     public let user: AuthUser
 }

--- a/Sources/CrossmintAuth/AuthSession.swift
+++ b/Sources/CrossmintAuth/AuthSession.swift
@@ -1,3 +1,10 @@
+//
+//  AuthSession.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 6/1/26.
+//
+
 /// The authenticated session returned after a successful OTP verification.
 public struct AuthSession: Sendable {
     /// A short-lived JWT for authorizing requests to Crossmint APIs.

--- a/Sources/CrossmintAuth/AuthUser.swift
+++ b/Sources/CrossmintAuth/AuthUser.swift
@@ -1,3 +1,10 @@
+//
+//  AuthUser.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 6/1/26.
+//
+
 /// Identifies the authenticated user within an ``AuthSession``.
 public struct AuthUser: Sendable {
     public let email: String

--- a/Sources/CrossmintAuth/AuthUser.swift
+++ b/Sources/CrossmintAuth/AuthUser.swift
@@ -1,10 +1,4 @@
-//
-//  AuthUser.swift
-//  CrossmintSDK
-//
-//  Created by Tomas Martins on 6/1/26.
-//
-
+/// Identifies the authenticated user within an ``AuthSession``.
 public struct AuthUser: Sendable {
     public let email: String
 }

--- a/Sources/CrossmintAuth/Data/AuthError.swift
+++ b/Sources/CrossmintAuth/Data/AuthError.swift
@@ -1,9 +1,13 @@
 import CrossmintService
 import Http
 
+/// An error thrown by ``AuthClient`` and ``CrossmintAuthManager`` operations.
 public enum AuthError: CrossmintError {
+    /// A Crossmint API or network error. Inspect the associated ``CrossmintServiceError`` for details.
     case serviceError(CrossmintServiceError)
+    /// The session has expired or the operation requires authentication. Call ``AuthClient/sendOTP(to:)`` to sign in again.
     case signInRequired
+    /// An unexpected error with a descriptive message.
     case generic(String)
 
     public var code: String {

--- a/Sources/CrossmintAuth/DefaultAuthClient.swift
+++ b/Sources/CrossmintAuth/DefaultAuthClient.swift
@@ -7,6 +7,9 @@
 
 import Utils
 
+/// Built-in ``AuthClient`` implementation that routes through ``CrossmintAuthManager``.
+///
+/// Obtain via ``CrossmintSDK/authClient`` — do not instantiate directly.
 public actor DefaultAuthClient: AuthClient {
     private let authService: AuthService
     private let authManager: CrossmintAuthManager

--- a/Sources/CrossmintAuth/DefaultAuthManager.swift
+++ b/Sources/CrossmintAuth/DefaultAuthManager.swift
@@ -153,7 +153,9 @@ public actor CrossmintAuthManager: AuthManager {
 
     /// Clears the local session state without contacting the server.
     ///
-    /// Prefer ``logout()`` to also revoke the server-side refresh token.
+    /// Use this when the server session is already gone (e.g. the refresh token expired or was
+    /// revoked externally) and you just need to reset local state. Prefer ``logout()`` when the
+    /// session is still valid and you want to revoke the server-side token as well.
     public func reset() async -> OTPAuthenticationStatus {
         otpAuthenticationStatus = .authenticationStatus(.nonAuthenticated)
         return otpAuthenticationStatus

--- a/Sources/CrossmintAuth/DefaultAuthManager.swift
+++ b/Sources/CrossmintAuth/DefaultAuthManager.swift
@@ -7,7 +7,7 @@ import Utils
 ///
 /// ## OTP flow
 /// ```swift
-/// let auth = CrossmintSDK.shared.authManager as! CrossmintAuthManager
+/// let auth = CrossmintSDK.shared.authManager
 ///
 /// try await auth.sendEmailOtp(email: "user@example.com")
 /// // ... user enters the code from their inbox ...

--- a/Sources/CrossmintAuth/DefaultAuthManager.swift
+++ b/Sources/CrossmintAuth/DefaultAuthManager.swift
@@ -3,6 +3,21 @@ import CrossmintService
 import SecureStorage
 import Utils
 
+/// Built-in ``AuthManager`` that authenticates users via email OTP.
+///
+/// ## OTP flow
+/// ```swift
+/// let auth = CrossmintSDK.shared.authManager as! CrossmintAuthManager
+///
+/// try await auth.sendEmailOtp(email: "user@example.com")
+/// // ... user enters the code from their inbox ...
+/// let status = try await auth.confirmEmailOtp(email: "user@example.com", code: userInput)
+/// if status.isAuthenticated {
+///     print("Signed in as", status.email ?? "")
+/// }
+/// ```
+///
+/// The JWT is refreshed automatically before expiry; no app-level polling is required.
 public actor CrossmintAuthManager: AuthManager {
     enum Errors: Error {
         case noBundleIdFound
@@ -73,6 +88,7 @@ public actor CrossmintAuthManager: AuthManager {
     }
 #endif
 
+    /// Sends a one-time password to the given email address. Call ``confirmEmailOtp(email:code:)`` next.
     public func sendEmailOtp(email: String) async throws(AuthManagerError) {
         let normalizedEmail = normalizeEmail(email)
         guard isValidEmail(normalizedEmail) else {
@@ -87,6 +103,10 @@ public actor CrossmintAuthManager: AuthManager {
         }
     }
 
+    /// Validates the OTP code and, on success, establishes an authenticated session.
+    ///
+    /// Must be called after ``sendEmailOtp(email:)`` with the same email address.
+    /// Throws ``AuthManagerError/noPendingOTP`` if no email has been sent yet.
     public func confirmEmailOtp(email: String, code: String) async throws(AuthManagerError) -> OTPAuthenticationStatus {
         if code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             throw AuthManagerError.invalidInput("OTP code cannot be empty")
@@ -108,6 +128,9 @@ public actor CrossmintAuthManager: AuthManager {
         }
     }
 
+    /// Invalidates the server-side refresh token and clears the local session.
+    ///
+    /// Has no effect if the user is not currently authenticated.
     public func logout() async throws(AuthManagerError) -> OTPAuthenticationStatus {
         guard case let .authenticationStatus(.authenticated(_, _, secret)) = otpAuthenticationStatus else {
             Logger.auth.debug("User is not authenticated. Nothing to logout")
@@ -128,6 +151,9 @@ public actor CrossmintAuthManager: AuthManager {
         }
     }
 
+    /// Clears the local session state without contacting the server.
+    ///
+    /// Prefer ``logout()`` to also revoke the server-side refresh token.
     public func reset() async -> OTPAuthenticationStatus {
         otpAuthenticationStatus = .authenticationStatus(.nonAuthenticated)
         return otpAuthenticationStatus

--- a/Sources/CrossmintAuth/OTPRequest.swift
+++ b/Sources/CrossmintAuth/OTPRequest.swift
@@ -1,11 +1,6 @@
-//
-//  OTPRequest.swift
-//  CrossmintSDK
-//
-//  Created by Tomas Martins on 6/1/26.
-//
-
+/// Carries the identifier needed to verify an OTP sent by ``AuthClient/sendOTP(to:)``.
 public struct OTPRequest: Sendable, Identifiable {
     public var id: String { requestId }
+    /// Pass this to ``AuthClient/verifyOTP(code:requestId:)`` along with the user's code.
     public let requestId: String
 }

--- a/Sources/CrossmintAuth/OTPRequest.swift
+++ b/Sources/CrossmintAuth/OTPRequest.swift
@@ -1,3 +1,10 @@
+//
+//  OTPRequest.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 6/1/26.
+//
+
 /// Carries the identifier needed to verify an OTP sent by ``AuthClient/sendOTP(to:)``.
 public struct OTPRequest: Sendable, Identifiable {
     public var id: String { requestId }

--- a/Sources/CrossmintClient/CrossmintClient.docc/CrossmintClient.md
+++ b/Sources/CrossmintClient/CrossmintClient.docc/CrossmintClient.md
@@ -1,0 +1,62 @@
+# ``CrossmintClient``
+
+Add Crossmint smart wallets and user authentication to your iOS app.
+
+## Overview
+
+The SDK exposes two entry points:
+
+- **``CrossmintSDK``** — includes the built-in email OTP signing flow (TEE) with reactive
+  `isOTPRequired` state. Works with SwiftUI, UIKit, or any other framework.
+  Call ``CrossmintSDK/shared(apiKey:authManager:logLevel:)`` once at startup.
+- **``CrossmintClient``** — a lighter entry point for apps that supply a fully custom
+  ``AuthManager`` or do not need the email OTP machinery.
+  Call ``CrossmintClient/sdk(key:authManager:)`` and hold the returned ``ClientSDK`` yourself.
+
+Both routes give you a ``CrossmintWallets`` factory and an ``AuthManager``. Wallets are
+chain-specific: use ``EVMWallet`` for Ethereum-compatible chains and ``SolanaWallet`` for Solana.
+Email OTP authentication is built-in via ``CrossmintAuthManager``.
+
+## Topics
+
+### Setup
+
+- ``CrossmintSDK``
+- ``CrossmintClient``
+- ``ClientSDK``
+
+### Wallets
+
+- ``CrossmintWallets``
+- ``Wallet``
+- ``EVMWallet``
+- ``SolanaWallet``
+- ``WalletOptions``
+- ``WalletError``
+
+### Signing
+
+- ``SignerConfig``
+- ``TransactionError``
+- ``SignatureError``
+
+### Transactions & Transfers
+
+- ``Transaction``
+- ``TransactionSummary``
+- ``Transfer``
+- ``TransferListResult``
+
+### Balances & NFTs
+
+- ``Balance``
+- ``Balances``
+- ``NFT``
+
+### Authentication
+
+- ``CrossmintAuthManager``
+- ``AuthManager``
+- ``AuthManagerError``
+- ``AuthenticationStatus``
+- ``OTPAuthenticationStatus``

--- a/Sources/CrossmintClient/CrossmintClient.docc/CrossmintClient.md
+++ b/Sources/CrossmintClient/CrossmintClient.docc/CrossmintClient.md
@@ -35,6 +35,7 @@ Wallets are chain-specific: use ``EVMWallet`` for Ethereum-compatible chains and
 ### Transactions & Transfers
 
 - ``Transaction``
+- ``TransactionStatus``
 - ``TransactionSummary``
 - ``Transfer``
 - ``TransferListResult``

--- a/Sources/CrossmintClient/CrossmintClient.docc/CrossmintClient.md
+++ b/Sources/CrossmintClient/CrossmintClient.docc/CrossmintClient.md
@@ -4,26 +4,18 @@ Add Crossmint smart wallets and user authentication to your iOS app.
 
 ## Overview
 
-The SDK exposes two entry points:
+Call ``CrossmintSDK/configure(apiKey:logLevel:)`` once at app startup, then access
+``CrossmintSDK/shared`` anywhere. It gives you a ``CrossmintWallets`` factory, a
+``CrossmintAuthManager``, and an ``AuthClient`` for explicit OTP lifecycle control.
 
-- **``CrossmintSDK``** — includes the built-in email OTP signing flow (TEE) with reactive
-  `isOTPRequired` state. Works with SwiftUI, UIKit, or any other framework.
-  Call ``CrossmintSDK/shared(apiKey:authManager:logLevel:)`` once at startup.
-- **``CrossmintClient``** — a lighter entry point for apps that supply a fully custom
-  ``AuthManager`` or do not need the email OTP machinery.
-  Call ``CrossmintClient/sdk(key:authManager:)`` and hold the returned ``ClientSDK`` yourself.
-
-Both routes give you a ``CrossmintWallets`` factory and an ``AuthManager``. Wallets are
-chain-specific: use ``EVMWallet`` for Ethereum-compatible chains and ``SolanaWallet`` for Solana.
-Email OTP authentication is built-in via ``CrossmintAuthManager``.
+Wallets are chain-specific: use ``EVMWallet`` for Ethereum-compatible chains and
+``SolanaWallet`` for Solana. Email OTP authentication is built-in via ``CrossmintAuthManager``.
 
 ## Topics
 
 ### Setup
 
 - ``CrossmintSDK``
-- ``CrossmintClient``
-- ``ClientSDK``
 
 ### Wallets
 
@@ -57,6 +49,11 @@ Email OTP authentication is built-in via ``CrossmintAuthManager``.
 
 - ``CrossmintAuthManager``
 - ``AuthManager``
+- ``AuthClient``
+- ``DefaultAuthClient``
+- ``OTPRequest``
+- ``AuthSession``
+- ``AuthUser``
 - ``AuthManagerError``
 - ``AuthenticationStatus``
 - ``OTPAuthenticationStatus``

--- a/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
+++ b/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
@@ -10,6 +10,30 @@ import Web
 
 @MainActor private var sdkInstances = 0
 
+/// Entry point for the Crossmint SDK.
+///
+/// Call ``configure(apiKey:logLevel:)`` once at app startup before accessing ``shared``.
+/// Accessing ``shared`` before configuring causes a `fatalError`.
+///
+/// When using an email OTP signer, observe ``isOTPRequired`` to know when to display an OTP input,
+/// then call ``submit(otp:)`` with the code the user enters.
+///
+/// ## Example
+/// ```swift
+/// @main
+/// struct MyApp: App {
+///     init() {
+///         CrossmintSDK.configure(apiKey: "ck_development_...", logLevel: .warn)
+///     }
+///
+///     var body: some Scene {
+///         WindowGroup {
+///             ContentView()
+///                 .environmentObject(CrossmintSDK.shared)
+///         }
+///     }
+/// }
+/// ```
 @MainActor
 final public class CrossmintSDK: ObservableObject {
     @MainActor private static var _shared: CrossmintSDK?
@@ -24,8 +48,13 @@ final public class CrossmintSDK: ObservableObject {
         return instance
     }
 
-    /// Configures the SDK with the given API key. Must be called before accessing `CrossmintSDK.shared`.
-    /// Subsequent calls are ignored — the SDK can only be configured once per process.
+    /// Configures the SDK. Must be called once before accessing ``shared``.
+    ///
+    /// Subsequent calls are silently ignored — the SDK can only be configured once per process.
+    ///
+    /// - Parameters:
+    ///   - apiKey: A client API key (prefixed `ck_`).
+    ///   - logLevel: Controls SDK log verbosity. Defaults to `.error`.
     @MainActor public static func configure(apiKey: String, logLevel: LogLevel = .error) {
         guard _shared == nil else {
             Logger.sdk.warn("CrossmintSDK.configure() called after SDK is already configured — ignoring")
@@ -44,12 +73,17 @@ final public class CrossmintSDK: ObservableObject {
 
     let crossmintTEE: CrossmintTEE
 
+    /// Emits `true` when a pending transaction is waiting for the user to enter an email OTP.
     public var isOTPRequired: Published<Bool>.Publisher {
         crossmintTEE.$isOTPRequired
     }
+
+    /// Provides the OTP entered by the user to unblock the pending transaction.
     public func submit(otp: String) {
         crossmintTEE.provideOTP(otp)
     }
+
+    /// Cancels the pending transaction waiting for an OTP.
     public func cancelTransaction() {
         crossmintTEE.cancelOTP()
     }
@@ -95,6 +129,7 @@ final public class CrossmintSDK: ObservableObject {
         )
     }
 
+    /// Invalidates the server-side refresh token, clears the local session, and resets OTP state.
     public func logout() async {
         do {
             _ = try await authManager.logout()

--- a/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
+++ b/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
@@ -69,6 +69,7 @@ final public class CrossmintSDK: ObservableObject {
     public let crossmintWallets: CrossmintWallets
     public let authManager: CrossmintAuthManager
     public let crossmintService: CrossmintService
+    /// Standalone auth client for explicit OTP lifecycle management. See ``AuthClient``.
     public let authClient: AuthClient
 
     let crossmintTEE: CrossmintTEE

--- a/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
+++ b/Sources/CrossmintClient/SwiftUI/CrossmintSDK.swift
@@ -38,6 +38,7 @@ import Web
 final public class CrossmintSDK: ObservableObject {
     @MainActor private static var _shared: CrossmintSDK?
 
+    /// The configured SDK instance. Access after calling ``configure(apiKey:logLevel:)``.
     @MainActor public static var shared: CrossmintSDK {
         guard let instance = _shared else {
             fatalError(
@@ -66,8 +67,11 @@ final public class CrossmintSDK: ObservableObject {
 
     private let sdk: ClientSDK
 
+    /// Factory for creating and retrieving smart wallets. See ``CrossmintWallets``.
     public let crossmintWallets: CrossmintWallets
+    /// Authentication manager for the email OTP flow. See ``CrossmintAuthManager``.
     public let authManager: CrossmintAuthManager
+    /// Low-level Crossmint service for direct API access.
     public let crossmintService: CrossmintService
     /// Standalone auth client for explicit OTP lifecycle management. See ``AuthClient``.
     public let authClient: AuthClient
@@ -89,6 +93,7 @@ final public class CrossmintSDK: ObservableObject {
         crossmintTEE.cancelOTP()
     }
 
+    /// Whether the SDK is running against the Crossmint production environment.
     public var isProductionEnvironment: Bool {
         crossmintService.isProductionEnvironment
     }

--- a/Sources/Wallet/CrossmintWallets.swift
+++ b/Sources/Wallet/CrossmintWallets.swift
@@ -3,7 +3,7 @@ import CrossmintCommonTypes
 /// Factory for obtaining and creating Crossmint smart wallets.
 ///
 /// Obtain an instance from ``ClientSDK/crossmintWallets()`` or ``CrossmintSDK/crossmintWallets``.
-/// Prefer the chain-specific overloads (e.g. ``getWallet(chain:recovery:options:)-8u7wh``)
+/// Prefer the chain-specific overloads (e.g. ``getWallet(chain:recovery:options:)``)
 /// over the generic ones so you get a typed wallet back without an additional cast.
 ///
 /// ## Example

--- a/Sources/Wallet/CrossmintWallets.swift
+++ b/Sources/Wallet/CrossmintWallets.swift
@@ -1,12 +1,45 @@
 import CrossmintCommonTypes
 
+/// Factory for obtaining and creating Crossmint smart wallets.
+///
+/// Obtain an instance from ``ClientSDK/crossmintWallets()`` or ``CrossmintSDK/crossmintWallets``.
+/// Prefer the chain-specific overloads (e.g. ``getWallet(chain:recovery:options:)-8u7wh``)
+/// over the generic ones so you get a typed wallet back without an additional cast.
+///
+/// ## Example
+/// ```swift
+/// let wallets = CrossmintSDK.shared.crossmintWallets
+///
+/// // Get or create an EVM wallet with email recovery
+/// if let wallet = try await wallets.getWallet(chain: .baseMainnet, recovery: .email("user@example.com")) {
+///     print("Existing wallet:", wallet.address)
+/// } else {
+///     let wallet = try await wallets.createWallet(chain: .baseMainnet, recovery: .email("user@example.com"))
+///     print("New wallet:", wallet.address)
+/// }
+/// ```
 public protocol CrossmintWallets: Sendable {
+    /// Returns the wallet for the authenticated user on the given chain, or `nil` if none exists yet.
+    ///
+    /// - Parameters:
+    ///   - chain: The blockchain to look up.
+    ///   - recovery: The signer that can authorize recovery operations for this wallet.
+    ///   - options: Optional configuration, such as enabling a device signer.
     func getWallet(
         chain: Chain,
         recovery: any Signer,
         options: WalletOptions?
     ) async throws(WalletError) -> Wallet?
 
+    /// Creates a new smart wallet for the authenticated user on the given chain.
+    ///
+    /// Deploys the wallet contract on-chain. Calling this when a wallet already exists
+    /// returns the existing wallet rather than creating a duplicate.
+    ///
+    /// - Parameters:
+    ///   - chain: The blockchain to deploy to.
+    ///   - recovery: The signer that can authorize recovery operations for this wallet.
+    ///   - options: Optional configuration, such as enabling a device signer.
     func createWallet(
         chain: Chain,
         recovery: any Signer,
@@ -148,8 +181,13 @@ extension CrossmintWallets {
     }
 }
 
+/// Configuration for wallet creation and retrieval.
 public struct WalletOptions {
     let experimentalCallbacks: ExperimentalCallbacks?
+
+    /// When `true`, a device-bound signing key is generated in the Secure Enclave (or a software
+    /// keychain on devices without one) and registered as a delegated signer on the wallet.
+    /// Transactions can then be signed without an OTP prompt on that device.
     public let deviceSigner: Bool
 
     public init(deviceSigner: Bool = false) {

--- a/Sources/Wallet/Model/Transaction/TransactionStatus.swift
+++ b/Sources/Wallet/Model/Transaction/TransactionStatus.swift
@@ -1,6 +1,11 @@
+/// The lifecycle state of a transaction submitted through the Crossmint API.
 public enum TransactionStatus: String, Sendable {
+    /// Submitted to the API but not yet broadcast to the network.
     case pending
+    /// Waiting for one or more signers to approve before it can be submitted.
     case awaitingApproval = "awaiting-approval"
+    /// Confirmed on-chain.
     case success
+    /// Rejected or reverted on-chain.
     case failed
 }

--- a/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
+++ b/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
@@ -6,8 +6,8 @@ import Logger
 
 /// A Crossmint smart wallet on an EVM-compatible chain.
 ///
-/// Obtain an instance via ``CrossmintWallets/getWallet(chain:recovery:options:)-8u7wh``
-/// or ``CrossmintWallets/createWallet(chain:recovery:options:)-4u0gh``.
+/// Obtain an instance via ``CrossmintWallets/getWallet(chain:recovery:options:)``
+/// or ``CrossmintWallets/createWallet(chain:recovery:options:)``.
 open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
     public typealias SpecificChain = EVMChain
 

--- a/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
+++ b/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
@@ -11,6 +11,10 @@ import Logger
 open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
     public typealias SpecificChain = EVMChain
 
+    /// Casts a generic ``Wallet`` to ``EVMWallet``.
+    ///
+    /// Useful when you have a ``Wallet`` reference and need EVM-specific methods.
+    /// Throws ``WalletError`` if the wallet is not an EVM wallet.
     public static func from(wallet: Wallet) throws(WalletError) -> EVMWallet {
         guard let evmWallet = wallet as? EVMWallet else {
             throw .walletInvalidType("Cannot create an EVMWallet with the provided wallet")

--- a/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
+++ b/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
@@ -4,6 +4,10 @@ import DeviceSigner
 import Foundation
 import Logger
 
+/// A Crossmint smart wallet on an EVM-compatible chain.
+///
+/// Obtain an instance via ``CrossmintWallets/getWallet(chain:recovery:options:)-8u7wh``
+/// or ``CrossmintWallets/createWallet(chain:recovery:options:)-4u0gh``.
 open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
     public typealias SpecificChain = EVMChain
 
@@ -65,6 +69,24 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
         return transaction
     }
 
+    /// Sends a raw EVM transaction and polls until it is confirmed on-chain.
+    ///
+    /// - Parameters:
+    ///   - address: Recipient contract or EOA address (checksummed or lowercase hex).
+    ///   - value: Native token value in wei as a decimal string, e.g. `"1000000000000000"`. Pass `nil` or `"0"` for contract calls that transfer no ETH.
+    ///   - data: ABI-encoded call data as a `0x`-prefixed hex string. Pass `nil` or `"0x"` for plain ETH transfers.
+    ///   - chain: Target chain. Defaults to the chain the wallet was opened on.
+    ///
+    /// ## Example
+    /// ```swift
+    /// // Transfer 0.001 ETH
+    /// let summary = try await evmWallet.sendTransaction(
+    ///     to: "0xRecipient...",
+    ///     value: "1000000000000000",
+    ///     data: nil
+    /// )
+    /// print("Confirmed:", summary.explorerLink)
+    /// ```
     public func sendTransaction(
         to address: String,
         value: String?,
@@ -105,6 +127,18 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
         return completedTransaction.summary
     }
 
+    /// Signs an arbitrary message with this wallet.
+    ///
+    /// - Parameters:
+    ///   - message: The plain-text message to sign.
+    ///   - signer: Override which signer produces the signature. Defaults to the wallet's recovery signer.
+    ///   - isSmartWalletSignature: When `true` (default), produces an EIP-6492 smart-wallet-compatible
+    ///     signature. Set to `false` to produce a standard EOA signature instead.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let signature = try await evmWallet.signMessage("Hello, Crossmint!")
+    /// ```
     public func signMessage(
         _ message: String,
         signer: (any AdminSignerData)? = nil,
@@ -157,6 +191,12 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
         }
     }
 
+    /// Signs EIP-712 typed structured data with this wallet.
+    ///
+    /// - Parameters:
+    ///   - typedData: The structured data to sign, conforming to EIP-712.
+    ///   - signer: Override which signer produces the signature. Defaults to the wallet's recovery signer.
+    ///   - isSmartWalletSignature: See ``signMessage(_:signer:isSmartWalletSignature:)`` for semantics.
     public func signTypedData(
         _ typedData: EIP712.TypedData,
         signer: (any AdminSignerData)? = nil,

--- a/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
+++ b/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
@@ -73,7 +73,7 @@ public final class SolanaWallet: Wallet, WalletOnChain, @unchecked Sendable {
     /// ## Example
     /// ```swift
     /// let summary = try await solanaWallet.sendTransaction(transaction: base64EncodedTx)
-    /// print("Signature:", summary.txId)
+    /// print("Signature:", summary.hash)
     /// ```
     public func sendTransaction(
         transaction: String

--- a/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
+++ b/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
@@ -5,8 +5,8 @@ import Logger
 
 /// A Crossmint smart wallet on the Solana chain.
 ///
-/// Obtain an instance via ``CrossmintWallets/getWallet(chain:recovery:options:)-62jge``
-/// or ``CrossmintWallets/createWallet(chain:recovery:options:)-7e5ro``.
+/// Obtain an instance via ``CrossmintWallets/getWallet(chain:recovery:options:)``
+/// or ``CrossmintWallets/createWallet(chain:recovery:options:)``.
 public final class SolanaWallet: Wallet, WalletOnChain, @unchecked Sendable {
     public typealias SpecificChain = SolanaChain
 

--- a/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
+++ b/Sources/Wallet/Model/Wallet/Solana/SolanaWallet.swift
@@ -3,6 +3,10 @@ import DeviceSigner
 import Foundation
 import Logger
 
+/// A Crossmint smart wallet on the Solana chain.
+///
+/// Obtain an instance via ``CrossmintWallets/getWallet(chain:recovery:options:)-62jge``
+/// or ``CrossmintWallets/createWallet(chain:recovery:options:)-7e5ro``.
 public final class SolanaWallet: Wallet, WalletOnChain, @unchecked Sendable {
     public typealias SpecificChain = SolanaChain
 
@@ -62,6 +66,15 @@ public final class SolanaWallet: Wallet, WalletOnChain, @unchecked Sendable {
         return transaction
     }
 
+    /// Submits a serialized Solana transaction and polls until it is confirmed on-chain.
+    ///
+    /// - Parameter transaction: A base64-encoded, serialized Solana transaction.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let summary = try await solanaWallet.sendTransaction(transaction: base64EncodedTx)
+    /// print("Signature:", summary.txId)
+    /// ```
     public func sendTransaction(
         transaction: String
     ) async throws(TransactionError) -> TransactionSummary {

--- a/Sources/Wallet/Model/Wallet/TransactionSummary.swift
+++ b/Sources/Wallet/Model/Wallet/TransactionSummary.swift
@@ -1,7 +1,13 @@
 import Foundation
 
+/// A compact result returned after a token transfer is confirmed on-chain.
+///
+/// Returned by ``Wallet/send(_:_:_:idempotencyKey:)``.
 public struct TransactionSummary: Sendable {
+    /// The on-chain transaction hash.
     public let hash: String
+    /// The Crossmint transaction ID.
     public let transactionID: String
+    /// A block explorer URL for this transaction.
     public let explorerLink: URL
 }

--- a/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
@@ -7,6 +7,13 @@ extension Wallet {
 
     // MARK: - Public API
 
+    /// Approves and submits a pending transaction on behalf of the current signer.
+    ///
+    /// Use this when a transaction was created externally (e.g. via the Crossmint API) and
+    /// shows ``TransactionStatus/awaitingApproval``. The SDK signs the approval message and
+    /// polls until the transaction reaches a terminal state.
+    ///
+    /// - Parameter id: The transaction ID returned by the Crossmint API.
     public func approve(transactionId id: String) async throws(TransactionError) -> Transaction {
         Logger.smartWallet.info(LogEvents.walletApproveStart, attributes: [
             "transactionId": id
@@ -38,6 +45,14 @@ extension Wallet {
         }
     }
 
+    /// Removes an assigned signer from this wallet.
+    ///
+    /// Submits a remove-signer transaction on-chain. If the transaction requires approval,
+    /// the current signer signs it automatically before polling for completion.
+    ///
+    /// - Parameter locator: The signer locator string identifying the signer to remove
+    ///   (e.g. `"device:ABC123..."`, `"external-wallet:0x456..."`).
+    /// - Returns: The completed ``Transaction`` once the signer has been removed on-chain.
     public func removeSigner(locator: String) async throws(TransactionError) -> Transaction {
         Logger.smartWallet.info(LogEvents.walletRemoveSignerStart, attributes: [
             "locator": locator
@@ -113,6 +128,25 @@ extension Wallet {
         return transaction
     }
 
+    /// Transfers tokens to another wallet and polls until the transaction is confirmed on-chain.
+    ///
+    /// - Parameters:
+    ///   - walletLocator: Recipient address (e.g. `"0xABC..."` or a Solana public key).
+    ///   - tokenLocator: `"{chain}:{token}"`, e.g. `"base-sepolia:eth"` or `"solana:usdc"`.
+    ///   - amount: Amount as a human-readable decimal (e.g. `0.01` for 0.01 ETH).
+    ///   - idempotencyKey: Pass a stable key to prevent duplicate transactions on retry; omit to generate one automatically.
+    ///
+    /// - Returns: A ``TransactionSummary`` with the on-chain hash and explorer link once confirmed.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let summary = try await wallet.send(
+    ///     "0xRecipient...",
+    ///     "base-sepolia:usdc",
+    ///     5.0
+    /// )
+    /// print("Sent. Explorer:", summary.explorerLink)
+    /// ```
     public func send(
         _ walletLocator: String,
         _ tokenLocator: String,
@@ -144,6 +178,12 @@ extension Wallet {
         return transaction.summary
     }
 
+    /// Transfers an NFT or fungible token to a recipient.
+    ///
+    /// - Parameters:
+    ///   - tokenId: NFT token ID to transfer; omit for fungible token transfers.
+    ///   - recipient: Recipient address or wallet locator.
+    ///   - amount: Amount as a string (e.g. `"1"` for one NFT, or a fungible amount).
     public func transferToken(
         tokenId: String? = nil,
         recipient: TransferTokenRecipient,

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -91,6 +91,11 @@ open class Wallet: @unchecked Sendable {
         return walletModel.config.recovery.toDomain.locator == locator
     }
 
+    /// Returns a page of NFTs owned by this wallet.
+    ///
+    /// - Parameters:
+    ///   - page: Zero-based page index.
+    ///   - nftsPerPage: Number of NFTs per page.
     public func nfts(page: Int, nftsPerPage: Int) async throws(WalletError) -> [NFT] {
         try await smartWalletService.getNFTs(
             .init(walletLocator: .address(blockchainAddress), chain: chain, page: page, perPage: nftsPerPage)
@@ -152,6 +157,11 @@ open class Wallet: @unchecked Sendable {
         )
     }
 
+    /// Returns balances for the requested tokens, always including the chain's native token and USDC.
+    ///
+    /// - Parameters:
+    ///   - tokens: Additional tokens to include. Native token and USDC are always fetched.
+    ///   - chains: Additional chains to query. The wallet's own chain is always included.
     public func balances(
         _ tokens: [CryptoCurrency] = [],
         _ chains: [Chain] = []
@@ -183,6 +193,13 @@ open class Wallet: @unchecked Sendable {
         }
     }
 
+    /// Funds the wallet with test tokens from the Crossmint faucet.
+    ///
+    /// Only available in staging/development environments; throws in production.
+    ///
+    /// - Parameters:
+    ///   - token: The token to fund.
+    ///   - amount: Amount in the token's smallest unit (e.g. lamports for SOL, wei for ETH).
     public func fund(
         token: CryptoCurrency,
         amount: Int


### PR DESCRIPTION
This pull request adds DocC documentation to the public SDK surface. Every type, method, and property a developer is likely to interact with directly now has a doc comment, along with a landing page that organizes the module into logical topic groups.

The comments focus on what each thing is for and when to use it, not on restating what the signature already says. Main entry points (`CrossmintSDK.configure`, `getWallet`, `createWallet`, `sendTransaction`, `signMessage`, `AuthClient`) include a short code example.

## Changes

- **`CrossmintClient.docc/CrossmintClient.md`**: new DocC catalog landing page, organizes the module into Setup, Wallets, Signing, Transactions & Transfers, Balances & NFTs, and Authentication topic groups
- **`CrossmintSDK`**: class doc with setup example, docs on all public properties (`shared`, `crossmintWallets`, `authManager`, `authClient`, `crossmintService`, `isOTPRequired`, `isProductionEnvironment`) and methods (`configure`, `submit(otp:)`, `cancelTransaction`, `setJWT`, `logout`)
- **`CrossmintWallets`**: protocol doc with `getWallet`/`createWallet` examples, `WalletOptions` doc including the `deviceSigner` property
- **`Wallet`**: docs on `signers()`, `signerIsRegistered`, `nfts`, `listTransfers`, `balances`, `fund`; docs on `approve(transactionId:)`, `removeSigner`, `send(_:_:_:idempotencyKey:)`, and `transferToken` in `Wallet+Transactions.swift`
- **`EVMWallet`**: class doc, `from(wallet:)`, `sendTransaction(to:value:data:chain:)` with example, `signMessage` with `isSmartWalletSignature` explanation, `signTypedData`
- **`SolanaWallet`**: class doc and `sendTransaction` with base64 note
- **`TransactionStatus`**: new enum doc with all four cases (`pending`, `awaitingApproval`, `success`, `failed`)
- **`TransactionSummary`**: new struct doc with `hash`, `transactionID`, and `explorerLink`
- **`CrossmintAuthManager`**: class doc with full OTP flow example, `sendEmailOtp`, `confirmEmailOtp`, `logout`, `reset`
- **`AuthManager`**, **`AuthManagerError`**, **`AuthenticationStatus`**, **`OTPAuthenticationStatus`**: protocol and enum docs
- **`AuthClient`**: protocol doc with example, `sendOTP`, `verifyOTP`, `logout`; `DefaultAuthClient` class doc
- **`OTPRequest`**, **`AuthSession`**, **`AuthUser`**: type and property docs
- **`AuthError`**: enum doc with all three cases (`serviceError`, `signInRequired`, `generic`)
