### PR TITLE
Update CLAUDE.md with current architecture and engineering conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,88 +55,92 @@ make open
 
 ## Architecture Overview
 
-The Crossmint Swift SDK is being refactored toward a layered architecture defined in the [Mobile SDK API Review EDD](https://linear.app/crossmint/project/mobile-sdk-api-review-182dfa4d5add/overview). The sections below describe the **target architecture** — some parts are in flight. See the in-flight work list at the end of this section.
+The Crossmint Swift SDK follows a layered architecture with a configured singleton as the entry point, domain services for API communication, and chain-specific `Wallet` subclasses as the primary consumer-facing type. The [Mobile SDK API Review EDD](https://linear.app/crossmint/project/mobile-sdk-api-review-182dfa4d5add/overview) defines the long-term target; these sections describe the current state, with notes where the two diverge.
 
 ### Layered Architecture
 
 ```
-CrossmintSDK.shared                     (configured singleton — @MainActor)
-  ├── .wallets  (WalletClient protocol)
-  ├── .auth     (AuthClient protocol)
+CrossmintSDK.shared                     (@MainActor final class)
+  ├── .crossmintWallets  (CrossmintWallets)
+  ├── .authClient        (AuthClient protocol)
+  ├── .authManager       (CrossmintAuthManager)
+  ├── .crossmintService  (CrossmintService — internal detail, avoid in app code)
   └── setJWT(_:)
 
-WalletClient
-  └── getOrCreate(chain:signer:options:) → any Wallet
-  └── get(locator:) → any Wallet
+CrossmintWallets
+  └── getOrCreate(chain:signer:options:) → Wallet subclass
 
-Wallet (protocol — returned by WalletClient)
-  ├── send(to:token:amount:)
-  ├── sendTransaction(_:) / createTransaction(_:) / approve(transactionId:)
-  ├── signMessage(_:)
-  ├── balances(tokens:) / nfts(page:perPage:)
-  └── delegatedSigners() / addDelegatedSigner(_:)
+Wallet (open class — @unchecked Sendable; protocol refactor pending)
+  ├── balances(_:_:) / nfts(page:nftsPerPage:) / listTransfers(tokens:)
+  ├── signers() / signerIsRegistered(_:)
+  └── EVMWallet / SolanaWallet / StellarWallet (chain-specific subclasses)
+      [transaction/signing logic in Wallet+Transactions.swift extensions]
 
 --- INTERNAL ---
-Orchestrators (actors — coordinate multi-step flows)
-  ├── WalletOrchestrator   (getOrCreate flow)
-  └── TransactionOrchestrator  (send, sign, poll)
-
 Services (structs — single-responsibility API calls)
   WalletService / TransactionService / TransferService
-  BalanceService / NFTService / SignatureService
+  BalanceService / NFTService / SignatureService / SignerRegistrationService
 
 Infrastructure
-  AuthState (actor) / Logger / SecureStorage / HTTP Client
+  CrossmintAuth / Logger / SecureStorage / HTTP Client / DeviceSigner
 ```
 
 ### SDK Entry Point
 
-The singleton lives in `CrossmintCore`. Configuration wires together all clients:
+`CrossmintSDK` is a `@MainActor final class` in the `CrossmintClient` module:
 
 ```swift
-// Simple setup
-CrossmintSDK.configure(apiKey: "ck_staging_...")
+// Configure once, early in app startup
+CrossmintSDK.configure(apiKey: "ck_staging_...", logLevel: .error)
 
-// Advanced
-CrossmintSDK.configure(with: Configuration(apiKey: "ck_staging_...", logLevel: .debug))
+// Developer-managed auth (production — your backend issues the JWT)
+await CrossmintSDK.shared.setJWT(myJWT)
+await CrossmintSDK.shared.setJWT(nil)  // sign out
 
-// Custom auth (production)
-await CrossmintSDK.shared.setJWT(myJWTFromMyBackend)
-// Set to nil on sign out
+// Crossmint-managed auth (email/phone OTP)
+let authClient = CrossmintSDK.shared.authClient  // AuthClient protocol
+
+// Wallet access
+let wallets = CrossmintSDK.shared.crossmintWallets
 ```
 
-Environment (staging vs production) is decoded from the API key format — never pass it explicitly.
+Environment (staging vs production) is decoded from the API key format — never pass it explicitly. `crossmintService` is still a public property on the singleton but is an HTTP implementation detail — don't use it in application code.
 
-### Package Boundaries (Target)
+### Package Boundaries
 
 ```
-CrossmintCore          ← singleton shell, protocols, config, auth state, errors
-CrossmintTEE           ← TEEProvider protocol + MockTEEProvider (depends on Core)
-CrossmintWalletsImpl   ← wallet client, signers, orchestrators, services (depends on Core + TEE)
-CrossmintAuthImpl      ← auth client, OTP flow (depends on Core)
-CrossmintCheckoutImpl  ← checkout client + embedded view (depends on Core)
-CrossmintSDKProduct    ← assembly: configure() + wiring (depends on Core + TEE + all impls)
+CrossmintClient       ← SDK singleton (CrossmintSDK), SwiftUI integration, environment values
+CrossmintAuth         ← AuthClient protocol, OTP flow, JWT management
+Wallet                ← Wallet class, domain services, signers
+CrossmintCommonTypes  ← shared types (Chain, CryptoCurrency, BlockchainType, etc.)
+CrossmintService      ← HTTP client, request building, error mapping
+DeviceSigner          ← Secure Enclave key storage (zero external dependencies)
+Passkeys              ← Passkey authentication support
+SecureStorage         ← Keychain-based secure storage
+Http / Logger / Utils / Web ← infrastructure
 ```
 
-Public product imports: `CrossmintSDK` (everything), `CrossmintWallets`, `CrossmintAuth`.
+EDD target restructure: CrossmintCore, CrossmintWalletsImpl, CrossmintAuthImpl, CrossmintCheckoutImpl, CrossmintSDKProduct.
 
 ### Wallet
 
-`Wallet` is currently an `open class` with `@unchecked Sendable`. The target architecture (EDD) makes it a public protocol with an internal concrete implementation, but that refactor is still in progress. Chain-specific subclasses (`EVMWallet`, `SolanaWallet`, `StellarWallet`) extend it with chain-unique methods.
+`Wallet` is an `open class` with `@unchecked Sendable`. The EDD makes it a public protocol with an internal concrete implementation, but that refactor is still pending. Sign/poll logic was extracted into `Wallet+Transactions.swift` extensions (WAL-9976). Chain-specific subclasses (`EVMWallet`, `SolanaWallet`, `StellarWallet`) extend it with chain-unique methods.
 
 Add `.crossmintNonCustodialSigner()` to your root view when using email/phone signers — this injects the hidden WebView required for TEE communication.
 
 ### TEE Architecture
 
-`TEEProvider` is an internal protocol with swappable implementations: `WebViewTEEProvider` (current, WebView-based), `MockTEEProvider` (tests), and a future `DeviceTEEProvider` (Secure Enclave, no WebView). TEE is an implementation detail of email/phone signers — developers never interact with it directly.
+The TEE WebView lives in the `Wallet` module (`CrossmintTEE`). It handles auto-recovery from WebKit content-process termination internally. TEE is an implementation detail of email/phone signers — developers never interact with it directly.
+
+The EDD targets a `TEEProvider` protocol with swappable implementations (WebView-based, mock for tests, Secure Enclave future), but that abstraction hasn't landed yet.
 
 ### Auth State
 
-`AuthState` is an actor shared across all modules. `setJWT(_:)` on the singleton stores a developer-supplied token (no refresh). `AuthClient.verifyOTP()` stores both a JWT and refresh token and schedules auto-refresh. HTTP requests pick up the current token via `AuthMiddleware`.
+`CrossmintAuthManager` manages JWT state, persisting it to keychain. `setJWT(_:)` on the singleton stores a developer-supplied token (no refresh). `AuthClient.verifyOTP()` stores a JWT from Crossmint-managed auth. HTTP requests in the `Wallet` module inject the current JWT via `AuthenticatedCrossmintService`.
 
-### Error Protocol (Target)
+### Error Protocol
 
-All error types conform to `CrossmintError`:
+All error types conform to `CrossmintError` (WAL-9979, in progress):
 
 ```swift
 public protocol CrossmintError: Error, Sendable {
@@ -147,30 +151,17 @@ public protocol CrossmintError: Error, Sendable {
 }
 ```
 
-Domain errors: `WalletError`, `TransactionError`, `AuthError`, `SignerError`, `CheckoutError`.
+Domain errors: `WalletError`, `TransactionError`, `SignatureError`, `AuthError`.
 
 ### Services vs Orchestrators
 
 Services make exactly one API call per method — no orchestration, no polling. Orchestrators coordinate multi-step flows (signer init, create, sign, poll). Simple flows go client → service directly. Reach for an orchestrator only when a flow touches multiple services or requires retry/polling.
 
-### In-Flight Work (as of June 2026)
-
-| Issue | Summary | Status |
-|-------|---------|--------|
-| WAL-9974 / WAL-10195 / WAL-10196 | Singleton + configure() + setJWT | Done |
-| WAL-9977 | Auth client | Done |
-| WAL-9976 | Move sign/poll out of Wallet (extensions extracted; protocol refactor pending) | Done |
-| WAL-9978 / WAL-10194 | TEE refactor + TEEProvider protocol | Backlog |
-| WAL-9966 | OpenAPI HTTP client generation | Backlog |
-| WAL-9979 | Error protocol | In Progress |
-| WAL-9980 | Logging improvements | In Progress |
-| WAL-9981 | DocC documentation | In Progress (do last; API not stable) |
-
 ## Code Conventions
 
 ### Protocol-First Design
 
-Expose behavior through protocols, keep concrete types internal. If the protocol lives in `CrossmintCore`, the implementation lives in the feature module (`CrossmintWalletsImpl`, etc.). External consumers only import protocols and public value types.
+Expose behavior through protocols, keep concrete types internal. Protocols live in the same module as their primary consumer; implementations are `internal` or `package` unless they need to be subclassed. External consumers only import protocols and public value types.
 
 ### Naming
 
@@ -267,6 +258,14 @@ Functions should depend only on what they use. Prefer passing specific values ov
 ### Complexity Threshold
 
 Before adding background tasks, timers, or retry loops, check whether a simpler pre-call check would suffice, and whether the other SDKs (React Native, Kotlin) do the same thing. Complexity that isn't warranted by the feature and not matched cross-platform creates drift.
+
+### Swift Concurrency Patterns
+
+**Typed throws.** Use domain-typed errors where the failure set is known at the call site. The codebase uses `throws(WalletError)`, `throws(TransactionError)`, etc. Don't use untyped `throws` for internal methods whose errors are knowable — the compiler enforces exhaustiveness and eliminates the need for casts.
+
+**`@MainActor` propagation.** `CrossmintSDK` is `@MainActor`. Code that updates UI or calls into the singleton must run on the main actor. Use `await MainActor.run { }` to hop explicitly rather than `DispatchQueue.main.async` — that is UIKit-era code that breaks structured concurrency.
+
+**Structured concurrency.** Use `async let` for parallel independent calls. Use `TaskGroup` when the fan-out count is dynamic. Avoid `Task.detached` unless you explicitly need to break task inheritance (priority, cancellation, actor context) — detached tasks orphan work and make testing harder.
 
 ## Test Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,43 @@ Services make exactly one API call per method — no orchestration, no polling. 
 
 Expose behavior through protocols, keep concrete types internal. If the protocol lives in `CrossmintCore`, the implementation lives in the feature module (`CrossmintWalletsImpl`, etc.). External consumers only import protocols and public value types.
 
+### Naming
+
+Variable names must not duplicate the type or the name of the containing object:
+
+```swift
+// Bad — duplicates type info, duplicates containing type name
+struct Wallet {
+    var walletAddress: String   // "wallet" already in Wallet
+    var isValid: Bool           // "is" prefix duplicates Bool
+    var creationDate: Date      // "Date" redundant
+}
+
+// Good
+struct Wallet {
+    var address: String
+    var valid: Bool
+    var createdOn: Date
+}
+```
+
+Avoid vague verbs (`manage`, `handle`, `process`) in function and type names — they obscure responsibility. Use specific action names: `validateOrder`, `persistPayment`, `signTransaction`.
+
+Functions should do one thing. A name that requires "and" is a signal to split: `validateAndPersist` → `validate` + `persist`.
+
+### Abstraction Discipline
+
+Inline code unless the abstraction meets one of these criteria:
+- It self-documents a non-obvious relationship or hides significant complexity
+- It maintains state the algorithm requires across iterations
+- It has multiple, current implementations (e.g. a protocol with two concrete types in active use)
+
+A helper function that just renames a call, or a type that wraps only one thing, adds indirection without value. Remove it.
+
+### Business Logic Placement
+
+Business logic lives in orchestrators (and clients for simple cases), not in services. Services are generic and unaware of business context — they make API calls and return data. Orchestrators coordinate, retry, poll, and decide. Never let a service embed flow logic; never let a client embed multi-step coordination that warrants an orchestrator.
+
 ### Actors for Mutable Async State
 
 Use `actor` for any type that holds mutable state accessed from multiple async contexts. Never use `@unchecked Sendable` — fix the root cause (isolate to an actor or make the state immutable). If a framework type requires `@unchecked Sendable` on a mock, that is acceptable, but document why.
@@ -236,7 +273,11 @@ The same applies to stored properties: if a property is only read during `init`,
 
 ### Error Type Requirements
 
-All new error types must conform to `CrossmintError`. Error codes use `SCREAMING_SNAKE_CASE` (e.g., `WALLET_NOT_FOUND`). Provide a `recoverySuggestion` whenever the developer can take a specific action to fix the problem.
+All new error types must conform to `CrossmintError`. Error codes use `SCREAMING_SNAKE_CASE` (e.g., `WALLET_NOT_FOUND`). Provide a `recoverySuggestion` whenever the developer can take a specific action to fix the problem. Errors communicate exactly two things: whether the caller should retry, and whether the fault is theirs or the system's. Don't create subclasses or cases beyond what's needed to express those two distinctions.
+
+### Function Inputs
+
+Functions should depend only on what they use. Prefer passing specific values over large objects when only a subset of fields is needed — this keeps the function usable in a wider range of contexts and makes its dependencies explicit.
 
 ### Complexity Threshold
 
@@ -325,6 +366,20 @@ struct WalletCreationTests { ... }
 
 Staging tests: mark with `(STAG)` in the `@Test` display name and tag `.staging`. Use GUID-based Mailnesia detection for OTP (RSS items are not sorted chronologically).
 
+### Test Philosophy
+
+Hard-to-write tests are a signal to refactor production code, not to add test complexity. Tests are consumers of production interfaces — a test that requires a complex setup is asking for a cleaner dependency injection point or more expressive return values.
+
+When assertion logic grows complex (e.g. asserting 20 individual fields across multiple tests), that logic belongs on the production type as a method (like `isEqual`), not in the test.
+
+Each test case should be a distinct set of inputs and an expected output. Fix only the values relevant to what you're asserting and randomize everything else — incidental state should be invisible so readers immediately see what the test proves.
+
+Build a testing fabric where each layer tests different assumptions. Avoid tests that only verify data routing (a mocked value passes through unchanged, a parameter is forwarded to a dependency) — they mirror production logic and share its blind spots. Focus on boundary conditions and transformations.
+
+Mocks should only be used when there is no alternative — typically for resources unavailable in a test sandbox (network, disk, external services). Prefer factory-created objects with real or randomized data over mocks wherever possible.
+
+Tests must be fully isolated. Shared global state causes order-dependent failures that are expensive to diagnose.
+
 ### Hard Bans
 
 - No `@Suite(.serialized)` — causes a Swift compiler ICE. Use actor or Task coordination instead.
@@ -351,9 +406,14 @@ Staging tests: mark with `(STAG)` in the `@Test` display name and tag `.staging`
 
 - **Hardcoding environment or API version strings.** Environment comes from the API key. API versions come from a centralized constant or the OpenAPI generated client.
 
-## Scott's Best Practices
+## Documentation Rules
 
-TODO: Scott's best-practices documents were not found in Linear during the WAL-10266 update (searched all workspace documents and filtered by creator). Once located, add a summary here covering naming conventions, function length, comment style, public API discipline, and cross-SDK consistency rules.
+Document only what cannot be derived from the code or its version history. Source: `best-practices/documentation.md` and `best-practices/code/README.md`.
+
+- Comments and doc comments should only explain **why**, never **what** or **how** — if the what requires explanation, the code needs to be renamed or restructured.
+- TODOs should describe why something is suboptimal, not propose solutions (solutions change; the underlying problem is what matters).
+- Place documentation alongside the authoritative source whose scope it belongs to: code comments for code-level context, PR descriptions for why a decision was made, Linear issues for why it needs to change.
+- State each idea exactly once. Don't preview in an introduction what the detail immediately below already covers.
 
 ## Development Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Building the SDK
 ```bash
-# Build using xcodebuild directly
 make build
 ```
 
@@ -24,10 +23,9 @@ xcodebuild -scheme CrossmintClientSDK -destination "platform=iOS Simulator,name=
 
 ### Linting
 ```bash
-# Run SwiftLint to check for issues
 make lint
 
-# Run SwiftLint with auto-fix
+# auto-fix
 make lint-fix
 
 # Using swift package directly
@@ -42,13 +40,8 @@ make build-evm-demo
 
 ### Other Commands
 ```bash
-# Clean build artifacts
 make clean
-
-# Resolve Swift package dependencies
 make resolve
-
-# Open in Xcode
 make open
 # or double-click "Crossmint SDK.xcworkspace"
 ```
@@ -136,8 +129,6 @@ The TEE WebView lives in the `Wallet` module (`CrossmintTEE`). It handles auto-r
 
 ### Error Protocol
 
-All new error types must conform to `CrossmintError`:
-
 ```swift
 public protocol CrossmintError: Error, Sendable {
     var code: String { get }               // SCREAMING_SNAKE_CASE
@@ -153,247 +144,8 @@ Domain errors: `WalletError`, `TransactionError`, `SignatureError`, `AuthError`.
 
 Services make exactly one API call per method — no coordination, no polling. Multi-step flows (getOrCreate, sign + poll) live in the client (`DefaultCrossmintWallets`) or in `Wallet+Transactions.swift` extensions. Never embed flow logic or polling inside a service method.
 
-## Code Conventions
-
-### Protocol-First Design
-
-Expose behavior through protocols, keep concrete types internal. Protocols live in the same module as their primary consumer; implementations are `internal` or `package` unless they need to be subclassed. External consumers only import protocols and public value types.
-
-### Naming
-
-Variable names must not duplicate the type or the name of the containing object:
-
-```swift
-// Bad — duplicates type info, duplicates containing type name
-struct Wallet {
-    var walletAddress: String   // "wallet" already in Wallet
-    var isValid: Bool           // "is" prefix duplicates Bool
-    var creationDate: Date      // "Date" redundant
-}
-
-// Good
-struct Wallet {
-    var address: String
-    var valid: Bool
-    var createdOn: Date
-}
-```
-
-Avoid vague verbs (`manage`, `handle`, `process`) in function and type names — they obscure responsibility. Use specific action names: `validateOrder`, `persistPayment`, `signTransaction`.
-
-Functions should do one thing. A name that requires "and" is a signal to split: `validateAndPersist` → `validate` + `persist`.
-
-### Abstraction Discipline
-
-Inline code unless the abstraction meets one of these criteria:
-- It self-documents a non-obvious relationship or hides significant complexity
-- It maintains state the algorithm requires across iterations
-- It has multiple, current implementations (e.g. a protocol with two concrete types in active use)
-
-A helper function that just renames a call, or a type that wraps only one thing, adds indirection without value. Remove it.
-
-### Business Logic Placement
-
-Business logic lives in the client layer (`DefaultCrossmintWallets`, wallet extensions), not in services. Services are generic and unaware of business context — they make API calls and return data. Coordination, polling, and retry belong in the client or wallet layer.
-
-### Actors for Mutable Async State
-
-Use `actor` for any type that holds mutable state accessed from multiple async contexts. Never use `@unchecked Sendable` — fix the root cause (isolate to an actor or make the state immutable). If a framework type requires `@unchecked Sendable` on a mock, that is acceptable, but document why.
-
-### Optional JSON Body Fields
-
-Synthesized `Encodable` encodes `nil` optionals as `null`, which many APIs reject or misinterpret. When a field should be omitted from the body when `nil`, always implement `CodingKeys` + `encodeIfPresent` manually:
-
-```swift
-// Wrong — synthesized Encodable sends null for nil signer
-struct TransferBody: Encodable {
-    let to: String
-    let signer: String?  // encodes as null
-}
-
-// Right — encodeIfPresent omits the field entirely
-struct TransferBody: Encodable {
-    let to: String
-    let signer: String?
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(to, forKey: .to)
-        try container.encodeIfPresent(signer, forKey: .signer)
-    }
-}
-```
-
-### Simple Expressions Over Chains
-
-Split complex one-liners into named intermediate steps. Clarity beats brevity:
-
-```swift
-// Avoid — what does this do?
-let result = try await service.fetch(id: pending.pendingApproval?.id ?? "").flatMap { ... }
-
-// Prefer — each step is obvious
-guard let approvalId = pending.pendingApproval?.id else { return }
-let approval = try await service.fetch(id: approvalId)
-```
-
-### Public API Surface Discipline
-
-Before making anything `public`, ask: who outside this module calls this? If the answer is "only sibling modules," use `package` access. If the answer is "nobody yet," keep it `internal`. Exposing unnecessary public surface makes future refactors painful and forces semver consideration.
-
-The same applies to stored properties: if a property is only read during `init`, use a local variable instead.
-
-### Error Type Requirements
-
-All new error types must conform to `CrossmintError`. Error codes use `SCREAMING_SNAKE_CASE` (e.g., `WALLET_NOT_FOUND`). Provide a `recoverySuggestion` whenever the developer can take a specific action to fix the problem. Errors communicate exactly two things: whether the caller should retry, and whether the fault is theirs or the system's. Don't create subclasses or cases beyond what's needed to express those two distinctions.
-
-### Function Inputs
-
-Functions should depend only on what they use. Prefer passing specific values over large objects when only a subset of fields is needed — this keeps the function usable in a wider range of contexts and makes its dependencies explicit.
-
-### Complexity Threshold
-
-Before adding background tasks, timers, or retry loops, check whether a simpler pre-call check would suffice, and whether the other SDKs (React Native, Kotlin) do the same thing. Complexity that isn't warranted by the feature and not matched cross-platform creates drift.
-
-### Swift Concurrency Patterns
-
-**Typed throws.** Use domain-typed errors where the failure set is known at the call site. The codebase uses `throws(WalletError)`, `throws(TransactionError)`, etc. Don't use untyped `throws` for internal methods whose errors are knowable — the compiler enforces exhaustiveness and eliminates the need for casts.
-
-**`@MainActor` propagation.** `CrossmintSDK` is `@MainActor`. Code that updates UI or calls into the singleton must run on the main actor. Use `await MainActor.run { }` to hop explicitly rather than `DispatchQueue.main.async` — that is UIKit-era code that breaks structured concurrency.
-
-**Structured concurrency.** Use `async let` for parallel independent calls. Use `TaskGroup` when the fan-out count is dynamic. Avoid `Task.detached` unless you explicitly need to break task inheritance (priority, cancellation, actor context) — detached tasks orphan work and make testing harder.
-
-## Test Conventions
-
-Full reference: `docs/test-conventions.md`. Key rules inline:
-
-### Framework and File Layout
-
-- `import Testing` — not `import XCTest`
-- Test types are `struct` — not `class`
-- One test file per feature/concern: `Tests/<Module>Tests/<Domain>/<Feature>Tests.swift`
-- Mocks in `Tests/<Module>Tests/Mocks/Mock<Protocol>.swift` (one mock per protocol)
-- Helpers in `Tests/<Module>Tests/Helpers/<Feature>Helpers.swift`
-- JSON fixtures in `Tests/<Module>Tests/Resources/<Fixture>.json`, registered in `Package.swift`
-
-### Naming
-
-- Test functions: `camelCase`, BDD-style, no verb prefix
-- Good: `sendsOtpToValidEmail()`, `rejectsEmptyOtpCode()`, `returnsNilWhenWalletDoesNotExist()`
-- Bad: `shouldSendOtp()`, `itCanReject()`, `willReturn()`, `canFetch()`
-- Suite → Test names should read as a sentence: `Wallet Creation > rejects unknown chain string`
-- Constants: `UPPER_SNAKE_CASE`
-- Mock types: `Mock` prefix (`MockAuthService`, `MockSecureStorage`)
-
-### `@Suite` and `@Test`
-
-```swift
-@Suite("Wallet Creation")
-struct WalletCreationTests {
-    @Test func createsEVMWalletWithApiKeySigner() async throws { }
-
-    @Suite("when the chain is invalid")
-    struct InvalidChainTests {
-        @Test func rejectsUnknownChainString() throws { }
-    }
-}
-```
-
-### Assertions
-
-| Macro | When |
-|-------|------|
-| `#expect(condition)` | General assertion — test continues on failure |
-| `#require(condition)` | Halts test on failure (unwrapping, preconditions) |
-| `#expect(throws: ErrorType.self) { }` | Verify throw by type |
-| `#expect { } throws: { error in ... }` | Verify throw type and properties |
-
-### Mock Pattern
-
-```swift
-final class MockAuthService: AuthService, @unchecked Sendable {
-    var validateEmailCallCount = 0
-    var validateEmailLastRequest: ValidateEmailRequest?
-    var validateEmailError: AuthError?
-    var validateEmailResponse = ValidateEmailResponse(emailId: "mock-email-id")
-
-    func validateEmail(_ request: ValidateEmailRequest) async throws -> ValidateEmailResponse {
-        validateEmailCallCount += 1
-        validateEmailLastRequest = request
-        if let error = validateEmailError { throw error }
-        return validateEmailResponse
-    }
-}
-```
-
-Rules: track `callCount` + `lastRequest` per method. Make outcomes configurable via `var` with sensible defaults. Use `actor` instead of `@unchecked Sendable` when the mock holds mutable async state.
-
-### Tagging
-
-Define tags in `Tests/<AnyTarget>/Tags.swift`. Apply at suite level where possible:
-
-```swift
-extension Tag {
-    @Tag static var unit: Self
-    @Tag static var staging: Self
-    @Tag static var critical: Self
-    @Tag static var flaky: Self
-}
-
-@Suite("Wallet Creation", .tags(.critical))
-struct WalletCreationTests { ... }
-```
-
-Staging tests: mark with `(STAG)` in the `@Test` display name and tag `.staging`. Use GUID-based Mailnesia detection for OTP (RSS items are not sorted chronologically).
-
-### Test Philosophy
-
-Hard-to-write tests are a signal to refactor production code, not to add test complexity. Tests are consumers of production interfaces — a test that requires a complex setup is asking for a cleaner dependency injection point or more expressive return values.
-
-When assertion logic grows complex (e.g. asserting 20 individual fields across multiple tests), that logic belongs on the production type as a method (like `isEqual`), not in the test.
-
-Each test case should be a distinct set of inputs and an expected output. Fix only the values relevant to what you're asserting and randomize everything else — incidental state should be invisible so readers immediately see what the test proves.
-
-Build a testing fabric where each layer tests different assumptions. Avoid tests that only verify data routing (a mocked value passes through unchanged, a parameter is forwarded to a dependency) — they mirror production logic and share its blind spots. Focus on boundary conditions and transformations.
-
-Mocks should only be used when there is no alternative — typically for resources unavailable in a test sandbox (network, disk, external services). Prefer factory-created objects with real or randomized data over mocks wherever possible.
-
-Tests must be fully isolated. Shared global state causes order-dependent failures that are expensive to diagnose.
-
-### Hard Bans
-
-- No `@Suite(.serialized)` — causes a Swift compiler ICE. Use actor or Task coordination instead.
-- No `XCTest`
-- No `class` test types
-- No verb prefixes (`should`, `it`, `will`, `can`, `does`)
-- No testing of implementation details — test observable behavior through public or `@testable` internal APIs
-
-## Common Mistakes to Avoid
-
-- **Storing init-only values as properties.** If a value is used during `init` and never again, assign it to a local, not `self.property`. Stored properties signal that the value is needed beyond init.
-
-- **Leaking internal types into the public API.** The HTTP client (`crossmintService`), internal service types, and factory classes must not appear in any public protocol or `public` property. Before adding a `public` property, ask whether external developers actually need it.
-
-- **Synthesized `Encodable` with optional fields.** Synthesized conformance encodes `nil` as `null`. For any request body with optional fields, use `CodingKeys` + `encodeIfPresent`. See Code Conventions above.
-
-- **`@unchecked Sendable` to suppress concurrency errors.** This hides real data races. Fix the isolation instead — move state to an actor, make the type a value type, or properly annotate `@MainActor`.
-
-- **Adding a timer or background refresh without cross-SDK justification.** Always check whether a simpler pre-call expiry check would work, and whether the React Native and Kotlin SDKs do the same. Background tasks that aren't matched cross-platform create platform drift and maintenance burden.
-
-- **Chaining optional access with complex fallbacks in one expression.** Break it into steps. One-liners that need a comment to explain what they do should be multiple lines.
-
-- **Embedding flow logic in a service method.** Services make exactly one API call. Coordination, polling, and retry belong in the client or wallet layer.
-
-- **Hardcoding environment or API version strings.** Environment comes from the API key. API versions come from a centralized constant or the OpenAPI generated client.
-
-## Documentation Rules
-
-Document only what cannot be derived from the code or its version history.
-
-- Comments and doc comments should only explain **why**, never **what** or **how** — if the what requires explanation, the code needs to be renamed or restructured.
-- TODOs should describe why something is suboptimal, not propose solutions (solutions change; the underlying problem is what matters).
-- Place documentation alongside the authoritative source whose scope it belongs to: code comments for code-level context, PR descriptions for why a decision was made.
-- State each idea exactly once. Don't preview in an introduction what the detail immediately below already covers.
+@docs/conventions/code.md
+@docs/conventions/tests.md
 
 ## Development Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ make test
 make ci-test
 
 # Run specific test target
-xcodebuild -scheme CrossmintClientSDK -destination "platform=iOS Simulator,name=iPhone 16 Pro,OS=latest" test
+xcodebuild -scheme CrossmintClientSDK -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=latest" test
 ```
 
 ### Linting
@@ -418,11 +418,9 @@ Document only what cannot be derived from the code or its version history. Sourc
 ## Development Workflow
 
 1. All code must pass SwiftLint checks before merging (`make lint`).
-2. Tests run on iPhone 16 Pro simulator by default.
+2. Tests run on iPhone 17 Pro simulator by default.
 3. The SDK uses Swift Package Manager for dependency management.
 4. SwiftLint is integrated as a build tool plugin.
-5. Run `/afeight-review` before opening any PR.
-6. Run `/sdk-compare` whenever changing or adding anything on the public API surface — the TypeScript SDK (wallets-v1) is the canonical reference.
-7. Set these environment variables when running the demo app:
+5. Set these environment variables when running the demo app:
    - `CROSSMINT_API_KEY` — your Crossmint API key
    - `CROSSMINT_WHITELISTED_DOMAIN` — whitelisted domain for the SDK

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Building the SDK
 ```bash
-
 # Build using xcodebuild directly
 make build
 ```
@@ -56,75 +55,314 @@ make open
 
 ## Architecture Overview
 
-The Crossmint Swift SDK is a modular iOS SDK for integrating Crossmint services. The architecture follows a clean separation of concerns with distinct modules for different functionalities.
+The Crossmint Swift SDK is being refactored toward a layered architecture defined in the [Mobile SDK API Review EDD](https://linear.app/crossmint/project/mobile-sdk-api-review-182dfa4d5add/overview). The sections below describe the **target architecture** — some parts are in flight. See the in-flight work list at the end of this section.
 
-### Core Modules
+### Layered Architecture
 
-1. **CrossmintClient** - Main entry point providing the `ClientSDK` protocol implementation
-   - Aggregates all SDK functionality
-   - Provides access to wallets, authentication, and services
+```
+CrossmintSDK.shared                     (configured singleton — @MainActor)
+  ├── .wallets  (WalletClient protocol)
+  ├── .auth     (AuthClient protocol)
+  └── setJWT(_:)
 
-2. **Wallet** - Smart wallet functionality
-   - Generic `Wallet` protocol with specialized implementations (`EVMWallet`, `SolanaWallet`)
-   - Supports multiple signer types (EOA, Passkeys)
-   - Transaction creation, signing, and management
+WalletClient
+  └── getOrCreate(chain:signer:options:) → any Wallet
+  └── get(locator:) → any Wallet
 
-3. **Auth** - Authentication management
-   - OTP-based authentication flow
-   - JWT token management
-   - Session persistence
+Wallet (protocol — returned by WalletClient)
+  ├── send(to:token:amount:)
+  ├── sendTransaction(_:) / createTransaction(_:) / approve(transactionId:)
+  ├── signMessage(_:)
+  ├── balances(tokens:) / nfts(page:perPage:)
+  └── delegatedSigners() / addDelegatedSigner(_:)
 
-4. **Payments** - Payment processing
-   - Headless checkout functionality
-   - Embedded checkout UI components
-   - Multiple payment method support (crypto, card, express checkout)
+--- INTERNAL ---
+Orchestrators (actors — coordinate multi-step flows)
+  ├── WalletOrchestrator   (getOrCreate flow)
+  └── TransactionOrchestrator  (send, sign, poll)
 
-5. **CrossmintService** - Low-level API communication
-   - Request building and execution
-   - Error handling
-   - Environment configuration
+Services (structs — single-responsibility API calls)
+  WalletService / TransactionService / TransferService
+  BalanceService / NFTService / SignatureService
 
-### Supporting Modules
+Infrastructure
+  AuthState (actor) / Logger / SecureStorage / HTTP Client
+```
 
-- **CrossmintCommonTypes** - Shared types across modules (blockchains, currencies, etc.)
-- **SecureStorage** - Keychain-based secure storage for sensitive data
-- **Http** - Network layer abstraction
-- **Logger** - Unified logging system
-- **Utils** - Common utilities and extensions
-- **Passkeys** - Passkey authentication support
+### SDK Entry Point
 
-### Key Design Patterns
+The singleton lives in `CrossmintCore`. Configuration wires together all clients:
 
-1. **Protocol-Oriented Design**: Most functionality exposed through protocols (`ClientSDK`, `AuthManager`, `CrossmintWallets`, `Wallet`, etc.)
+```swift
+// Simple setup
+CrossmintSDK.configure(apiKey: "ck_staging_...")
 
-2. **Dependency Injection**: Modules depend on protocol abstractions rather than concrete implementations
+// Advanced
+CrossmintSDK.configure(with: Configuration(apiKey: "ck_staging_...", logLevel: .debug))
 
-3. **Error Handling**: Typed errors using Swift's throwing mechanism with specific error types per module
+// Custom auth (production)
+await CrossmintSDK.shared.setJWT(myJWTFromMyBackend)
+// Set to nil on sign out
+```
 
-4. **Async/Await**: Modern Swift concurrency throughout the codebase
+Environment (staging vs production) is decoded from the API key format — never pass it explicitly.
 
-5. **SwiftUI Integration**: Provides environment values and view modifiers for easy SwiftUI integration
+### Package Boundaries (Target)
 
-### Environment Configuration
+```
+CrossmintCore          ← singleton shell, protocols, config, auth state, errors
+CrossmintTEE           ← TEEProvider protocol + MockTEEProvider (depends on Core)
+CrossmintWalletsImpl   ← wallet client, signers, orchestrators, services (depends on Core + TEE)
+CrossmintAuthImpl      ← auth client, OTP flow (depends on Core)
+CrossmintCheckoutImpl  ← checkout client + embedded view (depends on Core)
+CrossmintSDKProduct    ← assembly: configure() + wiring (depends on Core + TEE + all impls)
+```
 
-When running the demo apps, set these environment variables:
-- `CROSSMINT_API_KEY` - Your Crossmint API key
-- `CROSSMINT_WHITELISTED_DOMAIN` - Whitelisted domain for the SDK
+Public product imports: `CrossmintSDK` (everything), `CrossmintWallets`, `CrossmintAuth`.
 
-## Test Structure
+### Wallet Protocol & Signers
 
-Tests are organized by module:
-- **CrossmintCommonTypesTests** - Tests for common types
-- **CrossmintServiceTests** - Service layer tests
-- **WalletTests** - Wallet functionality tests
-- **PaymentTests** - Payment processing tests
-- **UtilsTests** - Utility function tests
+`Wallet` is a public protocol — not a class. The concrete implementation is internal `WalletImpl`. Chain-specific extensions (e.g. `EVMWallet`) add chain-unique methods.
 
-Test resources (JSON fixtures) are included in each test target's Resources directory.
+Signer configuration uses a static-factory struct pattern for trailing-closure syntax:
+
+```swift
+let wallet = try await CrossmintSDK.shared.wallets.getOrCreate(
+    chain: .baseSepolia,
+    signer: .email("user@example.com", onAuthRequired: { flow in
+        // push flow into @State — closure returns immediately
+        // signer suspends internally until flow.verifyOTP() or flow.cancel()
+        await MainActor.run { otpFlow = flow }
+    })
+)
+```
+
+`OTPFlow` is a public struct with `sendOTP`, `verifyOTP`, and `cancel` closures. The signer suspends on a `CheckedContinuation` — the closure just delivers the flow object to the UI layer. Add `.crossmintWalletSigner()` to your root view when using email/phone signers.
+
+### TEE Architecture
+
+`TEEProvider` is an internal protocol with swappable implementations: `WebViewTEEProvider` (current, WebView-based), `MockTEEProvider` (tests), and a future `DeviceTEEProvider` (Secure Enclave, no WebView). TEE is an implementation detail of email/phone signers — developers never interact with it directly.
+
+### Auth State
+
+`AuthState` is an actor shared across all modules. `setJWT(_:)` on the singleton stores a developer-supplied token (no refresh). `AuthClient.verifyOTP()` stores both a JWT and refresh token and schedules auto-refresh. HTTP requests pick up the current token via `AuthMiddleware`.
+
+### Error Protocol (Target)
+
+All error types conform to `CrossmintError`:
+
+```swift
+public protocol CrossmintError: Error, Sendable {
+    var code: String { get }               // SCREAMING_SNAKE_CASE
+    var message: String { get }
+    var recoverySuggestion: String? { get }
+    var underlyingError: Error? { get }
+}
+```
+
+Domain errors: `WalletError`, `TransactionError`, `AuthError`, `SignerError`, `CheckoutError`.
+
+### Services vs Orchestrators
+
+Services make exactly one API call per method — no orchestration, no polling. Orchestrators coordinate multi-step flows (signer init, create, sign, poll). Simple flows go client → service directly. Reach for an orchestrator only when a flow touches multiple services or requires retry/polling.
+
+### In-Flight Work (as of June 2026)
+
+| Issue | Summary | Status |
+|-------|---------|--------|
+| WAL-9974 / WAL-10195 / WAL-10196 | Singleton + configure() + setJWT | In Review / Done |
+| WAL-10193 | OTPFlow callback pattern | In Review |
+| WAL-9977 | Auth client | In Progress |
+| WAL-9976 | Move sign/poll out of Wallet | In Progress |
+| WAL-10312 | Move onAuthRequired to WalletOptions.Callbacks | Backlog |
+| WAL-9978 / WAL-10194 | TEE refactor + TEEProvider protocol | Backlog |
+| WAL-9966 | OpenAPI HTTP client generation | Backlog |
+| WAL-9979 | Error protocol | Todo |
+| WAL-9980 | Logging improvements | Todo |
+| WAL-9981 | DocC documentation | Todo (blocked — do last; API not stable) |
+
+## Code Conventions
+
+### Protocol-First Design
+
+Expose behavior through protocols, keep concrete types internal. If the protocol lives in `CrossmintCore`, the implementation lives in the feature module (`CrossmintWalletsImpl`, etc.). External consumers only import protocols and public value types.
+
+### Actors for Mutable Async State
+
+Use `actor` for any type that holds mutable state accessed from multiple async contexts. Never use `@unchecked Sendable` — fix the root cause (isolate to an actor or make the state immutable). If a framework type requires `@unchecked Sendable` on a mock, that is acceptable, but document why.
+
+### Optional JSON Body Fields
+
+Synthesized `Encodable` encodes `nil` optionals as `null`, which many APIs reject or misinterpret. When a field should be omitted from the body when `nil`, always implement `CodingKeys` + `encodeIfPresent` manually:
+
+```swift
+// Wrong — synthesized Encodable sends null for nil signer
+struct TransferBody: Encodable {
+    let to: String
+    let signer: String?  // encodes as null
+}
+
+// Right — encodeIfPresent omits the field entirely
+struct TransferBody: Encodable {
+    let to: String
+    let signer: String?
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(to, forKey: .to)
+        try container.encodeIfPresent(signer, forKey: .signer)
+    }
+}
+```
+
+### Simple Expressions Over Chains
+
+Split complex one-liners into named intermediate steps. Clarity beats brevity:
+
+```swift
+// Avoid — what does this do?
+let result = try await service.fetch(id: pending.pendingApproval?.id ?? "").flatMap { ... }
+
+// Prefer — each step is obvious
+guard let approvalId = pending.pendingApproval?.id else { return }
+let approval = try await service.fetch(id: approvalId)
+```
+
+### Public API Surface Discipline
+
+Before making anything `public`, ask: who outside this module calls this? If the answer is "only sibling modules," use `package` access. If the answer is "nobody yet," keep it `internal`. Exposing unnecessary public surface makes future refactors painful and forces semver consideration.
+
+The same applies to stored properties: if a property is only read during `init`, use a local variable instead.
+
+### Error Type Requirements
+
+All new error types must conform to `CrossmintError`. Error codes use `SCREAMING_SNAKE_CASE` (e.g., `WALLET_NOT_FOUND`). Provide a `recoverySuggestion` whenever the developer can take a specific action to fix the problem.
+
+### Complexity Threshold
+
+Before adding background tasks, timers, or retry loops, check whether a simpler pre-call check would suffice, and whether the other SDKs (React Native, Kotlin) do the same thing. Complexity that isn't warranted by the feature and not matched cross-platform creates drift.
+
+## Test Conventions
+
+Full reference: `docs/test-conventions.md`. Key rules inline:
+
+### Framework and File Layout
+
+- `import Testing` — not `import XCTest`
+- Test types are `struct` — not `class`
+- One test file per feature/concern: `Tests/<Module>Tests/<Domain>/<Feature>Tests.swift`
+- Mocks in `Tests/<Module>Tests/Mocks/Mock<Protocol>.swift` (one mock per protocol)
+- Helpers in `Tests/<Module>Tests/Helpers/<Feature>Helpers.swift`
+- JSON fixtures in `Tests/<Module>Tests/Resources/<Fixture>.json`, registered in `Package.swift`
+
+### Naming
+
+- Test functions: `camelCase`, BDD-style, no verb prefix
+- Good: `sendsOtpToValidEmail()`, `rejectsEmptyOtpCode()`, `returnsNilWhenWalletDoesNotExist()`
+- Bad: `shouldSendOtp()`, `itCanReject()`, `willReturn()`, `canFetch()`
+- Suite → Test names should read as a sentence: `Wallet Creation > rejects unknown chain string`
+- Constants: `UPPER_SNAKE_CASE`
+- Mock types: `Mock` prefix (`MockAuthService`, `MockSecureStorage`)
+
+### `@Suite` and `@Test`
+
+```swift
+@Suite("Wallet Creation")
+struct WalletCreationTests {
+    @Test func createsEVMWalletWithApiKeySigner() async throws { }
+
+    @Suite("when the chain is invalid")
+    struct InvalidChainTests {
+        @Test func rejectsUnknownChainString() throws { }
+    }
+}
+```
+
+### Assertions
+
+| Macro | When |
+|-------|------|
+| `#expect(condition)` | General assertion — test continues on failure |
+| `#require(condition)` | Halts test on failure (unwrapping, preconditions) |
+| `#expect(throws: ErrorType.self) { }` | Verify throw by type |
+| `#expect { } throws: { error in ... }` | Verify throw type and properties |
+
+### Mock Pattern
+
+```swift
+final class MockAuthService: AuthService, @unchecked Sendable {
+    var validateEmailCallCount = 0
+    var validateEmailLastRequest: ValidateEmailRequest?
+    var validateEmailError: AuthError?
+    var validateEmailResponse = ValidateEmailResponse(emailId: "mock-email-id")
+
+    func validateEmail(_ request: ValidateEmailRequest) async throws -> ValidateEmailResponse {
+        validateEmailCallCount += 1
+        validateEmailLastRequest = request
+        if let error = validateEmailError { throw error }
+        return validateEmailResponse
+    }
+}
+```
+
+Rules: track `callCount` + `lastRequest` per method. Make outcomes configurable via `var` with sensible defaults. Use `actor` instead of `@unchecked Sendable` when the mock holds mutable async state.
+
+### Tagging
+
+Define tags in `Tests/<AnyTarget>/Tags.swift`. Apply at suite level where possible:
+
+```swift
+extension Tag {
+    @Tag static var unit: Self
+    @Tag static var staging: Self
+    @Tag static var critical: Self
+    @Tag static var flaky: Self
+}
+
+@Suite("Wallet Creation", .tags(.critical))
+struct WalletCreationTests { ... }
+```
+
+Staging tests: mark with `(STAG)` in the `@Test` display name and tag `.staging`. Use GUID-based Mailnesia detection for OTP (RSS items are not sorted chronologically).
+
+### Hard Bans
+
+- No `@Suite(.serialized)` — causes a Swift compiler ICE. Use actor or Task coordination instead.
+- No `XCTest`
+- No `class` test types
+- No verb prefixes (`should`, `it`, `will`, `can`, `does`)
+- No testing of implementation details — test observable behavior through public or `@testable` internal APIs
+
+## Common Mistakes to Avoid
+
+- **Storing init-only values as properties.** If a value is used during `init` and never again, assign it to a local, not `self.property`. Stored properties signal that the value is needed beyond init.
+
+- **Leaking internal types into the public API.** The HTTP client (`crossmintService`), internal service types, and factory classes must not appear in any public protocol or `public` property. Before adding a `public` property, ask whether external developers actually need it.
+
+- **Synthesized `Encodable` with optional fields.** Synthesized conformance encodes `nil` as `null`. For any request body with optional fields, use `CodingKeys` + `encodeIfPresent`. See Code Conventions above.
+
+- **`@unchecked Sendable` to suppress concurrency errors.** This hides real data races. Fix the isolation instead — move state to an actor, make the type a value type, or properly annotate `@MainActor`.
+
+- **Adding a timer or background refresh without cross-SDK justification.** Always check whether a simpler pre-call expiry check would work, and whether the React Native and Kotlin SDKs do the same. Background tasks that aren't matched cross-platform create platform drift and maintenance burden.
+
+- **Chaining optional access with complex fallbacks in one expression.** Break it into steps. One-liners that need a comment to explain what they do should be multiple lines.
+
+- **Adding an orchestrator for a single-service flow.** Orchestrators are only warranted when a flow coordinates multiple services or requires retry/polling state. A single API call goes client → service directly.
+
+- **Hardcoding environment or API version strings.** Environment comes from the API key. API versions come from a centralized constant or the OpenAPI generated client.
+
+## Scott's Best Practices
+
+TODO: Scott's best-practices documents were not found in Linear during the WAL-10266 update (searched all workspace documents and filtered by creator). Once located, add a summary here covering naming conventions, function length, comment style, public API discipline, and cross-SDK consistency rules.
 
 ## Development Workflow
 
-1. All code must pass SwiftLint checks before merging
-2. Tests run on iPhone 16 Pro simulator by default
-3. The SDK uses Swift Package Manager for dependency management
-4. SwiftLint is integrated as a build tool plugin
+1. All code must pass SwiftLint checks before merging (`make lint`).
+2. Tests run on iPhone 16 Pro simulator by default.
+3. The SDK uses Swift Package Manager for dependency management.
+4. SwiftLint is integrated as a build tool plugin.
+5. Run `/afeight-review` before opening any PR.
+6. Run `/sdk-compare` whenever changing or adding anything on the public API surface — the TypeScript SDK (wallets-v1) is the canonical reference.
+7. Set these environment variables when running the demo app:
+   - `CROSSMINT_API_KEY` — your Crossmint API key
+   - `CROSSMINT_WHITELISTED_DOMAIN` — whitelisted domain for the SDK

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,24 +120,11 @@ CrossmintSDKProduct    ← assembly: configure() + wiring (depends on Core + TEE
 
 Public product imports: `CrossmintSDK` (everything), `CrossmintWallets`, `CrossmintAuth`.
 
-### Wallet Protocol & Signers
+### Wallet
 
-`Wallet` is a public protocol — not a class. The concrete implementation is internal `WalletImpl`. Chain-specific extensions (e.g. `EVMWallet`) add chain-unique methods.
+`Wallet` is currently an `open class` with `@unchecked Sendable`. The target architecture (EDD) makes it a public protocol with an internal concrete implementation, but that refactor is still in progress. Chain-specific subclasses (`EVMWallet`, `SolanaWallet`, `StellarWallet`) extend it with chain-unique methods.
 
-Signer configuration uses a static-factory struct pattern for trailing-closure syntax:
-
-```swift
-let wallet = try await CrossmintSDK.shared.wallets.getOrCreate(
-    chain: .baseSepolia,
-    signer: .email("user@example.com", onAuthRequired: { flow in
-        // push flow into @State — closure returns immediately
-        // signer suspends internally until flow.verifyOTP() or flow.cancel()
-        await MainActor.run { otpFlow = flow }
-    })
-)
-```
-
-`OTPFlow` is a public struct with `sendOTP`, `verifyOTP`, and `cancel` closures. The signer suspends on a `CheckedContinuation` — the closure just delivers the flow object to the UI layer. Add `.crossmintWalletSigner()` to your root view when using email/phone signers.
+Add `.crossmintNonCustodialSigner()` to your root view when using email/phone signers — this injects the hidden WebView required for TEE communication.
 
 ### TEE Architecture
 
@@ -170,16 +157,14 @@ Services make exactly one API call per method — no orchestration, no polling. 
 
 | Issue | Summary | Status |
 |-------|---------|--------|
-| WAL-9974 / WAL-10195 / WAL-10196 | Singleton + configure() + setJWT | In Review / Done |
-| WAL-10193 | OTPFlow callback pattern | In Review |
-| WAL-9977 | Auth client | In Progress |
-| WAL-9976 | Move sign/poll out of Wallet | In Progress |
-| WAL-10312 | Move onAuthRequired to WalletOptions.Callbacks | Backlog |
+| WAL-9974 / WAL-10195 / WAL-10196 | Singleton + configure() + setJWT | Done |
+| WAL-9977 | Auth client | Done |
+| WAL-9976 | Move sign/poll out of Wallet (extensions extracted; protocol refactor pending) | Done |
 | WAL-9978 / WAL-10194 | TEE refactor + TEEProvider protocol | Backlog |
 | WAL-9966 | OpenAPI HTTP client generation | Backlog |
-| WAL-9979 | Error protocol | Todo |
-| WAL-9980 | Logging improvements | Todo |
-| WAL-9981 | DocC documentation | Todo (blocked — do last; API not stable) |
+| WAL-9979 | Error protocol | In Progress |
+| WAL-9980 | Logging improvements | In Progress |
+| WAL-9981 | DocC documentation | In Progress (do last; API not stable) |
 
 ## Code Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ CrossmintSDK.shared                     (@MainActor final class)
 CrossmintWallets
   └── getOrCreate(chain:signer:options:) → Wallet subclass
 
-Wallet (open class — @unchecked Sendable; protocol refactor pending)
+Wallet (open class — @unchecked Sendable)
   ├── balances(_:_:) / nfts(page:nftsPerPage:) / listTransfers(tokens:)
   ├── signers() / signerIsRegistered(_:)
   └── EVMWallet / SolanaWallet / StellarWallet (chain-specific subclasses)
@@ -122,7 +122,7 @@ Http / Logger / Utils / Web ← infrastructure
 
 ### Wallet
 
-`Wallet` is an `open class` with `@unchecked Sendable`. The plan is to make it a public protocol with an internal concrete implementation, but that refactor is still pending. Sign/poll logic lives in `Wallet+Transactions.swift` extensions. Chain-specific subclasses (`EVMWallet`, `SolanaWallet`, `StellarWallet`) extend it with chain-unique methods.
+`Wallet` is an `open class` with `@unchecked Sendable`. Sign/poll logic lives in `Wallet+Transactions.swift` extensions. Chain-specific subclasses (`EVMWallet`, `SolanaWallet`, `StellarWallet`) extend it with chain-unique methods.
 
 Add `.crossmintNonCustodialSigner()` to your root view when using email/phone signers — this injects the hidden WebView required for TEE communication.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ make open
 
 ## Architecture Overview
 
-The Crossmint Swift SDK follows a layered architecture with a configured singleton as the entry point, domain services for API communication, and chain-specific `Wallet` subclasses as the primary consumer-facing type. The [Mobile SDK API Review EDD](https://linear.app/crossmint/project/mobile-sdk-api-review-182dfa4d5add/overview) defines the long-term target; these sections describe the current state, with notes where the two diverge.
+The Crossmint Swift SDK follows a layered architecture with a configured singleton as the entry point, domain services for API communication, and chain-specific `Wallet` subclasses as the primary consumer-facing type.
 
 ### Layered Architecture
 
@@ -120,11 +120,9 @@ SecureStorage         ← Keychain-based secure storage
 Http / Logger / Utils / Web ← infrastructure
 ```
 
-EDD target restructure: CrossmintCore, CrossmintWalletsImpl, CrossmintAuthImpl, CrossmintCheckoutImpl, CrossmintSDKProduct.
-
 ### Wallet
 
-`Wallet` is an `open class` with `@unchecked Sendable`. The EDD makes it a public protocol with an internal concrete implementation, but that refactor is still pending. Sign/poll logic was extracted into `Wallet+Transactions.swift` extensions (WAL-9976). Chain-specific subclasses (`EVMWallet`, `SolanaWallet`, `StellarWallet`) extend it with chain-unique methods.
+`Wallet` is an `open class` with `@unchecked Sendable`. The plan is to make it a public protocol with an internal concrete implementation, but that refactor is still pending. Sign/poll logic lives in `Wallet+Transactions.swift` extensions. Chain-specific subclasses (`EVMWallet`, `SolanaWallet`, `StellarWallet`) extend it with chain-unique methods.
 
 Add `.crossmintNonCustodialSigner()` to your root view when using email/phone signers — this injects the hidden WebView required for TEE communication.
 
@@ -132,15 +130,13 @@ Add `.crossmintNonCustodialSigner()` to your root view when using email/phone si
 
 The TEE WebView lives in the `Wallet` module (`CrossmintTEE`). It handles auto-recovery from WebKit content-process termination internally. TEE is an implementation detail of email/phone signers — developers never interact with it directly.
 
-The EDD targets a `TEEProvider` protocol with swappable implementations (WebView-based, mock for tests, Secure Enclave future), but that abstraction hasn't landed yet.
-
 ### Auth State
 
 `CrossmintAuthManager` manages JWT state, persisting it to keychain. `setJWT(_:)` on the singleton stores a developer-supplied token (no refresh). `AuthClient.verifyOTP()` stores a JWT from Crossmint-managed auth. HTTP requests in the `Wallet` module inject the current JWT via `AuthenticatedCrossmintService`.
 
 ### Error Protocol
 
-All error types conform to `CrossmintError` (WAL-9979, in progress):
+All new error types must conform to `CrossmintError`:
 
 ```swift
 public protocol CrossmintError: Error, Sendable {
@@ -153,9 +149,9 @@ public protocol CrossmintError: Error, Sendable {
 
 Domain errors: `WalletError`, `TransactionError`, `SignatureError`, `AuthError`.
 
-### Services vs Orchestrators
+### Services
 
-Services make exactly one API call per method — no orchestration, no polling. Orchestrators coordinate multi-step flows (signer init, create, sign, poll). Simple flows go client → service directly. Reach for an orchestrator only when a flow touches multiple services or requires retry/polling.
+Services make exactly one API call per method — no coordination, no polling. Multi-step flows (getOrCreate, sign + poll) live in the client (`DefaultCrossmintWallets`) or in `Wallet+Transactions.swift` extensions. Never embed flow logic or polling inside a service method.
 
 ## Code Conventions
 
@@ -198,7 +194,7 @@ A helper function that just renames a call, or a type that wraps only one thing,
 
 ### Business Logic Placement
 
-Business logic lives in orchestrators (and clients for simple cases), not in services. Services are generic and unaware of business context — they make API calls and return data. Orchestrators coordinate, retry, poll, and decide. Never let a service embed flow logic; never let a client embed multi-step coordination that warrants an orchestrator.
+Business logic lives in the client layer (`DefaultCrossmintWallets`, wallet extensions), not in services. Services are generic and unaware of business context — they make API calls and return data. Coordination, polling, and retry belong in the client or wallet layer.
 
 ### Actors for Mutable Async State
 
@@ -386,17 +382,17 @@ Tests must be fully isolated. Shared global state causes order-dependent failure
 
 - **Chaining optional access with complex fallbacks in one expression.** Break it into steps. One-liners that need a comment to explain what they do should be multiple lines.
 
-- **Adding an orchestrator for a single-service flow.** Orchestrators are only warranted when a flow coordinates multiple services or requires retry/polling state. A single API call goes client → service directly.
+- **Embedding flow logic in a service method.** Services make exactly one API call. Coordination, polling, and retry belong in the client or wallet layer.
 
 - **Hardcoding environment or API version strings.** Environment comes from the API key. API versions come from a centralized constant or the OpenAPI generated client.
 
 ## Documentation Rules
 
-Document only what cannot be derived from the code or its version history. Source: `best-practices/documentation.md` and `best-practices/code/README.md`.
+Document only what cannot be derived from the code or its version history.
 
 - Comments and doc comments should only explain **why**, never **what** or **how** — if the what requires explanation, the code needs to be renamed or restructured.
 - TODOs should describe why something is suboptimal, not propose solutions (solutions change; the underlying problem is what matters).
-- Place documentation alongside the authoritative source whose scope it belongs to: code comments for code-level context, PR descriptions for why a decision was made, Linear issues for why it needs to change.
+- Place documentation alongside the authoritative source whose scope it belongs to: code comments for code-level context, PR descriptions for why a decision was made.
 - State each idea exactly once. Don't preview in an introduction what the detail immediately below already covers.
 
 ## Development Workflow

--- a/docs/conventions/code.md
+++ b/docs/conventions/code.md
@@ -1,0 +1,134 @@
+# Code Conventions
+
+## Protocol-First Design
+
+Expose behavior through protocols, keep concrete types internal. Protocols live in the same module as their primary consumer; implementations are `internal` or `package` unless they need to be subclassed. External consumers only import protocols and public value types.
+
+## Naming
+
+Variable names must not duplicate the type or the name of the containing object:
+
+```swift
+// Bad — duplicates type info, duplicates containing type name
+struct Wallet {
+    var walletAddress: String   // "wallet" already in Wallet
+    var isValid: Bool           // "is" prefix duplicates Bool
+    var creationDate: Date      // "Date" redundant
+}
+
+// Good
+struct Wallet {
+    var address: String
+    var valid: Bool
+    var createdOn: Date
+}
+```
+
+Avoid vague verbs (`manage`, `handle`, `process`) in function and type names — they obscure responsibility. Use specific action names: `validateOrder`, `persistPayment`, `signTransaction`.
+
+Functions should do one thing. A name that requires "and" is a signal to split: `validateAndPersist` → `validate` + `persist`.
+
+## Abstraction Discipline
+
+Inline code unless the abstraction meets one of these criteria:
+- It self-documents a non-obvious relationship or hides significant complexity
+- It maintains state the algorithm requires across iterations
+- It has multiple, current implementations (e.g. a protocol with two concrete types in active use)
+
+A helper function that just renames a call, or a type that wraps only one thing, adds indirection without value. Remove it.
+
+## Business Logic Placement
+
+Coordination, polling, and retry belong in `DefaultCrossmintWallets` or wallet extensions. Services are single-call — they don't know or care about the flow around them.
+
+## Actors for Mutable Async State
+
+Use `actor` for types with mutable state accessed from multiple async contexts. `@unchecked Sendable` hides real data races — fix the isolation instead. The one exception is test mocks where mutations are test-isolated; see `docs/conventions/tests.md`.
+
+## Optional JSON Body Fields
+
+Synthesized `Encodable` encodes `nil` optionals as `null`, which many APIs reject or misinterpret. When a field should be omitted from the body when `nil`, always implement `CodingKeys` + `encodeIfPresent` manually:
+
+```swift
+// Wrong — synthesized Encodable sends null for nil signer
+struct TransferBody: Encodable {
+    let to: String
+    let signer: String?  // encodes as null
+}
+
+// Right — encodeIfPresent omits the field entirely
+struct TransferBody: Encodable {
+    let to: String
+    let signer: String?
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(to, forKey: .to)
+        try container.encodeIfPresent(signer, forKey: .signer)
+    }
+}
+```
+
+## Simple Expressions Over Chains
+
+Split complex one-liners into named intermediate steps. Clarity beats brevity:
+
+```swift
+// Avoid — what does this do?
+let result = try await service.fetch(id: pending.pendingApproval?.id ?? "").flatMap { ... }
+
+// Prefer — each step is obvious
+guard let approvalId = pending.pendingApproval?.id else { return }
+let approval = try await service.fetch(id: approvalId)
+```
+
+## Public API Surface Discipline
+
+Before making anything `public`, ask: who outside this module calls this? If the answer is "only sibling modules," use `package` access. If the answer is "nobody yet," keep it `internal`. Exposing unnecessary public surface makes future refactors painful and forces semver consideration.
+
+The same applies to stored properties: if a property is only read during `init`, use a local variable instead.
+
+## Error Type Requirements
+
+All new error types must conform to `CrossmintError`. Error codes use `SCREAMING_SNAKE_CASE` (e.g., `WALLET_NOT_FOUND`). Provide a `recoverySuggestion` whenever the developer can take a specific action to fix the problem. Errors communicate exactly two things: whether the caller should retry, and whether the fault is theirs or the system's. Don't create subclasses or cases beyond what's needed to express those two distinctions.
+
+## Function Inputs
+
+Functions should depend only on what they use. Prefer passing specific values over large objects when only a subset of fields is needed — this keeps the function usable in a wider range of contexts and makes its dependencies explicit.
+
+## Complexity Threshold
+
+Before adding background tasks, timers, or retry loops, check whether a simpler pre-call check would suffice, and whether the other SDKs (React Native, Kotlin) do the same thing. Complexity that isn't warranted by the feature and not matched cross-platform creates drift.
+
+## Swift Concurrency Patterns
+
+**Typed throws.** Use domain-typed errors where the failure set is known at the call site. The codebase uses `throws(WalletError)`, `throws(TransactionError)`, etc. Don't use untyped `throws` for internal methods whose errors are knowable — the compiler enforces exhaustiveness and eliminates the need for casts.
+
+**`@MainActor` propagation.** `CrossmintSDK` is `@MainActor`. Code that updates UI or calls into the singleton must run on the main actor. Use `await MainActor.run { }` to hop explicitly rather than `DispatchQueue.main.async` — that is UIKit-era code that breaks structured concurrency.
+
+**Structured concurrency.** Use `async let` for parallel independent calls. Use `TaskGroup` when the fan-out count is dynamic. Avoid `Task.detached` unless you explicitly need to break task inheritance (priority, cancellation, actor context) — detached tasks orphan work and make testing harder.
+
+## Common Mistakes to Avoid
+
+- **Storing init-only values as properties.** If a value is used during `init` and never again, assign it to a local, not `self.property`. Stored properties signal that the value is needed beyond init.
+
+- **Leaking internal types into the public API.** The HTTP client (`crossmintService`), internal service types, and factory classes must not appear in any public protocol or `public` property. Before adding a `public` property, ask whether external developers actually need it.
+
+- **Synthesized `Encodable` with optional fields.** Synthesized conformance encodes `nil` as `null`. For any request body with optional fields, use `CodingKeys` + `encodeIfPresent`. See above.
+
+- **Adding a timer or background refresh without cross-SDK justification.** Always check whether a simpler pre-call expiry check would work, and whether the React Native and Kotlin SDKs do the same. Background tasks that aren't matched cross-platform create platform drift and maintenance burden.
+
+- **Chaining optional access with complex fallbacks in one expression.** Break it into steps. One-liners that need a comment to explain what they do should be multiple lines.
+
+- **Embedding flow logic in a service method.** Services make exactly one API call. Coordination, polling, and retry belong in the client or wallet layer.
+
+- **Hardcoding environment or API version strings.** Environment comes from the API key. API versions come from a centralized constant or the OpenAPI generated client.
+
+## Documentation Rules
+
+Document only what cannot be derived from the code or its version history.
+
+- Comments and doc comments should only explain **why**, never **what** or **how** — if the what requires explanation, the code needs to be renamed or restructured.
+- TODOs should describe why something is suboptimal, not propose solutions (solutions change; the underlying problem is what matters).
+- Place documentation alongside the authoritative source whose scope it belongs to: code comments for code-level context, PR descriptions for why a decision was made.
+- State each idea exactly once. Don't preview in an introduction what the detail immediately below already covers.

--- a/docs/conventions/tests.md
+++ b/docs/conventions/tests.md
@@ -1,0 +1,100 @@
+# Test Conventions
+
+Full reference: `docs/test-conventions.md`. Key rules inline:
+
+## Framework and File Layout
+
+- `import Testing` — not `import XCTest`
+- Test types are `struct` — not `class`
+- One test file per feature/concern: `Tests/<Module>Tests/<Domain>/<Feature>Tests.swift`
+- Mocks in `Tests/<Module>Tests/Mocks/Mock<Protocol>.swift` (one mock per protocol)
+- Helpers in `Tests/<Module>Tests/Helpers/<Feature>Helpers.swift`
+- JSON fixtures in `Tests/<Module>Tests/Resources/<Fixture>.json`, registered in `Package.swift`
+
+## Naming
+
+- Test functions: `camelCase`, BDD-style, no verb prefix
+- Good: `sendsOtpToValidEmail()`, `rejectsEmptyOtpCode()`, `returnsNilWhenWalletDoesNotExist()`
+- Bad: `shouldSendOtp()`, `itCanReject()`, `willReturn()`, `canFetch()`
+- Suite → Test names should read as a sentence: `Wallet Creation > rejects unknown chain string`
+- Constants: `UPPER_SNAKE_CASE`
+- Mock types: `Mock` prefix (`MockAuthService`, `MockSecureStorage`)
+
+## `@Suite` and `@Test`
+
+```swift
+@Suite("Wallet Creation")
+struct WalletCreationTests {
+    @Test func createsEVMWalletWithApiKeySigner() async throws { }
+
+    @Suite("when the chain is invalid")
+    struct InvalidChainTests {
+        @Test func rejectsUnknownChainString() throws { }
+    }
+}
+```
+
+## Assertions
+
+| Macro | When |
+|-------|------|
+| `#expect(condition)` | General assertion — test continues on failure |
+| `#require(condition)` | Halts test on failure (unwrapping, preconditions) |
+| `#expect(throws: ErrorType.self) { }` | Verify throw by type |
+| `#expect { } throws: { error in ... }` | Verify throw type and properties |
+
+## Mock Pattern
+
+```swift
+final class MockAuthService: AuthService, @unchecked Sendable {
+    var validateEmailCallCount = 0
+    var validateEmailLastRequest: ValidateEmailRequest?
+    var validateEmailError: AuthError?
+    var validateEmailResponse = ValidateEmailResponse(emailId: "mock-email-id")
+
+    func validateEmail(_ request: ValidateEmailRequest) async throws -> ValidateEmailResponse {
+        validateEmailCallCount += 1
+        validateEmailLastRequest = request
+        if let error = validateEmailError { throw error }
+        return validateEmailResponse
+    }
+}
+```
+
+Rules: track `callCount` + `lastRequest` per method. Make outcomes configurable via `var` with sensible defaults. `@unchecked Sendable` is fine here because mutations are test-isolated; use `actor` if the mock is accessed concurrently across tasks.
+
+## Tagging
+
+Define tags in `Tests/<AnyTarget>/Tags.swift`. Apply at suite level where possible:
+
+```swift
+extension Tag {
+    @Tag static var unit: Self
+    @Tag static var staging: Self
+    @Tag static var critical: Self
+    @Tag static var flaky: Self
+}
+
+@Suite("Wallet Creation", .tags(.critical))
+struct WalletCreationTests { ... }
+```
+
+Staging tests: mark with `(STAG)` in the `@Test` display name and tag `.staging`. Use GUID-based Mailnesia detection for OTP (RSS items are not sorted chronologically).
+
+## Test Philosophy
+
+Hard-to-write tests are a signal to refactor production code, not to add test complexity. A test that requires complex setup is asking for a cleaner dependency injection point or more expressive return values.
+
+Fix only the values relevant to what you're asserting and randomize everything else. When assertion logic grows complex across multiple tests, that logic belongs on the production type as a method, not in the test.
+
+Avoid tests that only verify data routing — a mocked value passing through unchanged mirrors production logic and shares its blind spots. Focus on boundary conditions and transformations. Prefer factory-created objects with real data over mocks; reach for mocks only when the resource is unavailable in a test sandbox (network, disk, external services).
+
+Tests must be fully isolated. Shared global state causes order-dependent failures that are expensive to diagnose.
+
+## Hard Bans
+
+- No `@Suite(.serialized)` — causes a Swift compiler ICE. Use actor or Task coordination instead.
+- No `XCTest`
+- No `class` test types
+- No verb prefixes (`should`, `it`, `will`, `can`, `does`)
+- No testing of implementation details — test observable behavior through public or `@testable` internal APIs


### PR DESCRIPTION
This updates `CLAUDE.md` to reflect the current state of the codebase following the latest refactors, and consolidates the engineering conventions that were previously spread across separate documents. Most of the code and test conventions hadn't been pulled in yet.

## Changes

- Replaced the architecture overview with a layered diagram, SDK entry point code example, actual package boundaries, and internal design notes covering `Wallet`, TEE, auth state, error protocol, and the services layer.
- Added `docs/conventions/code.md` with code conventions: naming, abstraction discipline, business logic placement, actor usage, `encodeIfPresent`, public API surface discipline, error type requirements, Swift concurrency patterns, common mistakes, and documentation rules.
- Added `docs/conventions/tests.md` with test conventions: Swift Testing framework, BDD naming, `@Suite`/`@Test` usage, assertion macros, mock patterns, tagging, and test philosophy.
- `CLAUDE.md` imports both files via `@` so they load automatically as context.
- Updated the Development Workflow with the lint command, iPhone 17 Pro simulator target, and demo app environment variables.