### PR TITLE
ci: rename dispatch package name to wallets/swift format

### DIFF
--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -83,4 +83,4 @@ jobs:
           token: ${{ steps.generate_app_token.outputs.token }}
           repository: Paella-Labs/crossbit-main
           event-type: sdk-reference-docs-update
-          client-payload: '{"run_id": "${{ github.run_id }}", "packages": "swift", "source_repo": "crossmint-swift-sdk", "source_ref": ${{ toJSON(inputs.ref || github.ref_name) }}}'
+          client-payload: '{"run_id": "${{ github.run_id }}", "packages": "wallets/swift", "source_repo": "crossmint-swift-sdk", "source_ref": ${{ toJSON(inputs.ref || github.ref_name) }}}'


### PR DESCRIPTION
## Summary

Part of [DVRL-1307](https://linear.app/crossmint/issue/DVRL-1307): renames the dispatch package name from `swift` to `wallets/swift` in the `sdk-reference-docs-generate.yml` workflow's `client-payload`.

```diff
- "packages": "swift"
+ "packages": "wallets/swift"
```

The receiver in crossbit-main ([PR #27234](https://github.com/Paella-Labs/crossbit-main/pull/27234)) already accepts both old and new formats.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/887eb0cd4b564b41bf40bcc42d343d0d
Requested by: @jmderby