### PR TITLE
Add getTransaction to Wallet

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -162,6 +162,7 @@ let package = Package(
                 .process("Resources/Transaction/CreateSolanaTransactionResponse.json"),
                 .process("Resources/Transaction/CreateStellarTransactionResponse.json"),
                 .process("Resources/Transaction/SolanaSignerRegistrationAwaitingApproval.json"),
+                .process("Resources/Transaction/GetTransactionResponse.json"),
                 .process("Resources/Signature/CreateSignatureAwaitingApproval.json"),
                 .process("Resources/WalletEVMApiKey.json"),
                 .process("Resources/WalletEVMEmail.json"),

--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -189,6 +189,15 @@ public enum LogEvents {
     /// Failed to get balances
     public static let walletBalancesError = "wallet.balances.error"
 
+    /// Getting a transaction by ID
+    public static let walletGetTransactionStart = "wallet.getTransaction.start"
+
+    /// Transaction retrieved successfully
+    public static let walletGetTransactionSuccess = "wallet.getTransaction.success"
+
+    /// Failed to get transaction
+    public static let walletGetTransactionError = "wallet.getTransaction.error"
+
     /// Starting staging fund
     public static let walletStagingFundStart = "wallet.stagingFund.start"
 

--- a/Sources/Wallet/Model/Transaction/TransactionCompleted.swift
+++ b/Sources/Wallet/Model/Transaction/TransactionCompleted.swift
@@ -55,8 +55,8 @@ internal struct TransactionCompleted: Sendable {
 
     var summary: TransactionSummary {
         TransactionSummary(
-            hash: id,
-            transactionID: onChain.txId,
+            hash: onChain.txId,
+            transactionID: id,
             explorerLink: onChain.explorerLink
         )
     }

--- a/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
@@ -45,6 +45,43 @@ extension Wallet {
         }
     }
 
+    /// Fetches a transaction by its ID.
+    ///
+    /// Use this to check the current status of a transaction, including its
+    /// ``TransactionStatus``, on-chain data, and any pending or submitted approvals.
+    ///
+    /// - Parameter id: The transaction ID returned by the Crossmint API.
+    /// - Returns: The ``Transaction`` matching the given ID.
+    /// - Throws: ``TransactionError`` if the transaction cannot be retrieved or decoded.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let transaction = try await wallet.getTransaction(id: "42bbb192-...")
+    /// if transaction.status == .success {
+    ///     print("Confirmed:", transaction.onChain.txId ?? "")
+    /// }
+    /// ```
+    public func getTransaction(id: String) async throws(TransactionError) -> Transaction {
+        Logger.smartWallet.debug(LogEvents.walletGetTransactionStart, attributes: [
+            "transactionId": id
+        ])
+
+        do {
+            let transaction = try await self.transaction(withId: id)
+            Logger.smartWallet.debug(LogEvents.walletGetTransactionSuccess, attributes: [
+                "transactionId": transaction.id,
+                "status": transaction.status.rawValue
+            ])
+            return transaction
+        } catch {
+            Logger.smartWallet.error(LogEvents.walletGetTransactionError, attributes: [
+                "transactionId": id,
+                "error": "\(error)"
+            ])
+            throw error
+        }
+    }
+
     /// Removes an assigned signer from this wallet.
     ///
     /// Submits a remove-signer transaction on-chain. If the transaction requires approval,

--- a/Tests/WalletTests/Data/Transaction/GetTransactionTests.swift
+++ b/Tests/WalletTests/Data/Transaction/GetTransactionTests.swift
@@ -1,0 +1,118 @@
+import CrossmintService
+import Foundation
+import Testing
+import TestsUtils
+
+@testable import Http
+@testable import Wallet
+
+@Suite("Get Transaction", .tags(.unit))
+struct GetTransactionTests {
+    private final class RequestCapture: @unchecked Sendable {
+        var request: URLRequest?
+    }
+
+    private func makeService(httpClient: HTTPClient) throws -> DefaultTransactionService {
+        let crossmintService = DefaultCrossmintService(
+            apiKey: try ApiKey(key: "ck_staging_test123"),
+            appIdentifier: "com.crossmint.tests",
+            httpClient: httpClient
+        )
+        return DefaultTransactionService(crossmintService: crossmintService, jsonCoder: DefaultJSONCoder())
+    }
+
+    private func makeService(returning body: Data, capture: RequestCapture? = nil) throws -> DefaultTransactionService {
+        try makeService(
+            httpClient: HTTPClient(fetch: { request throws(NetworkError) in
+                capture?.request = request
+                return (body, URLResponse())
+            })
+        )
+    }
+
+    private func fixtureData(_ fileName: String) throws -> Data {
+        let url = try #require(Bundle.module.url(forResource: fileName, withExtension: "json"))
+        return try Data(contentsOf: url)
+    }
+
+    @Test func decodesEVMTransaction() async throws {
+        let service = try makeService(returning: try fixtureData("GetTransactionResponse"))
+
+        let transaction = try await service.fetchTransaction(
+            .init(transactionId: "42bbb192-1707-43ba-bd21-6e96d28bdcc9", chainType: .evm)
+        )
+
+        let model = try #require(transaction as? EVMTransactionApiModel)
+        #expect(model.id == "42bbb192-1707-43ba-bd21-6e96d28bdcc9")
+        #expect(model.status == .success)
+    }
+
+    @Test func decodesSolanaTransactionWithChainDrivenModel() async throws {
+        let service = try makeService(returning: try fixtureData("CreateSolanaTransactionResponse"))
+
+        let transaction = try await service.fetchTransaction(
+            .init(transactionId: "f662d74d-8790-4dbe-8865-93916b39d3d6", chainType: .solana)
+        )
+
+        let model = try #require(transaction as? SolanaTransactionApiModel)
+        #expect(model.id == "f662d74d-8790-4dbe-8865-93916b39d3d6")
+        #expect(model.status == .awaitingApproval)
+    }
+
+    @Test func requestsMeWalletTransactionPathWithGetMethod() async throws {
+        let capture = RequestCapture()
+        let service = try makeService(returning: try fixtureData("GetTransactionResponse"), capture: capture)
+
+        _ = try await service.fetchTransaction(.init(transactionId: "tx-123", chainType: .evm))
+
+        let request = try #require(capture.request)
+        let url = try #require(request.url)
+        #expect(request.httpMethod == "GET")
+        #expect(url.path.hasSuffix("/2025-06-09/wallets/me:evm/transactions/tx-123"))
+        #expect(request.httpBody == nil)
+    }
+
+    @Test func mapsHttpErrorToTransactionError() async throws {
+        let errorBody = Data(#"{"error": true, "message": "boom"}"#.utf8)
+        let service = try makeService(
+            httpClient: HTTPClient(fetch: { _ throws(NetworkError) in
+                throw NetworkError.badRequest(errorBody)
+            })
+        )
+
+        await #expect {
+            _ = try await service.fetchTransaction(.init(transactionId: "tx-123", chainType: .evm))
+        } throws: { error in
+            guard case .transactionGeneric(let message) = error as? TransactionError else { return false }
+            return message == "boom"
+        }
+    }
+
+    @Test func failsWhenResponseDoesNotMatchChainModel() async throws {
+        let service = try makeService(returning: Data(#"{"id": "tx-1"}"#.utf8))
+
+        await #expect {
+            _ = try await service.fetchTransaction(.init(transactionId: "tx-1", chainType: .evm))
+        } throws: { error in
+            guard case .transactionGeneric(let message) = error as? TransactionError else { return false }
+            return message == "Failed to decode transaction response"
+        }
+    }
+
+    @Suite("when mapping the API model to the domain")
+    struct DomainMappingTests {
+        @Test func mapsDecodedTransactionToDomain() async throws {
+            let model: EVMTransactionApiModel = try GetFromFile.getModelFrom(
+                fileName: "GetTransactionResponse",
+                bundle: Bundle.module
+            )
+
+            let transaction = try #require(model.toDomain(withService: MockSmartWalletService()))
+
+            #expect(transaction.id == "42bbb192-1707-43ba-bd21-6e96d28bdcc9")
+            #expect(transaction.status == .success)
+            #expect(transaction.onChain.txId == "0x9f52ec9b7e3a6a5c6a4d2f1f0f7f3f0a4a1b2c3d4e5f60718293a4b5c6d7e8f9")
+            #expect(transaction.params.signer == "external-wallet:0x20112298f0fb356fb914fb00548b2c86083126cc")
+        }
+    }
+}

--- a/Tests/WalletTests/Data/Transaction/TransactionSummaryTests.swift
+++ b/Tests/WalletTests/Data/Transaction/TransactionSummaryTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+import TestsUtils
+
+@testable import Wallet
+
+@Suite("Transaction Summary", .tags(.unit))
+struct TransactionSummaryTests {
+    @Test func exposesCrossmintIdAsTransactionIDAndOnChainTxIdAsHash() async throws {
+        let model: EVMTransactionApiModel = try GetFromFile.getModelFrom(
+            fileName: "GetTransactionResponse",
+            bundle: Bundle.module
+        )
+        let transaction = try #require(model.toDomain(withService: MockSmartWalletService()))
+
+        let summary = try #require(transaction.toCompleted()).summary
+
+        #expect(summary.transactionID == "42bbb192-1707-43ba-bd21-6e96d28bdcc9")
+        #expect(summary.hash == "0x9f52ec9b7e3a6a5c6a4d2f1f0f7f3f0a4a1b2c3d4e5f60718293a4b5c6d7e8f9")
+        #expect(summary.explorerLink.absoluteString.contains(summary.hash))
+    }
+}

--- a/Tests/WalletTests/Resources/Transaction/GetTransactionResponse.json
+++ b/Tests/WalletTests/Resources/Transaction/GetTransactionResponse.json
@@ -1,0 +1,54 @@
+{
+  "chainType": "evm",
+  "walletType": "smart",
+  "params": {
+    "calls": [
+      {
+        "to": "0xe9a353699Cb655265B633b03479890f9ACDF0Bd0",
+        "value": "1000000000000000000",
+        "data": "0x"
+      }
+    ],
+    "chain": "base-sepolia",
+    "signer": {
+      "type": "external-wallet",
+      "id": "0x20112298f0fb356fb914fb00548b2c86083126cc",
+      "locator": "external-wallet:0x20112298f0fb356fb914fb00548b2c86083126cc"
+    }
+  },
+  "onChain": {
+    "userOperation": {
+      "sender": "0x26Ca6fdA5E2c71A8E24e75eC40b897e2a5053515",
+      "nonce": "0x845adb2c711129d4f3966735ed98a9f09fc4ce5700190000000000000000",
+      "callData": "0xe9ae5c53",
+      "callGasLimit": "0x10296",
+      "verificationGasLimit": "0x4fe24",
+      "preVerificationGas": "0xe824",
+      "maxFeePerGas": "0x116b5a4d",
+      "maxPriorityFeePerGas": "0x18ecdc",
+      "signature": "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007a1c"
+    },
+    "userOperationHash": "0x40af6b30a067edc628b941cccf16bc95e490df4a55165ba81492db72f2792617",
+    "txId": "0x9f52ec9b7e3a6a5c6a4d2f1f0f7f3f0a4a1b2c3d4e5f60718293a4b5c6d7e8f9",
+    "explorerLink": "https://sepolia.basescan.org/tx/0x9f52ec9b7e3a6a5c6a4d2f1f0f7f3f0a4a1b2c3d4e5f60718293a4b5c6d7e8f9"
+  },
+  "id": "42bbb192-1707-43ba-bd21-6e96d28bdcc9",
+  "status": "success",
+  "approvals": {
+    "pending": [],
+    "submitted": [
+      {
+        "signature": "0x4e5df5f3f8fe3db359229bf1c3a18f150206f0d23dcbe9516ac345a0b40977db1b3cfb80daf460398c941e216c06c6ca1a2845fbcab806bc9cf119114dec6280",
+        "submittedAt": "2025-03-19T09:25:08.716Z",
+        "signer": {
+          "type": "external-wallet",
+          "id": "0x20112298f0fb356fb914fb00548b2c86083126cc",
+          "locator": "external-wallet:0x20112298f0fb356fb914fb00548b2c86083126cc"
+        },
+        "message": "0x40af6b30a067edc628b941cccf16bc95e490df4a55165ba81492db72f2792617"
+      }
+    ]
+  },
+  "createdAt": "2025-03-19T09:25:08.575Z",
+  "completedAt": "2025-03-19T09:25:31.002Z"
+}


### PR DESCRIPTION
This PR adds a public `getTransaction(id:)` method to `Wallet`. It returns the current state of a transaction by ID, including its status, on-chain data, and approvals.

This pull request also fixes a bug where `TransactionSummary` had `hash` and `transactionID` swapped at construction, so chaining `send` into `getTransaction` failed with a not-found error. A regression test is included.

Changes:
* `getTransaction(id:)` wraps the existing internal fetch path (`Endpoint.fetchTransaction`), no new endpoint or service code
* New `wallet.getTransaction.start/.success/.error` log events, same pattern as `listTransactions`. No API-layer logs on purpose, `fetchTransaction` is also hit once per second by the transaction polling loop
* `TransactionCompleted.summary` now assigns `onChain.txId` to `hash` and the Crossmint id to `transactionID`, matching their doc comments
* Tests cover the request path and method, per-chain decoding, HTTP and decode error mapping, domain mapping, and the summary fix, with a new success-status fixture