### PR TITLE
Add a Description column to reference docs property tables

### DIFF
--- a/scripts/docc-to-markdown.py
+++ b/scripts/docc-to-markdown.py
@@ -351,16 +351,18 @@ def json_to_mdx(json_path: Path, data: dict) -> str | None:
                 if child_data:
                     name = child_data.get("metadata", {}).get("title", "")
                     prop_type = extract_property_type(get_declaration(child_data))
+                    desc = render_inline_content(child_data.get("abstract", []), child_data.get("references", {}))
                 else:
                     ref = references.get(identifier, {})
                     name = ref.get("title", identifier.split("/")[-1])
                     prop_type = ""
-                rows.append((name, prop_type))
+                    desc = ""
+                rows.append((name, prop_type, desc))
             if rows:
                 md.append(f"\n## {section_title}\n")
-                md.append("\n| Property | Type |\n| ------ | ------ |\n")
-                for name, prop_type in rows:
-                    md.append(f"| {code_cell(name)} | {code_cell(prop_type)} |\n")
+                md.append("\n| Property | Type | Description |\n| ------ | ------ | ------ |\n")
+                for name, prop_type, desc in rows:
+                    md.append(f"| {code_cell(name)} | {code_cell(prop_type)} | {text_cell(desc) or '-'} |\n")
             continue
 
         if section_title == "Enumeration Cases":
@@ -379,7 +381,7 @@ def json_to_mdx(json_path: Path, data: dict) -> str | None:
                 md.append(f"\n## {section_title}\n")
                 md.append("\n| Case | Description |\n| ------ | ------ |\n")
                 for name, desc in rows:
-                    md.append(f"| {code_cell(name)} | {text_cell(desc)} |\n")
+                    md.append(f"| {code_cell(name)} | {text_cell(desc) or '-'} |\n")
             continue
 
         md.append(f"\n## {section_title}\n")


### PR DESCRIPTION
This pull request adds a Description column to the property tables in the generated reference docs. The tables previously only listed name and type, so the DocC abstracts on properties were not showing up on the docs site.

<img width="1411" height="987" alt="Screenshot 2026-07-08 at 7 03 10 PM" src="https://github.com/user-attachments/assets/9d4f44e5-9c4d-4325-9055-0ca7278fd4da" />

## Changes:
- Property tables render as `| Property | Type | Description |`, pulling each property's abstract through the same path the enum case table already uses.
- Undocumented properties get `-` in the Description cell.
- Enumeration case tables use the same `-` fallback for undocumented cases, so both tables follow one convention.

Sample output from `classes/crossmintsdk.mdx`:

```
| Property | Type | Description |
| ------ | ------ | ------ |
| `authClient` | `AuthClient` | Standalone auth client for explicit OTP lifecycle management. See `AuthClient`. |
| `isOTPRequired` | `Published<Bool>.Publisher` | Emits `true` when a pending transaction is waiting for the user to enter an email OTP. |
```
