### PR TITLE
Add isSignerApproved to Wallet

### DIFF
--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -227,6 +227,12 @@ public enum LogEvents {
     /// API: Wallet retrieved successfully
     public static let apiGetWalletSuccess = "wallets.api.getWallet.success"
 
+    /// API: Getting signer
+    public static let apiGetSignerStart = "wallets.api.getSigner"
+
+    /// API: Signer retrieved successfully
+    public static let apiGetSignerSuccess = "wallets.api.getSigner.success"
+
     /// API: Sending transaction
     public static let apiSendStart = "wallets.api.send"
 
@@ -402,6 +408,17 @@ public enum LogEvents {
 
     /// addSigner failed
     public static let walletAddSignerError = "wallet.addSigner.error"
+
+    // MARK: - isSignerApproved Events
+
+    /// Starting isSignerApproved
+    public static let walletIsSignerApprovedStart = "wallet.isSignerApproved.start"
+
+    /// isSignerApproved resolved
+    public static let walletIsSignerApprovedSuccess = "wallet.isSignerApproved.success"
+
+    /// isSignerApproved failed
+    public static let walletIsSignerApprovedError = "wallet.isSignerApproved.error"
 
     // MARK: - recover Events
 

--- a/Sources/Wallet/Data/CreateWallet/AddDelegatedSignerResponse.swift
+++ b/Sources/Wallet/Data/CreateWallet/AddDelegatedSignerResponse.swift
@@ -13,6 +13,12 @@ public struct ChainRegistrationEntry: Decodable {
 /// entries EVM returns under `chains`.
 public struct RegistrationTransaction: Decodable {
     public let id: String
+    public let status: String?
+
+    init(id: String, status: String? = nil) {
+        self.id = id
+        self.status = status
+    }
 }
 
 public struct AddDelegatedSignerResponse: Decodable {

--- a/Sources/Wallet/Data/DefaultSmartWalletService.swift
+++ b/Sources/Wallet/Data/DefaultSmartWalletService.swift
@@ -82,7 +82,7 @@ public final class DefaultSmartWalletService: SmartWalletService {
     public func getSigner(
         _ signerLocator: String,
         chainType: ChainType
-    ) async throws(WalletError) -> AddDelegatedSignerResponse {
+    ) async throws(WalletError) -> AddDelegatedSignerResponse? {
         try await walletService.getSigner(signerLocator, chainType: chainType)
     }
 

--- a/Sources/Wallet/Data/DefaultSmartWalletService.swift
+++ b/Sources/Wallet/Data/DefaultSmartWalletService.swift
@@ -79,6 +79,13 @@ public final class DefaultSmartWalletService: SmartWalletService {
         try await walletService.removeSigner(signerLocator, chainType: chainType, chainName: chainName)
     }
 
+    public func getSigner(
+        _ signerLocator: String,
+        chainType: ChainType
+    ) async throws(WalletError) -> AddDelegatedSignerResponse {
+        try await walletService.getSigner(signerLocator, chainType: chainType)
+    }
+
     // MARK: - TransactionService
 
     public func createTransaction(

--- a/Sources/Wallet/Data/Endpoints/WalletEndpoints.swift
+++ b/Sources/Wallet/Data/Endpoints/WalletEndpoints.swift
@@ -15,6 +15,18 @@ extension Endpoint {
         Endpoint(path: "/v1-alpha2/wallets/\(address)/balances", method: .post, headers: headers, body: body)
     }
 
+    static func getSigner(
+        chainType: ChainType,
+        encodedLocator: String,
+        headers: [String: String] = [:]
+    ) -> Endpoint {
+        Endpoint(
+            path: "/2025-06-09/wallets/me:\(chainType.rawValue)/signers/\(encodedLocator)",
+            method: .get,
+            headers: headers
+        )
+    }
+
     static func removeSigner(
         chainType: ChainType,
         encodedLocator: String,

--- a/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
+++ b/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
@@ -92,13 +92,19 @@ struct DefaultWalletService: WalletService {
     func getSigner(
         _ signerLocator: String,
         chainType: ChainType
-    ) async throws(WalletError) -> AddDelegatedSignerResponse {
+    ) async throws(WalletError) -> AddDelegatedSignerResponse? {
         Logger.smartWallet.info(LogEvents.apiGetSignerStart, attributes: ["locator": signerLocator])
         let endpoint = Endpoint.getSigner(
             chainType: chainType,
             encodedLocator: encodedSignerLocator(signerLocator)
         )
-        let data = try await crossmintService.executeRequestForRawData(endpoint, errorType: WalletError.self)
+        let data: Data
+        do {
+            data = try await crossmintService.executeRequestForRawData(endpoint, errorType: WalletError.self)
+        } catch {
+            if case .walletNotFound = error { return nil }
+            throw error
+        }
         guard let result = try? jsonCoder.decode(AddDelegatedSignerResponse.self, from: data) else {
             throw WalletError.walletGeneric("Failed to decode signer response")
         }

--- a/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
+++ b/Sources/Wallet/Data/Services/Wallet/DefaultWalletService.swift
@@ -89,6 +89,23 @@ struct DefaultWalletService: WalletService {
         return try decodeTransaction(from: data, mapping: chainType.mappingType)
     }
 
+    func getSigner(
+        _ signerLocator: String,
+        chainType: ChainType
+    ) async throws(WalletError) -> AddDelegatedSignerResponse {
+        Logger.smartWallet.info(LogEvents.apiGetSignerStart, attributes: ["locator": signerLocator])
+        let endpoint = Endpoint.getSigner(
+            chainType: chainType,
+            encodedLocator: encodedSignerLocator(signerLocator)
+        )
+        let data = try await crossmintService.executeRequestForRawData(endpoint, errorType: WalletError.self)
+        guard let result = try? jsonCoder.decode(AddDelegatedSignerResponse.self, from: data) else {
+            throw WalletError.walletGeneric("Failed to decode signer response")
+        }
+        Logger.smartWallet.info(LogEvents.apiGetSignerSuccess, attributes: ["locator": signerLocator])
+        return result
+    }
+
     private func decodeTransaction<T: WalletTypeTransactionMapping>(
         from data: Data,
         mapping: T.Type

--- a/Sources/Wallet/Data/Services/Wallet/WalletService.swift
+++ b/Sources/Wallet/Data/Services/Wallet/WalletService.swift
@@ -32,4 +32,9 @@ public protocol WalletService: Sendable {
         chainType: ChainType,
         chainName: String
     ) async throws(TransactionError) -> any TransactionApiModel
+
+    func getSigner(
+        _ signerLocator: String,
+        chainType: ChainType
+    ) async throws(WalletError) -> AddDelegatedSignerResponse
 }

--- a/Sources/Wallet/Data/Services/Wallet/WalletService.swift
+++ b/Sources/Wallet/Data/Services/Wallet/WalletService.swift
@@ -36,5 +36,5 @@ public protocol WalletService: Sendable {
     func getSigner(
         _ signerLocator: String,
         chainType: ChainType
-    ) async throws(WalletError) -> AddDelegatedSignerResponse
+    ) async throws(WalletError) -> AddDelegatedSignerResponse?
 }

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -105,20 +105,27 @@ open class Wallet: @unchecked Sendable {
     /// Returns whether the given signer is approved and usable on this wallet's chain.
     ///
     /// A freshly registered signer can require approval before it can sign — see ``addSigner(_:)``.
-    /// Returns `false` when the signer is not registered, and on any network error.
+    /// Returns `false` when the signer is not registered on this wallet.
     ///
     /// - Parameter locator: A signer locator string, e.g. `"email:user@example.com"`,
     ///   `"device:<pubkey>"`, `"api-key"`, `"passkey:<id>"`.
-    public func isSignerApproved(_ locator: String) async -> Bool {
+    /// - Throws: ``WalletError`` if the request fails.
+    public func isSignerApproved(_ locator: String) async throws(WalletError) -> Bool {
         Logger.smartWallet.debug(LogEvents.walletIsSignerApprovedStart)
         let response: AddDelegatedSignerResponse
         do {
             response = try await smartWalletService.getSigner(locator, chainType: chain.chainType)
         } catch {
+            if case .walletNotFound = error {
+                Logger.smartWallet.debug(LogEvents.walletIsSignerApprovedSuccess, attributes: [
+                    "approved": "false"
+                ])
+                return false
+            }
             Logger.smartWallet.error(LogEvents.walletIsSignerApprovedError, attributes: [
                 "error": "\(error)"
             ])
-            return false
+            throw error
         }
         let status = registrationStatus(of: response)
         let approved = status == "success" || status == "active"

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -102,6 +102,45 @@ open class Wallet: @unchecked Sendable {
         return await deviceSignerService.locator(for: storage)
     }
 
+    /// Returns whether the given signer is approved and usable on this wallet's chain.
+    ///
+    /// A freshly registered signer can require approval before it can sign — see ``addSigner(_:)``.
+    /// Returns `false` when the signer is not registered, and on any network error.
+    ///
+    /// - Parameter locator: A signer locator string, e.g. `"email:user@example.com"`,
+    ///   `"device:<pubkey>"`, `"api-key"`, `"passkey:<id>"`.
+    public func isSignerApproved(_ locator: String) async -> Bool {
+        Logger.smartWallet.debug(LogEvents.walletIsSignerApprovedStart)
+        let response: AddDelegatedSignerResponse
+        do {
+            response = try await smartWalletService.getSigner(locator, chainType: chain.chainType)
+        } catch {
+            Logger.smartWallet.error(LogEvents.walletIsSignerApprovedError, attributes: [
+                "error": "\(error)"
+            ])
+            return false
+        }
+        let status = registrationStatus(of: response)
+        let approved = status == "success" || status == "active"
+        Logger.smartWallet.debug(LogEvents.walletIsSignerApprovedSuccess, attributes: [
+            "approved": "\(approved)"
+        ])
+        return approved
+    }
+
+    /// EVM approval state lives in the per-chain entries; Solana and Stellar approve through
+    /// a transaction. An empty `chains` map means the signer was created together with the
+    /// wallet and needed no approval.
+    private func registrationStatus(of response: AddDelegatedSignerResponse) -> String? {
+        if chain.chainType == .solana || chain.chainType == .stellar {
+            return response.transaction?.status ?? "success"
+        }
+        guard let chains = response.chains, !chains.isEmpty else {
+            return "success"
+        }
+        return chains[chain.name]?.status
+    }
+
     /// Returns a page of NFTs owned by this wallet.
     ///
     /// - Parameters:

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -133,7 +133,10 @@ open class Wallet: @unchecked Sendable {
     /// wallet and needed no approval.
     private func registrationStatus(of response: AddDelegatedSignerResponse) -> String? {
         if chain.chainType == .solana || chain.chainType == .stellar {
-            return response.transaction?.status ?? "success"
+            guard let transaction = response.transaction else {
+                return "success"
+            }
+            return transaction.status
         }
         guard let chains = response.chains, !chains.isEmpty else {
             return "success"

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -112,20 +112,20 @@ open class Wallet: @unchecked Sendable {
     /// - Throws: ``WalletError`` if the request fails.
     public func isSignerApproved(_ locator: String) async throws(WalletError) -> Bool {
         Logger.smartWallet.debug(LogEvents.walletIsSignerApprovedStart)
-        let response: AddDelegatedSignerResponse
+        let response: AddDelegatedSignerResponse?
         do {
             response = try await smartWalletService.getSigner(locator, chainType: chain.chainType)
         } catch {
-            if case .walletNotFound = error {
-                Logger.smartWallet.debug(LogEvents.walletIsSignerApprovedSuccess, attributes: [
-                    "approved": "false"
-                ])
-                return false
-            }
             Logger.smartWallet.error(LogEvents.walletIsSignerApprovedError, attributes: [
                 "error": "\(error)"
             ])
             throw error
+        }
+        guard let response else {
+            Logger.smartWallet.debug(LogEvents.walletIsSignerApprovedSuccess, attributes: [
+                "approved": "false"
+            ])
+            return false
         }
         let status = registrationStatus(of: response)
         let approved = status == "success" || status == "active"

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -140,10 +140,7 @@ open class Wallet: @unchecked Sendable {
     /// wallet and needed no approval.
     private func registrationStatus(of response: AddDelegatedSignerResponse) -> String? {
         if chain.chainType == .solana || chain.chainType == .stellar {
-            guard let transaction = response.transaction else {
-                return "success"
-            }
-            return transaction.status
+            return response.transaction?.status ?? "success"
         }
         guard let chains = response.chains, !chains.isEmpty else {
             return "success"

--- a/Tests/WalletTests/Mocks/MockSmartWalletService.swift
+++ b/Tests/WalletTests/Mocks/MockSmartWalletService.swift
@@ -87,7 +87,7 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
 
     // MARK: - getSigner
 
-    var getSignerResult: AddDelegatedSignerResponse = AddDelegatedSignerResponse(chains: nil, transaction: nil)
+    var getSignerResult: AddDelegatedSignerResponse? = AddDelegatedSignerResponse(chains: nil, transaction: nil)
     var getSignerError: WalletError?
     var getSignerCallCount = 0
     var lastGetSignerLocator: String?
@@ -95,7 +95,7 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
     func getSigner(
         _ signerLocator: String,
         chainType: ChainType
-    ) async throws(WalletError) -> AddDelegatedSignerResponse {
+    ) async throws(WalletError) -> AddDelegatedSignerResponse? {
         getSignerCallCount += 1
         lastGetSignerLocator = signerLocator
         if let getSignerError {

--- a/Tests/WalletTests/Mocks/MockSmartWalletService.swift
+++ b/Tests/WalletTests/Mocks/MockSmartWalletService.swift
@@ -85,6 +85,25 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
         return fetchTransactionResult
     }
 
+    // MARK: - getSigner
+
+    var getSignerResult: AddDelegatedSignerResponse = AddDelegatedSignerResponse(chains: nil, transaction: nil)
+    var getSignerError: WalletError?
+    var getSignerCallCount = 0
+    var lastGetSignerLocator: String?
+
+    func getSigner(
+        _ signerLocator: String,
+        chainType: ChainType
+    ) async throws(WalletError) -> AddDelegatedSignerResponse {
+        getSignerCallCount += 1
+        lastGetSignerLocator = signerLocator
+        if let getSignerError {
+            throw getSignerError
+        }
+        return getSignerResult
+    }
+
     // MARK: - Unused stubs
 
     func getWallet(_ request: GetMeWalletRequest) async throws(WalletError) -> WalletApiModel {

--- a/Tests/WalletTests/Model/WalletIsSignerApprovedTests.swift
+++ b/Tests/WalletTests/Model/WalletIsSignerApprovedTests.swift
@@ -1,0 +1,127 @@
+import CrossmintCommonTypes
+import Foundation
+import Testing
+import TestsUtils
+
+@testable import Wallet
+
+private func makeEVMWallet(walletService: MockSmartWalletService) throws -> EVMWallet {
+    let baseModel: WalletApiModel = try GetFromFile.getModelFrom(
+        fileName: "WalletEVMEmail",
+        bundle: Bundle.module
+    )
+    return try EVMWallet(
+        smartWalletService: walletService,
+        signer: MockSigner(),
+        baseModel: baseModel,
+        evmChain: .polygon
+    )
+}
+
+private func makeSolanaWallet(walletService: MockSmartWalletService) throws -> SolanaWallet {
+    let baseModel: WalletApiModel = try GetFromFile.getModelFrom(
+        fileName: "WalletSolanaEmail",
+        bundle: Bundle.module
+    )
+    return try SolanaWallet(
+        smartWalletService: walletService,
+        signer: MockSigner(),
+        baseModel: baseModel,
+        solanaChain: .solana
+    )
+}
+
+@Suite("Wallet isSignerApproved", .tags(.unit))
+struct WalletIsSignerApprovedTests {
+
+    @Test func approvesActiveChainEntry() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.getSignerResult = AddDelegatedSignerResponse(
+            chains: ["polygon": ChainRegistrationEntry(id: nil, status: "active", approvals: nil)],
+            transaction: nil
+        )
+        let wallet = try makeEVMWallet(walletService: walletService)
+
+        #expect(await wallet.isSignerApproved("email:user@example.com"))
+        #expect(walletService.lastGetSignerLocator == "email:user@example.com")
+    }
+
+    @Test func approvesSuccessChainEntry() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.getSignerResult = AddDelegatedSignerResponse(
+            chains: ["polygon": ChainRegistrationEntry(id: nil, status: "success", approvals: nil)],
+            transaction: nil
+        )
+        let wallet = try makeEVMWallet(walletService: walletService)
+
+        #expect(await wallet.isSignerApproved("email:user@example.com"))
+    }
+
+    @Test func rejectsSignerAwaitingApproval() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.getSignerResult = AddDelegatedSignerResponse(
+            chains: ["polygon": ChainRegistrationEntry(id: "sig-1", status: "awaiting-approval", approvals: nil)],
+            transaction: nil
+        )
+        let wallet = try makeEVMWallet(walletService: walletService)
+
+        #expect(await wallet.isSignerApproved("email:user@example.com") == false)
+    }
+
+    @Test func rejectsSignerWithoutEntryForTheWalletChain() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.getSignerResult = AddDelegatedSignerResponse(
+            chains: ["base": ChainRegistrationEntry(id: nil, status: "active", approvals: nil)],
+            transaction: nil
+        )
+        let wallet = try makeEVMWallet(walletService: walletService)
+
+        #expect(await wallet.isSignerApproved("email:user@example.com") == false)
+    }
+
+    @Test func approvesSignerCreatedWithTheWallet() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.getSignerResult = AddDelegatedSignerResponse(chains: nil, transaction: nil)
+        let wallet = try makeEVMWallet(walletService: walletService)
+
+        #expect(await wallet.isSignerApproved("email:user@example.com"))
+    }
+
+    @Test func rejectsSignerWithPendingTransactionOnSolana() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.getSignerResult = AddDelegatedSignerResponse(
+            chains: nil,
+            transaction: RegistrationTransaction(id: "tx-1", status: "pending")
+        )
+        let wallet = try makeSolanaWallet(walletService: walletService)
+
+        #expect(await wallet.isSignerApproved("email:user@example.com") == false)
+    }
+
+    @Test func approvesSignerWithSuccessfulTransactionOnSolana() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.getSignerResult = AddDelegatedSignerResponse(
+            chains: nil,
+            transaction: RegistrationTransaction(id: "tx-1", status: "success")
+        )
+        let wallet = try makeSolanaWallet(walletService: walletService)
+
+        #expect(await wallet.isSignerApproved("email:user@example.com"))
+    }
+
+    @Test func approvesSignerWithoutTransactionOnSolana() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.getSignerResult = AddDelegatedSignerResponse(chains: nil, transaction: nil)
+        let wallet = try makeSolanaWallet(walletService: walletService)
+
+        #expect(await wallet.isSignerApproved("email:user@example.com"))
+    }
+
+    @Test func returnsFalseOnNetworkError() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.getSignerError = .walletGeneric("network error")
+        let wallet = try makeEVMWallet(walletService: walletService)
+
+        #expect(await wallet.isSignerApproved("email:user@example.com") == false)
+    }
+}

--- a/Tests/WalletTests/Model/WalletIsSignerApprovedTests.swift
+++ b/Tests/WalletTests/Model/WalletIsSignerApprovedTests.swift
@@ -42,7 +42,7 @@ struct WalletIsSignerApprovedTests {
         )
         let wallet = try makeEVMWallet(walletService: walletService)
 
-        #expect(await wallet.isSignerApproved("email:user@example.com"))
+        #expect(try await wallet.isSignerApproved("email:user@example.com"))
         #expect(walletService.lastGetSignerLocator == "email:user@example.com")
     }
 
@@ -54,7 +54,7 @@ struct WalletIsSignerApprovedTests {
         )
         let wallet = try makeEVMWallet(walletService: walletService)
 
-        #expect(await wallet.isSignerApproved("email:user@example.com"))
+        #expect(try await wallet.isSignerApproved("email:user@example.com"))
     }
 
     @Test func rejectsSignerAwaitingApproval() async throws {
@@ -65,7 +65,7 @@ struct WalletIsSignerApprovedTests {
         )
         let wallet = try makeEVMWallet(walletService: walletService)
 
-        #expect(await wallet.isSignerApproved("email:user@example.com") == false)
+        #expect(try await wallet.isSignerApproved("email:user@example.com") == false)
     }
 
     @Test func rejectsSignerWithoutEntryForTheWalletChain() async throws {
@@ -76,7 +76,7 @@ struct WalletIsSignerApprovedTests {
         )
         let wallet = try makeEVMWallet(walletService: walletService)
 
-        #expect(await wallet.isSignerApproved("email:user@example.com") == false)
+        #expect(try await wallet.isSignerApproved("email:user@example.com") == false)
     }
 
     @Test func approvesSignerCreatedWithTheWallet() async throws {
@@ -84,7 +84,7 @@ struct WalletIsSignerApprovedTests {
         walletService.getSignerResult = AddDelegatedSignerResponse(chains: nil, transaction: nil)
         let wallet = try makeEVMWallet(walletService: walletService)
 
-        #expect(await wallet.isSignerApproved("email:user@example.com"))
+        #expect(try await wallet.isSignerApproved("email:user@example.com"))
     }
 
     @Test func rejectsSignerWithPendingTransactionOnSolana() async throws {
@@ -95,7 +95,7 @@ struct WalletIsSignerApprovedTests {
         )
         let wallet = try makeSolanaWallet(walletService: walletService)
 
-        #expect(await wallet.isSignerApproved("email:user@example.com") == false)
+        #expect(try await wallet.isSignerApproved("email:user@example.com") == false)
     }
 
     @Test func approvesSignerWithSuccessfulTransactionOnSolana() async throws {
@@ -106,7 +106,7 @@ struct WalletIsSignerApprovedTests {
         )
         let wallet = try makeSolanaWallet(walletService: walletService)
 
-        #expect(await wallet.isSignerApproved("email:user@example.com"))
+        #expect(try await wallet.isSignerApproved("email:user@example.com"))
     }
 
     @Test func rejectsSignerWithStatuslessTransactionOnSolana() async throws {
@@ -117,7 +117,7 @@ struct WalletIsSignerApprovedTests {
         )
         let wallet = try makeSolanaWallet(walletService: walletService)
 
-        #expect(await wallet.isSignerApproved("email:user@example.com") == false)
+        #expect(try await wallet.isSignerApproved("email:user@example.com") == false)
     }
 
     @Test func approvesSignerWithoutTransactionOnSolana() async throws {
@@ -125,14 +125,24 @@ struct WalletIsSignerApprovedTests {
         walletService.getSignerResult = AddDelegatedSignerResponse(chains: nil, transaction: nil)
         let wallet = try makeSolanaWallet(walletService: walletService)
 
-        #expect(await wallet.isSignerApproved("email:user@example.com"))
+        #expect(try await wallet.isSignerApproved("email:user@example.com"))
     }
 
-    @Test func returnsFalseOnNetworkError() async throws {
+    @Test func returnsFalseWhenSignerIsNotRegistered() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.getSignerError = .walletNotFound
+        let wallet = try makeEVMWallet(walletService: walletService)
+
+        #expect(try await wallet.isSignerApproved("email:user@example.com") == false)
+    }
+
+    @Test func throwsOnNetworkError() async throws {
         let walletService = MockSmartWalletService()
         walletService.getSignerError = .walletGeneric("network error")
         let wallet = try makeEVMWallet(walletService: walletService)
 
-        #expect(await wallet.isSignerApproved("email:user@example.com") == false)
+        await #expect(throws: WalletError.self) {
+            try await wallet.isSignerApproved("email:user@example.com")
+        }
     }
 }

--- a/Tests/WalletTests/Model/WalletIsSignerApprovedTests.swift
+++ b/Tests/WalletTests/Model/WalletIsSignerApprovedTests.swift
@@ -109,6 +109,17 @@ struct WalletIsSignerApprovedTests {
         #expect(await wallet.isSignerApproved("email:user@example.com"))
     }
 
+    @Test func rejectsSignerWithStatuslessTransactionOnSolana() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.getSignerResult = AddDelegatedSignerResponse(
+            chains: nil,
+            transaction: RegistrationTransaction(id: "tx-1")
+        )
+        let wallet = try makeSolanaWallet(walletService: walletService)
+
+        #expect(await wallet.isSignerApproved("email:user@example.com") == false)
+    }
+
     @Test func approvesSignerWithoutTransactionOnSolana() async throws {
         let walletService = MockSmartWalletService()
         walletService.getSignerResult = AddDelegatedSignerResponse(chains: nil, transaction: nil)

--- a/Tests/WalletTests/Model/WalletIsSignerApprovedTests.swift
+++ b/Tests/WalletTests/Model/WalletIsSignerApprovedTests.swift
@@ -109,7 +109,7 @@ struct WalletIsSignerApprovedTests {
         #expect(try await wallet.isSignerApproved("email:user@example.com"))
     }
 
-    @Test func rejectsSignerWithStatuslessTransactionOnSolana() async throws {
+    @Test func approvesSignerWithStatuslessTransactionOnSolana() async throws {
         let walletService = MockSmartWalletService()
         walletService.getSignerResult = AddDelegatedSignerResponse(
             chains: nil,
@@ -117,7 +117,7 @@ struct WalletIsSignerApprovedTests {
         )
         let wallet = try makeSolanaWallet(walletService: walletService)
 
-        #expect(try await wallet.isSignerApproved("email:user@example.com") == false)
+        #expect(try await wallet.isSignerApproved("email:user@example.com"))
     }
 
     @Test func approvesSignerWithoutTransactionOnSolana() async throws {
@@ -130,7 +130,7 @@ struct WalletIsSignerApprovedTests {
 
     @Test func returnsFalseWhenSignerIsNotRegistered() async throws {
         let walletService = MockSmartWalletService()
-        walletService.getSignerError = .walletNotFound
+        walletService.getSignerResult = nil
         let wallet = try makeEVMWallet(walletService: walletService)
 
         #expect(try await wallet.isSignerApproved("email:user@example.com") == false)


### PR DESCRIPTION
This PR adds `isSignerApproved` to `Wallet`, which checks whether a signer is approved and usable on the wallet's chain. Freshly registered signers can still be awaiting approval, and before this there was no way to check that state short of trying to sign

## Changes

- Adds `public func isSignerApproved(_ locator: String) async throws(WalletError) -> Bool` to `Wallet`, returning `false` when the signer is not registered and throwing on any other failure
- Adds a `getSigner` endpoint (`GET /wallets/me:{chainType}/signers/{locator}`) with the matching `WalletService` method, since the wallet GET response carries no approval status
- Treats `active` and `success` statuses as approved: EVM reads the signer's per-chain entry, while Solana and Stellar read the registration transaction. An empty `chains` map also counts as approved since it means the signer was created together with the wallet
- Adds a `status` field to `RegistrationTransaction`; a transaction without one resolves to not approved
- Adds `wallet.isSignerApproved` and `wallets.api.getSigner` log events
- Adds a `WalletIsSignerApprovedTests` suite with 11 cases covering the status variants, missing chain entry, the Solana transaction path, unknown signers, and network errors
