### PR TITLE
fix(demo): expose activity row child identifiers to XCUITest

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Activity/ActivityView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Activity/ActivityView.swift
@@ -34,6 +34,11 @@ struct ActivityView: View {
                 } else {
                     List(Array(transfers.enumerated()), id: \.element.id) { offset, transfer in
                         TransferRow(transfer: transfer, offset: offset)
+                            // .contain keeps the row a container so the child
+                            // -amount/-token identifiers stay visible to XCUITest;
+                            // without it the identifier collapses the row into a
+                            // single accessibility element and hides them.
+                            .accessibilityElement(children: .contain)
                             .accessibilityIdentifier("activity-item-\(offset)")
                     }
                     .accessibilityIdentifier("activity-list")

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Activity/ActivityView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Activity/ActivityView.swift
@@ -34,10 +34,7 @@ struct ActivityView: View {
                 } else {
                     List(Array(transfers.enumerated()), id: \.element.id) { offset, transfer in
                         TransferRow(transfer: transfer, offset: offset)
-                            // .contain keeps the row a container so the child
-                            // -amount/-token identifiers stay visible to XCUITest;
-                            // without it the identifier collapses the row into a
-                            // single accessibility element and hides them.
+                            // .contain keeps child identifiers visible to XCUITest.
                             .accessibilityElement(children: .contain)
                             .accessibilityIdentifier("activity-item-\(offset)")
                     }


### PR DESCRIPTION
## Summary
- Applying `accessibilityIdentifier` directly to `TransferRow` collapses the row into a single accessibility element, hiding the child `activity-item-N-amount` / `activity-item-N-token` identifiers from Maestro/XCUITest.
- Seen in mobile E2E run [28588052265](https://github.com/Crossmint/crossmint-mobile-e2e-tests/actions/runs/28588052265): `activity-item-0` resolved but `activity-item-0-token` did not, while both values were visibly rendered on the Activity sheet.
- Fix: mark the row as an accessibility container with `.accessibilityElement(children: .contain)` so the row identifier and the child identifiers are all exposed.

## Test plan
- [ ] Dispatch `crossmint-mobile-e2e-tests` activity flow with `sdk_ref_swift=fix/gen-2386-activity-row-identifiers` and confirm the Swift iOS job passes the `activity-item-0-token` / `-amount` asserts

🤖 Generated with [Claude Code](https://claude.com/claude-code)