### PR TITLE
Bump stale SDKVersion value

### DIFF
--- a/CrossmintDeviceSigner.podspec
+++ b/CrossmintDeviceSigner.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CrossmintDeviceSigner'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.summary          = 'Hardware-backed device signer key storage for Crossmint wallets (iOS).'
   s.homepage         = 'https://github.com/Crossmint/crossmint-swift-sdk'
   s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }

--- a/Sources/Utils/SDKVersion.swift
+++ b/Sources/Utils/SDKVersion.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-/// This version is automatically updated by the release workflow
+/// Shipped in Datadog logs. Bump this to match the release tag when cutting a release.
 public enum SDKVersion {
     /// The current version of the Crossmint Swift SDK
-    public static let version = "0.0.9"
+    public static let version = "1.1.1"
 }


### PR DESCRIPTION
The SDK version in Datadog logs had been frozen at `0.0.9`, so every release since reported the wrong version. This bumps it to `1.1.1` to match the release being cut

Will work on fixing our stale release automation, which will bump the tag version in this file automatically, in a follow up pull request