### PR TITLE
test(gen-2383-2387): accessibility identifiers for chain, transfer, activity, signers (Swift)

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Activity/ActivityView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Activity/ActivityView.swift
@@ -33,7 +33,7 @@ struct ActivityView: View {
                     )
                 } else {
                     List(Array(transfers.enumerated()), id: \.element.id) { offset, transfer in
-                        TransferRow(transfer: transfer)
+                        TransferRow(transfer: transfer, offset: offset)
                             .accessibilityIdentifier("activity-item-\(offset)")
                     }
                     .accessibilityIdentifier("activity-list")

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Activity/ActivityView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Activity/ActivityView.swift
@@ -32,9 +32,11 @@ struct ActivityView: View {
                         description: Text("No transfers found for this wallet.")
                     )
                 } else {
-                    List(transfers) { transfer in
+                    List(Array(transfers.enumerated()), id: \.element.id) { offset, transfer in
                         TransferRow(transfer: transfer)
+                            .accessibilityIdentifier("activity-item-\(offset)")
                     }
+                    .accessibilityIdentifier("activity-list")
                     .refreshable { await loadTransfers(isRefresh: true) }
                 }
             }

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Activity/TransferRow.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Activity/TransferRow.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 struct TransferRow: View {
     let transfer: Transfer
+    let offset: Int
 
     private var isOutgoing: Bool { transfer.type == .outgoing }
 
@@ -34,10 +35,15 @@ struct TransferRow: View {
             Spacer()
 
             VStack(alignment: .trailing, spacing: 2) {
-                Text("\(isOutgoing ? "-" : "+")\(transfer.amount.formatted()) \(transfer.tokenSymbol ?? "")")
+                Text("\(isOutgoing ? "-" : "+")\(transfer.amount.formatted())")
                     .font(.subheadline)
                     .fontWeight(.medium)
                     .foregroundStyle(isOutgoing ? .red : .green)
+                    .accessibilityIdentifier("activity-item-\(offset)-amount")
+                Text(transfer.tokenSymbol ?? "")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("activity-item-\(offset)-token")
             }
         }
         .padding(.vertical, 2)

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/ChainPicker/ChainPickerMenu.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/ChainPicker/ChainPickerMenu.swift
@@ -21,9 +21,11 @@ struct ChainPickerMenu: View {
                         chain.icon
                     }
                 }
+                .accessibilityIdentifier("chain-option-\(chain.name.lowercased())")
             }
         } label: {
             selectedChain.icon
         }
+        .accessibilityIdentifier("chain-picker-button")
     }
 }

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Signers/SignersView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Signers/SignersView.swift
@@ -57,8 +57,10 @@ struct SignersView: View {
                         Label("Add Signer…", systemImage: "plus.circle")
                     }
                     .disabled(appState.wallet == nil)
+                    .accessibilityIdentifier("signers-add-button")
                 }
             }
+            .accessibilityIdentifier("signers-list")
             .navigationTitle("Signers")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Transfer/TransferView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Transfer/TransferView.swift
@@ -54,6 +54,7 @@ struct TransferView: View {
                     }
                     .pickerStyle(.segmented)
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    .accessibilityIdentifier("transfer-token-picker")
                 }
 
                 Section("Recipient") {
@@ -62,12 +63,14 @@ struct TransferView: View {
                         .autocorrectionDisabled()
                         .font(.system(.body, design: .monospaced))
                         .focused($isAnyFieldFocused)
+                        .accessibilityIdentifier("transfer-recipient-input")
                 }
 
                 Section("Amount") {
                     TextField("0.00", text: $amount)
                         .keyboardType(.decimalPad)
                         .focused($isAnyFieldFocused)
+                        .accessibilityIdentifier("transfer-amount-input")
                     if let bal = selectedTokenBalance {
                         LabeledContent("Balance", value: bal)
                             .font(.footnote)
@@ -83,6 +86,7 @@ struct TransferView: View {
                             Label("Transaction submitted", systemImage: "checkmark.circle.fill")
                                 .foregroundStyle(.green)
                                 .fontWeight(.medium)
+                                .accessibilityIdentifier("transfer-success-label")
                             CopyButton(value: txId, lineLimit: 2)
                         }
                     }
@@ -93,6 +97,7 @@ struct TransferView: View {
                         Label(error, systemImage: "exclamationmark.triangle")
                             .foregroundStyle(.red)
                             .font(.footnote)
+                            .accessibilityIdentifier("transfer-error-label")
                     }
                 }
 
@@ -109,6 +114,7 @@ struct TransferView: View {
                         }
                     }
                     .disabled(!isFormValid || isSending)
+                    .accessibilityIdentifier("transfer-submit-button")
                 }
             }
             .navigationTitle("Transfer")

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Wallet/AddressRow.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Wallet/AddressRow.swift
@@ -27,6 +27,7 @@ struct AddressRow: View {
                 }
                 .buttonStyle(.plain)
                 .sensoryFeedback(.success, trigger: addressCopied)
+                .accessibilityIdentifier("wallet-address-copy-button")
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds `.accessibilityIdentifier(...)` modifiers to the Swift demo app for 4 tickets:

- **WAL-2383 (chain switching)** `ChainPickerMenu.swift` — `chain-picker-button` on the Menu, `chain-option-{name}` on each chain Button
- **WAL-2384 (transfer)** `TransferView.swift` — `transfer-token-picker`, `transfer-recipient-input`, `transfer-amount-input`, `transfer-submit-button`, `transfer-success-label`, `transfer-error-label`
- **WAL-2386 (activity)** `ActivityView.swift` — `activity-list` on the List, `activity-item-{index}` on each row
- **WAL-2387 (signers)** `SignersView.swift` — `signers-list` on the List, `signers-add-button` on the Add Signer button

## Test plan

- [ ] Run `flows/wallet/chain-switching.yaml` against the Swift demo app
- [ ] Run `flows/wallet/transfer.yaml` against the Swift demo app
- [ ] Run `flows/wallet/activity.yaml` against the Swift demo app
- [ ] Run `flows/signers/signers-list.yaml` against the Swift demo app