### PR TITLE
Bump CrossmintDeviceSigner podspec to 1.1.0

### DIFF
--- a/CrossmintDeviceSigner.podspec
+++ b/CrossmintDeviceSigner.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CrossmintDeviceSigner'
-  s.version          = '0.12.2'
+  s.version          = '1.1.0'
   s.summary          = 'Hardware-backed device signer key storage for Crossmint wallets (iOS).'
   s.homepage         = 'https://github.com/Crossmint/crossmint-swift-sdk'
   s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }


### PR DESCRIPTION
Bumps the `CrossmintDeviceSigner` podspec version from `0.12.2` to `1.1.0` ahead of the 1.1.0 release tag.

## Changes

- `CrossmintDeviceSigner.podspec`: version `0.12.2` → `1.1.0`