### PR TITLE
Fix all SwiftLint and compiler warnings

### DIFF
--- a/Sources/CrossmintAuth/DefaultAuthManager.swift
+++ b/Sources/CrossmintAuth/DefaultAuthManager.swift
@@ -239,7 +239,9 @@ public actor CrossmintAuthManager: AuthManager {
         do {
             return try await secureStorage.getOneTimeSecret() ?? ""
         } catch {
-            Logger.auth.error("Failed to read one-time secret from keychain, treating as non-authenticated: \(error.localizedDescription)")
+            let message = "Failed to read one-time secret from keychain, " +
+                "treating as non-authenticated: \(error.localizedDescription)"
+            Logger.auth.error(message)
             return ""
         }
     }

--- a/Sources/CrossmintService/DefaultCrossmintService.swift
+++ b/Sources/CrossmintService/DefaultCrossmintService.swift
@@ -72,17 +72,12 @@ public struct DefaultCrossmintService: CrossmintService {
         do {
             let (data, _) = try await httpClient.fetch(try getRequest(endpoint))
             return data
-        } catch let networkError as NetworkError {
-            if let mappedError = transform(networkError) {
+        } catch {
+            if let mappedError = transform(error) {
                 throw mappedError
             }
 
-            throw E.fromNetworkError(networkError)
-        } catch let serviceError as CrossmintServiceError {
-            throw E.fromServiceError(serviceError)
-        } catch {
-            // This type of error should never happen.
-            throw E.fromServiceError(.unknown)
+            throw E.fromNetworkError(error)
         }
     }
 

--- a/Sources/Passkeys/PasskeyDelegate.swift
+++ b/Sources/Passkeys/PasskeyDelegate.swift
@@ -160,6 +160,7 @@ class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate,
         )
 
         let getResponse = AuthenticationResponseJSON(
+            type: .publicKey,
             id: credential.credentialID,
             rawId: credential.credentialID,
             authenticatorAttachment: nil,
@@ -189,6 +190,7 @@ class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate,
         )
 
         let getResponse = AuthenticationResponseJSON(
+            type: .publicKey,
             id: credential.credentialID,
             rawId: credential.credentialID,
             authenticatorAttachment: nil,

--- a/Sources/Passkeys/PasskeyResponses.swift
+++ b/Sources/Passkeys/PasskeyResponses.swift
@@ -51,7 +51,7 @@ public struct AuthenticatorAttestationResponseJSON: Sendable {
  */
 public struct AuthenticationResponseJSON: Codable, Sendable {
 
-    public let type: PublicKeyCredentialType = .publicKey
+    public let type: PublicKeyCredentialType
 
     public let id: Data
 

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -281,7 +281,10 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
     ) async {
         let existingPublicKeyBase64 = await storage.getKey(address: walletApiModel.address)
         guard !isDeviceSignerRegistered(existingPublicKeyBase64, in: walletApiModel) else { return }
-        guard let deviceSignerPendingAssignment = findMatchingDeviceSignerKey(in: walletApiModel, storage: storage) else { return }
+        guard let deviceSignerPendingAssignment = findMatchingDeviceSignerKey(
+            in: walletApiModel,
+            storage: storage
+        ) else { return }
 
         do {
             try await storage.mapAddressToKey(

--- a/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
+++ b/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
@@ -78,7 +78,9 @@ final class DeviceSignerService: Sendable {
         storage: any DeviceSignerKeyStorage
     ) async throws(WalletError) {
         let chainEntry = registration.chains?[chainName]
-        let pendingApprovalId = chainEntry?.status == "awaiting-approval" ? chainEntry?.id : registration.transaction?.id
+        let pendingApprovalId = chainEntry?.status == "awaiting-approval"
+            ? chainEntry?.id
+            : registration.transaction?.id
         if let pendingApprovalId {
             Logger.smartWallet.info(LogEvents.walletRegisterDeviceSignerAwaitingApproval, attributes: [
                 "approvalId": pendingApprovalId
@@ -98,7 +100,10 @@ final class DeviceSignerService: Sendable {
         }
     }
 
-    private func persistKey(_ publicKeyBase64: String, in storage: any DeviceSignerKeyStorage) async throws(WalletError) {
+    private func persistKey(
+        _ publicKeyBase64: String,
+        in storage: any DeviceSignerKeyStorage
+    ) async throws(WalletError) {
         do {
             try await storage.mapAddressToKey(address: address, publicKeyBase64: publicKeyBase64)
         } catch {

--- a/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
+++ b/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
@@ -304,20 +304,15 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
         signerLocator: String,
         message: String
     ) async throws(SignatureError) {
-        if signerLocator.hasPrefix("device:") && deviceSignerKeyStorage == nil {
-            throw SignatureError.approvalFailed
-        }
-        if signerLocator.hasPrefix("device:"), let storage = deviceSignerKeyStorage {
-            let request: SignRequestApi
-            do {
-                request = try await deviceSignerService.buildSignRequest(
-                    signerLocator: signerLocator, message: message, storage: storage
-                )
-            } catch {
+        if signerLocator.hasPrefix("device:") {
+            guard let storage = deviceSignerKeyStorage else {
                 throw SignatureError.approvalFailed
             }
-            return try await smartWalletService.approveSignature(
-                .init(transactionId: signatureID, apiRequest: request, chainType: chain.chainType)
+            return try await approveDeviceSignature(
+                signatureID: signatureID,
+                signerLocator: signerLocator,
+                message: message,
+                storage: storage
             )
         }
 
@@ -336,24 +331,7 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
                 )
             )
         } catch {
-            switch error {
-            case .passkey(let passkeyError):
-                switch passkeyError {
-                case .cancelled:
-                    throw .userCancelled
-                default:
-                    throw .approvalFailed
-                }
-            case .signingFailed,
-                    .invalidAddress,
-                    .invalidEmail,
-                    .invalidSigner,
-                    .invalidMessage,
-                    .invalidPrivateKey,
-                    .notStarted,
-                    .cancelled:
-                throw .approvalFailed
-            }
+            throw mapSignerError(error)
         }
 
         return try await smartWalletService.approveSignature(
@@ -363,5 +341,45 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
                 chainType: chain.chainType
             )
         )
+    }
+
+    private func approveDeviceSignature(
+        signatureID: String,
+        signerLocator: String,
+        message: String,
+        storage: any DeviceSignerKeyStorage
+    ) async throws(SignatureError) {
+        let request: SignRequestApi
+        do {
+            request = try await deviceSignerService.buildSignRequest(
+                signerLocator: signerLocator, message: message, storage: storage
+            )
+        } catch {
+            throw SignatureError.approvalFailed
+        }
+        return try await smartWalletService.approveSignature(
+            .init(transactionId: signatureID, apiRequest: request, chainType: chain.chainType)
+        )
+    }
+
+    private func mapSignerError(_ error: SignerError) -> SignatureError {
+        switch error {
+        case .passkey(let passkeyError):
+            switch passkeyError {
+            case .cancelled:
+                return .userCancelled
+            default:
+                return .approvalFailed
+            }
+        case .signingFailed,
+                .invalidAddress,
+                .invalidEmail,
+                .invalidSigner,
+                .invalidMessage,
+                .invalidPrivateKey,
+                .notStarted,
+                .cancelled:
+            return .approvalFailed
+        }
     }
 }

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -43,14 +43,11 @@ extension Wallet {
             Logger.smartWallet.info(LogEvents.walletAddSignerSuccess)
         } catch {
             Logger.smartWallet.error(LogEvents.walletAddSignerError, attributes: ["error": "\(error)"])
-            guard let walletError = error as? WalletError else {
-                throw WalletError.walletGeneric(error.localizedDescription)
-            }
-            if case .deviceSignerNotSupported = walletError {
+            if case .deviceSignerNotSupported = error {
                 _deviceSignerUnsupported = true
                 _needsRecovery = false
             }
-            throw walletError
+            throw error
         }
     }
 
@@ -121,31 +118,15 @@ extension Wallet {
         case .device:
             try await activateDeviceSigner()
         case .email(let email):
-            let locator = "email:\(email)"
-            guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
-            let newSigner: any Signer = await MainActor.run { makeEmailSigner(email: email) }
-            selectedSigner = newSigner
-            selectedSignerLocator = locator
+            try await activateEmailSigner(email: email)
         case .phone(let phone):
-            let locator = "phone:\(phone)"
-            guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
-            throw WalletError.walletGeneric("Phone OTP signing is not yet supported on iOS.")
+            try await activatePhoneSigner(phone: phone)
         case .externalWallet(let address):
-            let locator = "external-wallet:\(address)"
-            guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
-            throw WalletError.walletGeneric(
-                "External wallet signers must approve transactions outside of the SDK."
-            )
+            try await activateExternalWalletSigner(address: address)
         case .passkey(let name, let host):
             try await activatePasskeySigner(name: name, host: host)
         case .apiKey:
-            let locator = self.config.recovery.locator
-            guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
-            guard let apiKeyData = self.config.recovery as? ApiKeySignerData else {
-                throw .walletGeneric("Recovery signer is not an ApiKeySignerData")
-            }
-            selectedSigner = ApiKeySigner(adminSigner: apiKeyData)
-            selectedSignerLocator = locator
+            try await activateApiKeySigner()
         }
     }
 
@@ -197,7 +178,8 @@ extension Wallet {
     private func activateDeviceSigner() async throws(WalletError) {
         if _deviceSignerUnsupported {
             throw .deviceSignerNotSupported(
-                "This wallet's provider does not support device signers. Use the recovery signer or another registered signer instead."
+                "This wallet's provider does not support device signers. " +
+                    "Use the recovery signer or another registered signer instead."
             )
         }
         let storage = deviceSignerKeyStorage ?? makeDeviceSignerStorage()
@@ -210,6 +192,36 @@ extension Wallet {
         }
         selectedSignerLocator = locator
         _deviceSignerApproved = true
+    }
+
+    private func activateEmailSigner(email: String) async throws(WalletError) {
+        let locator = "email:\(email)"
+        guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
+        let newSigner: any Signer = await MainActor.run { makeEmailSigner(email: email) }
+        selectedSigner = newSigner
+        selectedSignerLocator = locator
+    }
+
+    private func activatePhoneSigner(phone: String) async throws(WalletError) {
+        let locator = "phone:\(phone)"
+        guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
+        throw .walletGeneric("Phone OTP signing is not yet supported on iOS.")
+    }
+
+    private func activateExternalWalletSigner(address: String) async throws(WalletError) {
+        let locator = "external-wallet:\(address)"
+        guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
+        throw .walletGeneric("External wallet signers must approve transactions outside of the SDK.")
+    }
+
+    private func activateApiKeySigner() async throws(WalletError) {
+        let locator = config.recovery.locator
+        guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
+        guard let apiKeyData = config.recovery as? ApiKeySignerData else {
+            throw .walletGeneric("Recovery signer is not an ApiKeySignerData")
+        }
+        selectedSigner = ApiKeySigner(adminSigner: apiKeyData)
+        selectedSignerLocator = locator
     }
 
     private func activatePasskeySigner(name: String, host: String) async throws(WalletError) {

--- a/Tests/WalletTests/Data/DefaultWalletServiceTests.swift
+++ b/Tests/WalletTests/Data/DefaultWalletServiceTests.swift
@@ -58,7 +58,11 @@ struct DefaultWalletServiceTests {
     func throwsTypedErrorForDeviceSignerNotSupportedCode() async throws {
         let body = Data(
             """
-            {"error": true, "message": "Device signers are not supported for this provider", "code": "DEVICE_SIGNER_NOT_SUPPORTED"}
+            {
+                "error": true,
+                "message": "Device signers are not supported for this provider",
+                "code": "DEVICE_SIGNER_NOT_SUPPORTED"
+            }
             """.utf8
         )
         let service = try makeService(errorBody: body)

--- a/Tests/WalletTests/Mocks/MockSmartWalletService.swift
+++ b/Tests/WalletTests/Mocks/MockSmartWalletService.swift
@@ -27,7 +27,7 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
 
     // MARK: - registerTypedSigner
 
-    var registerTypedSignerResult: AddDelegatedSignerResponse = AddDelegatedSignerResponse(chains: nil, transaction: nil)
+    var registerTypedSignerResult = AddDelegatedSignerResponse(chains: nil, transaction: nil)
 
     func registerTypedSigner(
         _ signer: any AdminSignerData,

--- a/Tests/WebTests/CrossmintTEETests.swift
+++ b/Tests/WebTests/CrossmintTEETests.swift
@@ -3,537 +3,560 @@ import Foundation
 import Testing
 @testable import Web
 
-@Suite("CrossmintTEE Tests", .tags(.unit))
 @MainActor
-struct CrossmintTEETests {
-    @MainActor
-    struct TestFixture {
-        let authManager = MockAuthManager()
-        let webProxy = MockWebViewCommunicationProxy()
-        let apiKey = "test-api-key"
-        let tee: CrossmintTEE
+struct TEETestFixture {
+    let authManager = MockAuthManager()
+    let webProxy = MockWebViewCommunicationProxy()
+    let apiKey = "test-api-key"
+    let tee: CrossmintTEE
 
-        init(isProductionEnvironment: Bool = true) {
-            self.tee = CrossmintTEE(
-                auth: authManager,
-                webProxy: webProxy,
-                apiKey: apiKey,
-                isProductionEnvironment: isProductionEnvironment,
-                signerStorage: MockSignerStorage()
-            )
-        }
-
-        func setupAuthentication(
-            jwt: String? = nil,
-            email: String? = nil
-        ) async {
-            await authManager.setJWT(jwt ?? CrossmintTEETestHelpers.createTestJWT())
-            tee.email = email ?? "test@example.com"
-        }
-
-        func setupHandshake(verificationId: String = "test123") async throws {
-            let handshakeResponse = CrossmintTEETestHelpers.createHandshakeResponse(verificationId: verificationId)
-            webProxy.configureResponse(for: HandshakeResponse.self, response: handshakeResponse)
-            try await tee.load()
-        }
-
-        func configureReadyDevice() {
-            let statusResponse = CrossmintTEETestHelpers.createGetStatusResponse(
-                status: .success,
-                signerStatus: .ready
-            )
-            webProxy.configureResponse(for: GetStatusResponse.self, response: statusResponse)
-        }
-
-        func configureNewDevice() {
-            let statusResponse = CrossmintTEETestHelpers.createGetStatusResponse(
-                status: .success,
-                signerStatus: .newDevice
-            )
-            webProxy.configureResponse(for: GetStatusResponse.self, response: statusResponse)
-        }
-
-        func configureOnboardingFlow() {
-            let startOnboardingResponse = CrossmintTEETestHelpers.createStartOnboardingResponse()
-            webProxy.configureResponse(for: StartOnboardingResponse.self, response: startOnboardingResponse)
-
-            let completeOnboardingResponse = CrossmintTEETestHelpers.createCompleteOnboardingResponse()
-            webProxy.configureResponse(for: CompleteOnboardingResponse.self, response: completeOnboardingResponse)
-        }
-
-        func configureSignResponse(signature: String) {
-            let signResponse = CrossmintTEETestHelpers.createNonCustodialSignResponse(
-                signature: signature
-            )
-            webProxy.configureResponse(for: NonCustodialSignResponse.self, response: signResponse)
-        }
-
-        func configureErrorResponse(errorMessage: String) {
-            let statusResponse = CrossmintTEETestHelpers.createGetStatusResponse(
-                status: .error,
-                signerStatus: nil,
-                errorMessage: errorMessage
-            )
-            webProxy.configureResponse(for: GetStatusResponse.self, response: statusResponse)
-        }
-
-        func waitForOTPRequired() async throws {
-            var attempts = 0
-            while !tee.isOTPRequired {
-                if attempts >= 100 {
-                    throw CrossmintTEE.Error.generic("Timed out waiting for the OTP prompt")
-                }
-                await Task.yield()
-                attempts += 1
-            }
-        }
-
-        func verifyHandshakeCompleted(verificationId: String) {
-            let sentHandshakeRequest = webProxy.lastSentMessage(ofType: HandshakeRequest.self)
-            #expect(sentHandshakeRequest != nil)
-
-            let sentHandshakeComplete = webProxy.lastSentMessage(ofType: HandshakeComplete.self)
-            #expect(sentHandshakeComplete != nil)
-            #expect(sentHandshakeComplete?.data.requestVerificationId == verificationId)
-        }
-
-        func verifySignRequest(expectedTransaction: String) {
-            let statusRequest = webProxy.lastSentMessage(ofType: GetStatusRequest.self)
-            #expect(statusRequest != nil)
-            #expect(statusRequest?.data.authData.jwt == CrossmintTEETestHelpers.createTestJWT())
-
-            let signRequest = webProxy.lastSentMessage(ofType: NonCustodialSignRequest.self)
-            #expect(signRequest != nil)
-            #expect(signRequest?.data.data.bytes == expectedTransaction)
-        }
-
-        func verifyOnboardingRequests(email: String, otp: String) {
-            let startOnboardingRequest = webProxy.lastSentMessage(ofType: StartOnboardingRequest.self)
-            #expect(startOnboardingRequest != nil)
-            #expect(startOnboardingRequest?.data.data.authId == "email:\(email)")
-
-            let completeOnboardingRequest = webProxy.lastSentMessage(ofType: CompleteOnboardingRequest.self)
-            #expect(completeOnboardingRequest != nil)
-            #expect(completeOnboardingRequest?.data.data.onboardingAuthentication.encryptedOtp == otp)
-        }
-    }
-
-    @Test("Successfully completes handshake on first attempt")
-    func testSuccessfulHandshakeFirstAttempt() async throws {
-        let fixture = TestFixture()
-        try await fixture.setupHandshake(verificationId: "test123")
-
-        fixture.verifyHandshakeCompleted(verificationId: "test123")
-
-        #expect(fixture.webProxy.loadedURLs.count == 1)
-        #expect(fixture.webProxy.loadedURLs.first?.absoluteString.contains("signers.crossmint.com") == true)
-    }
-
-    @Test("Retries handshake on timeout up to 3 times")
-    func testHandshakeRetryOnTimeout() async throws {
-        let fixture = TestFixture()
-
-        await #expect(throws: CrossmintTEE.Error.handshakeFailed) {
-            try await fixture.tee.load()
-        }
-
-        let handshakeRequests = fixture.webProxy.sentMessages(ofType: HandshakeRequest.self)
-        #expect(handshakeRequests.count == 3)
-    }
-
-    @Test("Resets state correctly")
-    func testResetState() async throws {
-        let fixture = TestFixture()
-        try await fixture.setupHandshake()
-
-        fixture.tee.resetState()
-        fixture.webProxy.clearResponse(for: HandshakeResponse.self)
-
-        #expect(fixture.webProxy.resetCount == 1)
-
-        await #expect(throws: CrossmintTEE.Error.handshakeFailed) {
-            _ = try await fixture.tee.signTransaction(
-                transaction: "test",
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
-    }
-
-    @Test("Load fails when URL is not available")
-    func testLoadFailsWhenURLNotAvailable() async throws {
-        let fixture = TestFixture()
-
-        fixture.webProxy.shouldThrowOnLoad = true
-        fixture.webProxy.loadError = WebViewError.webViewNotAvailable
-
-        await #expect(throws: CrossmintTEE.Error.urlNotAvailable) {
-            try await fixture.tee.load()
-        }
-    }
-
-    @Test("Signs transaction when device is ready")
-    func testSignTransactionWhenDeviceReady() async throws {
-        let fixture = TestFixture()
-        await fixture.setupAuthentication()
-        try await fixture.setupHandshake()
-
-        fixture.configureReadyDevice()
-        fixture.configureSignResponse(signature: "0xsignature123")
-
-        let transaction = CrossmintTEETestHelpers.createTestTransaction()
-        let signature = try await fixture.tee.signTransaction(
-            transaction: transaction,
-            keyType: "keyType",
-            encoding: "encoding"
+    init(isProductionEnvironment: Bool = true) {
+        self.tee = CrossmintTEE(
+            auth: authManager,
+            webProxy: webProxy,
+            apiKey: apiKey,
+            isProductionEnvironment: isProductionEnvironment,
+            signerStorage: MockSignerStorage()
         )
-
-        #expect(signature == "0xsignature123")
-        fixture.verifySignRequest(expectedTransaction: transaction)
     }
 
-    @Test("Completes full onboarding flow for new device")
-    func testFullOnboardingFlowForNewDevice() async throws {
-        let fixture = TestFixture()
-        await fixture.setupAuthentication()
-        try await fixture.setupHandshake()
-
-        fixture.configureNewDevice()
-        fixture.configureOnboardingFlow()
-        fixture.configureSignResponse(signature: "0xsignature456")
-
-        let signTask = Task {
-            try await fixture.tee.signTransaction(
-                transaction: CrossmintTEETestHelpers.createTestTransaction(),
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
-
-        try await fixture.waitForOTPRequired()
-
-        fixture.tee.provideOTP("123456")
-
-        let signature = try await signTask.value
-        #expect(signature == "0xsignature456")
-        #expect(fixture.tee.isOTPRequired == false)
-
-        fixture.verifyOnboardingRequests(email: "test@example.com", otp: "123456")
+    func setupAuthentication(
+        jwt: String? = nil,
+        email: String? = nil
+    ) async {
+        await authManager.setJWT(jwt ?? CrossmintTEETestHelpers.createTestJWT())
+        tee.email = email ?? "test@example.com"
     }
 
-    @Test("Signing fails without handshake")
-    func testSigningFailsWithoutHandshake() async throws {
-        let fixture = TestFixture()
-
-        await #expect(throws: CrossmintTEE.Error.handshakeFailed) {
-            _ = try await fixture.tee.signTransaction(
-                transaction: "test",
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
+    func setupHandshake(verificationId: String = "test123") async throws {
+        let handshakeResponse = CrossmintTEETestHelpers.createHandshakeResponse(verificationId: verificationId)
+        webProxy.configureResponse(for: HandshakeResponse.self, response: handshakeResponse)
+        try await tee.load()
     }
 
-    @Test("Signing fails without JWT")
-    func testSigningFailsWithoutJWT() async throws {
-        let fixture = TestFixture()
-        try await fixture.setupHandshake()
-
-        await #expect(throws: CrossmintTEE.Error.jwtRequired) {
-            _ = try await fixture.tee.signTransaction(
-                transaction: "test",
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
-    }
-
-    @Test("Handles server error response")
-    func testHandlesServerErrorResponse() async throws {
-        let fixture = TestFixture()
-        await fixture.setupAuthentication()
-        try await fixture.setupHandshake()
-
-        fixture.configureErrorResponse(errorMessage: "Server error occurred")
-
-        await #expect(throws: CrossmintTEE.Error.generic("Server error occurred")) {
-            _ = try await fixture.tee.signTransaction(
-                transaction: "test",
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
-    }
-
-    @Test("Handles invalid signature response")
-    func testHandlesInvalidSignatureResponse() async throws {
-        let fixture = TestFixture()
-        await fixture.setupAuthentication()
-        try await fixture.setupHandshake()
-
-        fixture.configureReadyDevice()
-
-        let signResponse = CrossmintTEETestHelpers.createNonCustodialSignResponse(
-            signature: "",
-            status: .success
+    func configureReadyDevice() {
+        let statusResponse = CrossmintTEETestHelpers.createGetStatusResponse(
+            status: .success,
+            signerStatus: .ready
         )
-        fixture.webProxy.configureResponse(for: NonCustodialSignResponse.self, response: signResponse)
-
-        await #expect(throws: CrossmintTEE.Error.invalidSignature) {
-            _ = try await fixture.tee.signTransaction(
-                transaction: "test",
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
+        webProxy.configureResponse(for: GetStatusResponse.self, response: statusResponse)
     }
 
-    @Test("OTP cancellation handled correctly")
-    func testOTPCancellation() async throws {
-        let fixture = TestFixture()
-        await fixture.setupAuthentication()
-        try await fixture.setupHandshake()
-
-        fixture.configureNewDevice()
-        fixture.configureOnboardingFlow()
-
-        let signTask = Task {
-            try await fixture.tee.signTransaction(
-                transaction: CrossmintTEETestHelpers.createTestTransaction(),
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
-
-        try await fixture.waitForOTPRequired()
-
-        fixture.tee.cancelOTP()
-
-        await #expect(throws: CrossmintTEE.Error.userCancelled) {
-            _ = try await signTask.value
-        }
-
-        #expect(fixture.tee.isOTPRequired == false)
-    }
-
-    @Test("isOTPRequired property updates correctly")
-    func testIsOTPRequiredPropertyUpdates() async throws {
-        let fixture = TestFixture()
-        await fixture.setupAuthentication()
-        try await fixture.setupHandshake()
-
-        #expect(fixture.tee.isOTPRequired == false)
-
-        fixture.configureNewDevice()
-        fixture.configureOnboardingFlow()
-        fixture.configureSignResponse(signature: "0xsignature789")
-
-        let signTask = Task {
-            try await fixture.tee.signTransaction(
-                transaction: CrossmintTEETestHelpers.createTestTransaction(),
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
-
-        try await fixture.waitForOTPRequired()
-
-        fixture.tee.provideOTP("123456")
-
-        _ = try await signTask.value
-
-        #expect(fixture.tee.isOTPRequired == false)
-    }
-
-    @Test("Cancelling second duplicate request does not affect first")
-    func testCancellingSecondDuplicateRequestDoesNotAffectFirst() async throws {
-        let fixture = TestFixture()
-        await fixture.setupAuthentication()
-
-        let handshakeResponse = CrossmintTEETestHelpers.createHandshakeResponse(verificationId: "test123")
-        fixture.webProxy.configureResponseWithDelay(
-            for: HandshakeResponse.self,
-            response: handshakeResponse,
-            delay: 0.3
+    func configureNewDevice() {
+        let statusResponse = CrossmintTEETestHelpers.createGetStatusResponse(
+            status: .success,
+            signerStatus: .newDevice
         )
-        fixture.configureReadyDevice()
-        fixture.configureSignResponse(signature: "0xsignature_first")
-
-        let transaction = CrossmintTEETestHelpers.createTestTransaction()
-
-        let task1 = Task {
-            try await fixture.tee.signTransaction(
-                transaction: transaction,
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
-
-        await Task.yield()
-
-        let task2 = Task {
-            try await fixture.tee.signTransaction(
-                transaction: transaction,
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
-
-        await Task.yield()
-
-        task2.cancel()
-
-        let result1 = await task1.result
-        let result2 = await task2.result
-
-        switch result1 {
-        case .success(let signature):
-            #expect(signature == "0xsignature_first")
-        case .failure(let error):
-            Issue.record("First task should succeed but failed with: \(error)")
-        }
-
-        switch result2 {
-        case .success:
-            Issue.record("Second task should have been cancelled")
-        case .failure:
-            break
-        }
+        webProxy.configureResponse(for: GetStatusResponse.self, response: statusResponse)
     }
 
-    @Test("Recovers and re-handshakes after web content process termination")
-    func testRecoversAfterWebContentProcessTermination() async throws {
-        let fixture = TestFixture()
-        await fixture.setupAuthentication()
-        try await fixture.setupHandshake(verificationId: "test123")
-
-        #expect(fixture.webProxy.loadedURLs.count == 1)
-        #expect(fixture.webProxy.sentMessages(ofType: HandshakeRequest.self).count == 1)
-
-        fixture.webProxy.onWebContentProcessTerminated()
-        await fixture.tee.recoveryTask?.value
-
-        #expect(fixture.webProxy.loadedURLs.count == 2)
-        #expect(fixture.webProxy.sentMessages(ofType: HandshakeRequest.self).count == 2)
-
-        fixture.configureReadyDevice()
-        fixture.configureSignResponse(signature: "0xrecovered")
-
-        let transaction = CrossmintTEETestHelpers.createTestTransaction()
-        let signature = try await fixture.tee.signTransaction(
-            transaction: transaction,
-            keyType: "keyType",
-            encoding: "encoding"
-        )
-
-        #expect(signature == "0xrecovered")
-    }
-
-    @Test("resetState cancels an in-flight recovery and frees it to start again")
-    func testResetStateCancelsInFlightRecovery() async throws {
-        let fixture = TestFixture()
-        await fixture.setupAuthentication()
-        try await fixture.setupHandshake(verificationId: "test123")
-
-        fixture.webProxy.onWebContentProcessTerminated()
-        #expect(fixture.tee.recoveryTask != nil)
-
-        fixture.tee.resetState()
-        #expect(fixture.tee.recoveryTask == nil)
-
-        fixture.webProxy.onWebContentProcessTerminated()
-        #expect(fixture.tee.recoveryTask != nil)
-    }
-
-    @Test("Multiple identical requests process independently")
-    func testMultipleIdenticalRequestsProcessIndependently() async throws {
-        let fixture = TestFixture()
-        await fixture.setupAuthentication()
-
-        let handshakeResponse = CrossmintTEETestHelpers.createHandshakeResponse(verificationId: "test123")
-        fixture.webProxy.configureResponseWithDelay(
-            for: HandshakeResponse.self,
-            response: handshakeResponse,
-            delay: 0.2
-        )
-        fixture.configureReadyDevice()
-        fixture.configureSignResponse(signature: "0xsignature_all")
-
-        let transaction = CrossmintTEETestHelpers.createTestTransaction()
-
-        let task1 = Task {
-            try await fixture.tee.signTransaction(
-                transaction: transaction,
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
-
-        let task2 = Task {
-            try await fixture.tee.signTransaction(
-                transaction: transaction,
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
-
-        let task3 = Task {
-            try await fixture.tee.signTransaction(
-                transaction: transaction,
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
-
-        let results = await [task1.result, task2.result, task3.result]
-
-        var successCount = 0
-        for result in results {
-            switch result {
-            case .success(let signature):
-                #expect(signature == "0xsignature_all")
-                successCount += 1
-            case .failure(let error):
-                Issue.record("Task failed unexpectedly: \(error)")
-            }
-        }
-
-        #expect(successCount == 3)
-    }
-
-    @Test("Re-onboards with a fresh OTP when the frame reloads mid-onboarding")
-    func testReonboardsWhenFrameReloadsMidOnboarding() async throws {
-        let fixture = TestFixture()
-        await fixture.setupAuthentication()
-        try await fixture.setupHandshake()
-
-        fixture.configureNewDevice()
+    func configureOnboardingFlow() {
         let startOnboardingResponse = CrossmintTEETestHelpers.createStartOnboardingResponse()
-        fixture.webProxy.configureResponse(for: StartOnboardingResponse.self, response: startOnboardingResponse)
-        fixture.configureSignResponse(signature: "0xsignature_reonboard")
-
-        let signTask = Task {
-            try await fixture.tee.signTransaction(
-                transaction: CrossmintTEETestHelpers.createTestTransaction(),
-                keyType: "keyType",
-                encoding: "encoding"
-            )
-        }
-
-        try await fixture.waitForOTPRequired()
-        #expect(fixture.tee.isOTPRequired == true)
-        fixture.tee.provideOTP("stale-otp")
-
-        try await fixture.waitForOTPRequired()
-        #expect(fixture.tee.isOTPRequired == true)
+        webProxy.configureResponse(for: StartOnboardingResponse.self, response: startOnboardingResponse)
 
         let completeOnboardingResponse = CrossmintTEETestHelpers.createCompleteOnboardingResponse()
-        fixture.webProxy.configureResponse(for: CompleteOnboardingResponse.self, response: completeOnboardingResponse)
-        fixture.tee.provideOTP("fresh-otp")
+        webProxy.configureResponse(for: CompleteOnboardingResponse.self, response: completeOnboardingResponse)
+    }
 
-        let signature = try await signTask.value
-        #expect(signature == "0xsignature_reonboard")
-        #expect(fixture.tee.isOTPRequired == false)
-        #expect(fixture.webProxy.completeOnboardingRequestCount == 2)
+    func configureSignResponse(signature: String) {
+        let signResponse = CrossmintTEETestHelpers.createNonCustodialSignResponse(
+            signature: signature
+        )
+        webProxy.configureResponse(for: NonCustodialSignResponse.self, response: signResponse)
+    }
+
+    func configureErrorResponse(errorMessage: String) {
+        let statusResponse = CrossmintTEETestHelpers.createGetStatusResponse(
+            status: .error,
+            signerStatus: nil,
+            errorMessage: errorMessage
+        )
+        webProxy.configureResponse(for: GetStatusResponse.self, response: statusResponse)
+    }
+
+    func waitForOTPRequired() async throws {
+        var attempts = 0
+        while !tee.isOTPRequired {
+            if attempts >= 100 {
+                throw CrossmintTEE.Error.generic("Timed out waiting for the OTP prompt")
+            }
+            await Task.yield()
+            attempts += 1
+        }
+    }
+
+    func verifyHandshakeCompleted(verificationId: String) {
+        let sentHandshakeRequest = webProxy.lastSentMessage(ofType: HandshakeRequest.self)
+        #expect(sentHandshakeRequest != nil)
+
+        let sentHandshakeComplete = webProxy.lastSentMessage(ofType: HandshakeComplete.self)
+        #expect(sentHandshakeComplete != nil)
+        #expect(sentHandshakeComplete?.data.requestVerificationId == verificationId)
+    }
+
+    func verifySignRequest(expectedTransaction: String) {
+        let statusRequest = webProxy.lastSentMessage(ofType: GetStatusRequest.self)
+        #expect(statusRequest != nil)
+        #expect(statusRequest?.data.authData.jwt == CrossmintTEETestHelpers.createTestJWT())
+
+        let signRequest = webProxy.lastSentMessage(ofType: NonCustodialSignRequest.self)
+        #expect(signRequest != nil)
+        #expect(signRequest?.data.data.bytes == expectedTransaction)
+    }
+
+    func verifyOnboardingRequests(email: String, otp: String) {
+        let startOnboardingRequest = webProxy.lastSentMessage(ofType: StartOnboardingRequest.self)
+        #expect(startOnboardingRequest != nil)
+        #expect(startOnboardingRequest?.data.data.authId == "email:\(email)")
+
+        let completeOnboardingRequest = webProxy.lastSentMessage(ofType: CompleteOnboardingRequest.self)
+        #expect(completeOnboardingRequest != nil)
+        #expect(completeOnboardingRequest?.data.data.onboardingAuthentication.encryptedOtp == otp)
+    }
+}
+
+@Suite("CrossmintTEE Tests", .tags(.unit))
+struct CrossmintTEETests {
+
+    @Suite("Handshake")
+    @MainActor
+    struct HandshakeTests {
+        @Test("Successfully completes handshake on first attempt")
+        func testSuccessfulHandshakeFirstAttempt() async throws {
+            let fixture = TEETestFixture()
+            try await fixture.setupHandshake(verificationId: "test123")
+
+            fixture.verifyHandshakeCompleted(verificationId: "test123")
+
+            #expect(fixture.webProxy.loadedURLs.count == 1)
+            #expect(fixture.webProxy.loadedURLs.first?.absoluteString.contains("signers.crossmint.com") == true)
+        }
+
+        @Test("Retries handshake on timeout up to 3 times")
+        func testHandshakeRetryOnTimeout() async throws {
+            let fixture = TEETestFixture()
+
+            await #expect(throws: CrossmintTEE.Error.handshakeFailed) {
+                try await fixture.tee.load()
+            }
+
+            let handshakeRequests = fixture.webProxy.sentMessages(ofType: HandshakeRequest.self)
+            #expect(handshakeRequests.count == 3)
+        }
+
+        @Test("Resets state correctly")
+        func testResetState() async throws {
+            let fixture = TEETestFixture()
+            try await fixture.setupHandshake()
+
+            fixture.tee.resetState()
+            fixture.webProxy.clearResponse(for: HandshakeResponse.self)
+
+            #expect(fixture.webProxy.resetCount == 1)
+
+            await #expect(throws: CrossmintTEE.Error.handshakeFailed) {
+                _ = try await fixture.tee.signTransaction(
+                    transaction: "test",
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+        }
+
+        @Test("Load fails when URL is not available")
+        func testLoadFailsWhenURLNotAvailable() async throws {
+            let fixture = TEETestFixture()
+
+            fixture.webProxy.shouldThrowOnLoad = true
+            fixture.webProxy.loadError = WebViewError.webViewNotAvailable
+
+            await #expect(throws: CrossmintTEE.Error.urlNotAvailable) {
+                try await fixture.tee.load()
+            }
+        }
+    }
+
+    @Suite("Signing")
+    @MainActor
+    struct SigningTests {
+        @Test("Signs transaction when device is ready")
+        func testSignTransactionWhenDeviceReady() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+            try await fixture.setupHandshake()
+
+            fixture.configureReadyDevice()
+            fixture.configureSignResponse(signature: "0xsignature123")
+
+            let transaction = CrossmintTEETestHelpers.createTestTransaction()
+            let signature = try await fixture.tee.signTransaction(
+                transaction: transaction,
+                keyType: "keyType",
+                encoding: "encoding"
+            )
+
+            #expect(signature == "0xsignature123")
+            fixture.verifySignRequest(expectedTransaction: transaction)
+        }
+
+        @Test("Signing fails without handshake")
+        func testSigningFailsWithoutHandshake() async throws {
+            let fixture = TEETestFixture()
+
+            await #expect(throws: CrossmintTEE.Error.handshakeFailed) {
+                _ = try await fixture.tee.signTransaction(
+                    transaction: "test",
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+        }
+
+        @Test("Signing fails without JWT")
+        func testSigningFailsWithoutJWT() async throws {
+            let fixture = TEETestFixture()
+            try await fixture.setupHandshake()
+
+            await #expect(throws: CrossmintTEE.Error.jwtRequired) {
+                _ = try await fixture.tee.signTransaction(
+                    transaction: "test",
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+        }
+
+        @Test("Handles server error response")
+        func testHandlesServerErrorResponse() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+            try await fixture.setupHandshake()
+
+            fixture.configureErrorResponse(errorMessage: "Server error occurred")
+
+            await #expect(throws: CrossmintTEE.Error.generic("Server error occurred")) {
+                _ = try await fixture.tee.signTransaction(
+                    transaction: "test",
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+        }
+
+        @Test("Handles invalid signature response")
+        func testHandlesInvalidSignatureResponse() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+            try await fixture.setupHandshake()
+
+            fixture.configureReadyDevice()
+
+            let signResponse = CrossmintTEETestHelpers.createNonCustodialSignResponse(
+                signature: "",
+                status: .success
+            )
+            fixture.webProxy.configureResponse(for: NonCustodialSignResponse.self, response: signResponse)
+
+            await #expect(throws: CrossmintTEE.Error.invalidSignature) {
+                _ = try await fixture.tee.signTransaction(
+                    transaction: "test",
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+        }
+    }
+
+    @Suite("Onboarding")
+    @MainActor
+    struct OnboardingTests {
+        @Test("Completes full onboarding flow for new device")
+        func testFullOnboardingFlowForNewDevice() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+            try await fixture.setupHandshake()
+
+            fixture.configureNewDevice()
+            fixture.configureOnboardingFlow()
+            fixture.configureSignResponse(signature: "0xsignature456")
+
+            let signTask = Task {
+                try await fixture.tee.signTransaction(
+                    transaction: CrossmintTEETestHelpers.createTestTransaction(),
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+
+            try await fixture.waitForOTPRequired()
+
+            fixture.tee.provideOTP("123456")
+
+            let signature = try await signTask.value
+            #expect(signature == "0xsignature456")
+            #expect(fixture.tee.isOTPRequired == false)
+
+            fixture.verifyOnboardingRequests(email: "test@example.com", otp: "123456")
+        }
+
+        @Test("OTP cancellation handled correctly")
+        func testOTPCancellation() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+            try await fixture.setupHandshake()
+
+            fixture.configureNewDevice()
+            fixture.configureOnboardingFlow()
+
+            let signTask = Task {
+                try await fixture.tee.signTransaction(
+                    transaction: CrossmintTEETestHelpers.createTestTransaction(),
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+
+            try await fixture.waitForOTPRequired()
+
+            fixture.tee.cancelOTP()
+
+            await #expect(throws: CrossmintTEE.Error.userCancelled) {
+                _ = try await signTask.value
+            }
+
+            #expect(fixture.tee.isOTPRequired == false)
+        }
+
+        @Test("isOTPRequired property updates correctly")
+        func testIsOTPRequiredPropertyUpdates() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+            try await fixture.setupHandshake()
+
+            #expect(fixture.tee.isOTPRequired == false)
+
+            fixture.configureNewDevice()
+            fixture.configureOnboardingFlow()
+            fixture.configureSignResponse(signature: "0xsignature789")
+
+            let signTask = Task {
+                try await fixture.tee.signTransaction(
+                    transaction: CrossmintTEETestHelpers.createTestTransaction(),
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+
+            try await fixture.waitForOTPRequired()
+
+            fixture.tee.provideOTP("123456")
+
+            _ = try await signTask.value
+
+            #expect(fixture.tee.isOTPRequired == false)
+        }
+
+        @Test("Re-onboards with a fresh OTP when the frame reloads mid-onboarding")
+        func testReonboardsWhenFrameReloadsMidOnboarding() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+            try await fixture.setupHandshake()
+
+            fixture.configureNewDevice()
+            let startOnboardingResponse = CrossmintTEETestHelpers.createStartOnboardingResponse()
+            fixture.webProxy.configureResponse(for: StartOnboardingResponse.self, response: startOnboardingResponse)
+            fixture.configureSignResponse(signature: "0xsignature_reonboard")
+
+            let signTask = Task {
+                try await fixture.tee.signTransaction(
+                    transaction: CrossmintTEETestHelpers.createTestTransaction(),
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+
+            try await fixture.waitForOTPRequired()
+            #expect(fixture.tee.isOTPRequired == true)
+            fixture.tee.provideOTP("stale-otp")
+
+            try await fixture.waitForOTPRequired()
+            #expect(fixture.tee.isOTPRequired == true)
+
+            let completeOnboardingResponse = CrossmintTEETestHelpers.createCompleteOnboardingResponse()
+            fixture.webProxy.configureResponse(
+                for: CompleteOnboardingResponse.self,
+                response: completeOnboardingResponse
+            )
+            fixture.tee.provideOTP("fresh-otp")
+
+            let signature = try await signTask.value
+            #expect(signature == "0xsignature_reonboard")
+            #expect(fixture.tee.isOTPRequired == false)
+            #expect(fixture.webProxy.completeOnboardingRequestCount == 2)
+        }
+    }
+
+    @Suite("Concurrent Requests")
+    @MainActor
+    struct ConcurrentRequestsTests {
+        @Test("Cancelling second duplicate request does not affect first")
+        func testCancellingSecondDuplicateRequestDoesNotAffectFirst() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+
+            let handshakeResponse = CrossmintTEETestHelpers.createHandshakeResponse(verificationId: "test123")
+            fixture.webProxy.configureResponseWithDelay(
+                for: HandshakeResponse.self,
+                response: handshakeResponse,
+                delay: 0.3
+            )
+            fixture.configureReadyDevice()
+            fixture.configureSignResponse(signature: "0xsignature_first")
+
+            let transaction = CrossmintTEETestHelpers.createTestTransaction()
+
+            let task1 = Task {
+                try await fixture.tee.signTransaction(
+                    transaction: transaction,
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+
+            await Task.yield()
+
+            let task2 = Task {
+                try await fixture.tee.signTransaction(
+                    transaction: transaction,
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+
+            await Task.yield()
+
+            task2.cancel()
+
+            let result1 = await task1.result
+            let result2 = await task2.result
+
+            switch result1 {
+            case .success(let signature):
+                #expect(signature == "0xsignature_first")
+            case .failure(let error):
+                Issue.record("First task should succeed but failed with: \(error)")
+            }
+
+            switch result2 {
+            case .success:
+                Issue.record("Second task should have been cancelled")
+            case .failure:
+                break
+            }
+        }
+
+        @Test("Multiple identical requests process independently")
+        func testMultipleIdenticalRequestsProcessIndependently() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+
+            let handshakeResponse = CrossmintTEETestHelpers.createHandshakeResponse(verificationId: "test123")
+            fixture.webProxy.configureResponseWithDelay(
+                for: HandshakeResponse.self,
+                response: handshakeResponse,
+                delay: 0.2
+            )
+            fixture.configureReadyDevice()
+            fixture.configureSignResponse(signature: "0xsignature_all")
+
+            let transaction = CrossmintTEETestHelpers.createTestTransaction()
+
+            let task1 = Task {
+                try await fixture.tee.signTransaction(
+                    transaction: transaction,
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+
+            let task2 = Task {
+                try await fixture.tee.signTransaction(
+                    transaction: transaction,
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+
+            let task3 = Task {
+                try await fixture.tee.signTransaction(
+                    transaction: transaction,
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+
+            let results = await [task1.result, task2.result, task3.result]
+
+            var successCount = 0
+            for result in results {
+                switch result {
+                case .success(let signature):
+                    #expect(signature == "0xsignature_all")
+                    successCount += 1
+                case .failure(let error):
+                    Issue.record("Task failed unexpectedly: \(error)")
+                }
+            }
+
+            #expect(successCount == 3)
+        }
+    }
+
+    @Suite("Recovery")
+    @MainActor
+    struct RecoveryTests {
+        @Test("Recovers and re-handshakes after web content process termination")
+        func testRecoversAfterWebContentProcessTermination() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+            try await fixture.setupHandshake(verificationId: "test123")
+
+            #expect(fixture.webProxy.loadedURLs.count == 1)
+            #expect(fixture.webProxy.sentMessages(ofType: HandshakeRequest.self).count == 1)
+
+            fixture.webProxy.onWebContentProcessTerminated()
+            await fixture.tee.recoveryTask?.value
+
+            #expect(fixture.webProxy.loadedURLs.count == 2)
+            #expect(fixture.webProxy.sentMessages(ofType: HandshakeRequest.self).count == 2)
+
+            fixture.configureReadyDevice()
+            fixture.configureSignResponse(signature: "0xrecovered")
+
+            let transaction = CrossmintTEETestHelpers.createTestTransaction()
+            let signature = try await fixture.tee.signTransaction(
+                transaction: transaction,
+                keyType: "keyType",
+                encoding: "encoding"
+            )
+
+            #expect(signature == "0xrecovered")
+        }
+
+        @Test("resetState cancels an in-flight recovery and frees it to start again")
+        func testResetStateCancelsInFlightRecovery() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+            try await fixture.setupHandshake(verificationId: "test123")
+
+            fixture.webProxy.onWebContentProcessTerminated()
+            #expect(fixture.tee.recoveryTask != nil)
+
+            fixture.tee.resetState()
+            #expect(fixture.tee.recoveryTask == nil)
+
+            fixture.webProxy.onWebContentProcessTerminated()
+            #expect(fixture.tee.recoveryTask != nil)
+        }
     }
 }


### PR DESCRIPTION
This pull request cleans up all SwiftLint warnings in this project, and some additional unused code warnings.

## Changes

- Wrapped lines exceeding the 120-character limit across `DefaultAuthManager`, `DeviceSignerService`, `DefaultCrossmintWallets`, and two test files
- Split `Wallet+SignerManagement.useSigner` into one helper per signer type, dropping cyclomatic complexity from 11 to a plain switch, and removed a dead `WalletError` cast in `addSigner` that could never fail
- Split `EVMWallet.approveSignature` into `approveDeviceSignature` and `mapSignerError` to get it under the function body length limit
- Removed two casts in `DefaultCrossmintService.executeRequestForRawData` that could never actually execute, since the underlying call only ever throws `NetworkError`
- Fixed `AuthenticationResponseJSON.type` decoding by removing its default value, which was silently blocking Codable from ever writing to it
- Split `CrossmintTEETests` into nested suites by concern (Handshake, Signing, Onboarding, Concurrent Requests, Recovery) to get under the type body length limit