### PR TITLE
[GEN-2382] Add wallet-address-label accessibility identifier to AddressRow

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Wallet/AddressRow.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Wallet/AddressRow.swift
@@ -19,6 +19,7 @@ struct AddressRow: View {
                     HStack(spacing: 4) {
                         Text(formatAddress(address))
                             .foregroundStyle(.secondary)
+                            .accessibilityIdentifier("wallet-address-label")
                         Image(systemName: "doc.on.clipboard")
                             .foregroundStyle(.secondary)
                             .font(.footnote)


### PR DESCRIPTION
## Summary

Adds `.accessibilityIdentifier("wallet-address-label")` to the truncated wallet address `Text` in `Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Wallet/AddressRow.swift`.

This aligns the Swift demo app with the testID contract in `crossmint-mobile-e2e-tests/docs/testid-contract.md` so the shared Maestro `wallet-display.yaml` flow can target the element consistently across all SDKs.

## Changes

- `Examples/.../Playground/Wallet/AddressRow.swift` — add `.accessibilityIdentifier("wallet-address-label")` to the address Text

## Test plan

- [ ] Verify with \`maestro studio\` against a running iOS simulator that \`wallet-address-label\` appears in the element tree on the wallet dashboard

