### PR TITLE
Include the underlying Secure Enclave error in device signer failures

### DIFF
--- a/Sources/CrossmintService/CrossmintError.swift
+++ b/Sources/CrossmintService/CrossmintError.swift
@@ -16,6 +16,9 @@ extension CrossmintError {
         if let suggestion = recoverySuggestion {
             result += "\nRecovery: \(suggestion)"
         }
+        if let underlyingError {
+            result += "\nUnderlying: \(underlyingError)"
+        }
         return result
     }
 

--- a/Sources/DeviceSigner/DeviceSignerError.swift
+++ b/Sources/DeviceSigner/DeviceSignerError.swift
@@ -5,7 +5,6 @@
 //  Created by Tomas Martins on 4/3/26.
 //
 
-import CryptoKit
 import Foundation
 
 /// Errors that can occur during device signer operations.
@@ -14,9 +13,9 @@ public enum DeviceSignerError: Error, Sendable {
     case keyNotFound
     /// Key generation failed.
     case keyGenerationFailed
-    /// Signing the message failed. `operation` names the step that threw and
-    /// `underlyingError` is the original CryptoKit/Security error, exposed for
-    /// diagnostics and programmatic inspection via ``underlyingError``.
+    /// The signer failed to sign the message.
+    /// `operation` is the step that failed.
+    /// `underlyingError` is the error from CryptoKit or the Security framework.
     case signingFailed(operation: String, underlyingError: Error)
     /// A Keychain operation failed. The associated value is the `OSStatus` error code.
     case storageError(OSStatus)
@@ -41,7 +40,7 @@ public enum DeviceSignerError: Error, Sendable {
             "Failed to generate a device signer key."
         case .signingFailed(let operation, let underlyingError):
             "Failed to sign the message with the device signer key. "
-                + "\(operation) failed: \(Self.describeUnderlying(underlyingError))"
+                + "\(operation) failed: \(underlyingError)"
         case .storageError(let status):
             "Keychain operation failed with status \(status)."
         case .invalidMessage:
@@ -66,29 +65,11 @@ public enum DeviceSignerError: Error, Sendable {
         }
     }
 
-    /// The original error thrown by the underlying signing primitive
-    /// (CryptoKit / Secure Enclave / Keychain), when available.
+    /// The original error from the underlying signing operation. Returns `nil` if there is no such error.
     public var underlyingError: Error? {
         switch self {
         case .signingFailed(_, let underlyingError): underlyingError
         default: nil
         }
-    }
-
-    /// Builds a diagnostic string for an underlying error caught during a signing
-    /// operation, preserving the code the Secure Enclave surfaced.
-    ///
-    /// The Secure Enclave does not throw a typed error. CryptoKit collapses the
-    /// hardware/Security failure into a ``CryptoKitError`` — usually
-    /// `.underlyingCoreCryptoError(error:)`, whose associated `Int32` is the real
-    /// low-level code (a Security/OSStatus-family value, e.g. `-25293` for
-    /// `errSecAuthFailed`). `String(describing:)` keeps that code, so we surface it
-    /// verbatim; any other error is described by its bridged domain and code.
-    static func describeUnderlying(_ error: Error) -> String {
-        if let cryptoKitError = error as? CryptoKitError {
-            return "CryptoKitError.\(cryptoKitError)"
-        }
-        let nsError = error as NSError
-        return "\(nsError.domain)(\(nsError.code)): \(nsError.localizedDescription)"
     }
 }

--- a/Sources/DeviceSigner/DeviceSignerError.swift
+++ b/Sources/DeviceSigner/DeviceSignerError.swift
@@ -5,6 +5,7 @@
 //  Created by Tomas Martins on 4/3/26.
 //
 
+import CryptoKit
 import Foundation
 
 /// Errors that can occur during device signer operations.
@@ -13,8 +14,10 @@ public enum DeviceSignerError: Error, Sendable {
     case keyNotFound
     /// Key generation failed.
     case keyGenerationFailed
-    /// Signing the message failed.
-    case signingFailed
+    /// Signing the message failed. `operation` names the step that threw and
+    /// `underlyingError` is the original CryptoKit/Security error, exposed for
+    /// diagnostics and programmatic inspection via ``underlyingError``.
+    case signingFailed(operation: String, underlyingError: Error)
     /// A Keychain operation failed. The associated value is the `OSStatus` error code.
     case storageError(OSStatus)
     /// The message to sign could not be decoded.
@@ -36,8 +39,9 @@ public enum DeviceSignerError: Error, Sendable {
             "No device signer key found for this wallet."
         case .keyGenerationFailed:
             "Failed to generate a device signer key."
-        case .signingFailed:
-            "Failed to sign the message with the device signer key."
+        case .signingFailed(let operation, let underlyingError):
+            "Failed to sign the message with the device signer key. "
+                + "\(operation) failed: \(Self.describeUnderlying(underlyingError))"
         case .storageError(let status):
             "Keychain operation failed with status \(status)."
         case .invalidMessage:
@@ -53,8 +57,38 @@ public enum DeviceSignerError: Error, Sendable {
             "Ensure the device has sufficient storage and the app has Keychain access."
         case .storageError:
             "Ensure the app has Keychain entitlements and the device is unlocked."
-        case .signingFailed, .invalidMessage:
+        case .signingFailed:
+            "The stored device signer key can no longer sign on this device "
+                + "(for example after a device restore or Secure Enclave reset). "
+                + "Re-register a device signer for this wallet."
+        case .invalidMessage:
             nil
         }
+    }
+
+    /// The original error thrown by the underlying signing primitive
+    /// (CryptoKit / Secure Enclave / Keychain), when available.
+    public var underlyingError: Error? {
+        switch self {
+        case .signingFailed(_, let underlyingError): underlyingError
+        default: nil
+        }
+    }
+
+    /// Builds a diagnostic string for an underlying error caught during a signing
+    /// operation, preserving the code the Secure Enclave surfaced.
+    ///
+    /// The Secure Enclave does not throw a typed error. CryptoKit collapses the
+    /// hardware/Security failure into a ``CryptoKitError`` — usually
+    /// `.underlyingCoreCryptoError(error:)`, whose associated `Int32` is the real
+    /// low-level code (a Security/OSStatus-family value, e.g. `-25293` for
+    /// `errSecAuthFailed`). `String(describing:)` keeps that code, so we surface it
+    /// verbatim; any other error is described by its bridged domain and code.
+    static func describeUnderlying(_ error: Error) -> String {
+        if let cryptoKitError = error as? CryptoKitError {
+            return "CryptoKitError.\(cryptoKitError)"
+        }
+        let nsError = error as NSError
+        return "\(nsError.domain)(\(nsError.code)): \(nsError.localizedDescription)"
     }
 }

--- a/Sources/DeviceSigner/DeviceSignerError.swift
+++ b/Sources/DeviceSigner/DeviceSignerError.swift
@@ -56,11 +56,7 @@ public enum DeviceSignerError: Error, Sendable {
             "Ensure the device has sufficient storage and the app has Keychain access."
         case .storageError:
             "Ensure the app has Keychain entitlements and the device is unlocked."
-        case .signingFailed:
-            "The stored device signer key can no longer sign on this device "
-                + "(for example after a device restore or Secure Enclave reset). "
-                + "Re-register a device signer for this wallet."
-        case .invalidMessage:
+        case .signingFailed, .invalidMessage:
             nil
         }
     }

--- a/Sources/DeviceSigner/Storage/KeychainKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/KeychainKeyStorage.swift
@@ -84,7 +84,10 @@ public final class KeychainKeyStorage: DeviceSignerKeyStorage {
         do {
             ecdsaSignature = try key.signature(for: messageData)
         } catch {
-            throw DeviceSignerError.signingFailed
+            throw DeviceSignerError.signingFailed(
+                operation: "Keychain signature",
+                underlyingError: error
+            )
         }
 
         // rawRepresentation = 64 bytes: r (32) ‖ s (32)

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -98,8 +98,10 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
         do {
             key = try SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData)
         } catch {
-            // Key data was found but the SE key is unusable (e.g. biometric enrollment changed)
-            throw DeviceSignerError.signingFailed
+            throw DeviceSignerError.signingFailed(
+                operation: "Secure Enclave key reconstruction",
+                underlyingError: error
+            )
         }
 
         guard let messageData = Data(base64Encoded: message) else {
@@ -110,7 +112,10 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
         do {
             ecdsaSignature = try key.signature(for: messageData)
         } catch {
-            throw DeviceSignerError.signingFailed
+            throw DeviceSignerError.signingFailed(
+                operation: "Secure Enclave signature",
+                underlyingError: error
+            )
         }
 
         // rawRepresentation = 64 bytes: r (32) ‖ s (32)

--- a/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
+++ b/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
@@ -355,7 +355,7 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
                 signerLocator: signerLocator, message: message, storage: storage
             )
         } catch {
-            throw SignatureError.approvalFailed
+            throw SignatureError.signingFailed(underlyingError: error)
         }
         return try await smartWalletService.approveSignature(
             .init(transactionId: signatureID, apiRequest: request, chainType: chain.chainType)
@@ -369,17 +369,18 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
             case .cancelled:
                 return .userCancelled
             default:
-                return .approvalFailed
+                return .signingFailed(underlyingError: error)
             }
+        case .cancelled:
+            return .userCancelled
         case .signingFailed,
                 .invalidAddress,
                 .invalidEmail,
                 .invalidSigner,
                 .invalidMessage,
                 .invalidPrivateKey,
-                .notStarted,
-                .cancelled:
-            return .approvalFailed
+                .notStarted:
+            return .signingFailed(underlyingError: error)
         }
     }
 }

--- a/Sources/Wallet/Model/Wallet/SignatureError.swift
+++ b/Sources/Wallet/Model/Wallet/SignatureError.swift
@@ -4,8 +4,7 @@ import Http
 public enum SignatureError: CrossmintError {
     case creationFailed
     case approvalFailed
-    /// Producing the signature failed. `underlyingError` carries the original error
-    /// (for a device signer, the ``DeviceSignerError`` and its own `underlyingError`).
+    /// The wallet failed to produce the signature. `underlyingError` holds the original error.
     case signingFailed(underlyingError: Error)
     case userCancelled
     case serviceError(CrossmintServiceError)

--- a/Sources/Wallet/Model/Wallet/SignatureError.swift
+++ b/Sources/Wallet/Model/Wallet/SignatureError.swift
@@ -4,6 +4,9 @@ import Http
 public enum SignatureError: CrossmintError {
     case creationFailed
     case approvalFailed
+    /// Producing the signature failed. `underlyingError` carries the original error
+    /// (for a device signer, the ``DeviceSignerError`` and its own `underlyingError`).
+    case signingFailed(underlyingError: Error)
     case userCancelled
     case serviceError(CrossmintServiceError)
     case networkError
@@ -14,6 +17,7 @@ public enum SignatureError: CrossmintError {
         switch self {
         case .creationFailed: "SIGNATURE_CREATION_FAILED"
         case .approvalFailed: "SIGNATURE_APPROVAL_FAILED"
+        case .signingFailed: "SIGNATURE_SIGNING_FAILED"
         case .userCancelled: "USER_CANCELLED"
         case .serviceError: "SERVICE_ERROR"
         case .networkError: "NETWORK_ERROR"
@@ -28,6 +32,8 @@ public enum SignatureError: CrossmintError {
             error.message
         case .approvalFailed:
             "There was an error while approving the message"
+        case .signingFailed:
+            "There was an error while producing the signature"
         case .userCancelled:
             "User cancelled this action"
         case .creationFailed:
@@ -42,8 +48,11 @@ public enum SignatureError: CrossmintError {
     }
 
     public var underlyingError: Swift.Error? {
-        guard case .serviceError(let error) = self else { return nil }
-        return error
+        switch self {
+        case .serviceError(let error): error
+        case .signingFailed(let error): error
+        default: nil
+        }
     }
 }
 

--- a/Sources/Wallet/Model/Wallet/SignatureError.swift
+++ b/Sources/Wallet/Model/Wallet/SignatureError.swift
@@ -4,7 +4,6 @@ import Http
 public enum SignatureError: CrossmintError {
     case creationFailed
     case approvalFailed
-    /// The wallet failed to produce the signature. `underlyingError` holds the original error.
     case signingFailed(underlyingError: Error)
     case userCancelled
     case serviceError(CrossmintServiceError)

--- a/Tests/DeviceSignerTests/DeviceSignerErrorTests.swift
+++ b/Tests/DeviceSignerTests/DeviceSignerErrorTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import DeviceSigner
+
+private struct StubUnderlyingError: Error, CustomStringConvertible {
+    var description: String { "underlyingCoreCryptoError(error: -25293)" }
+}
+
+@Suite("DeviceSignerError")
+struct DeviceSignerErrorTests {
+
+    @Test("signingFailed exposes the code and the underlying error")
+    func signingFailedExposesUnderlying() {
+        let error = DeviceSignerError.signingFailed(
+            operation: "Secure Enclave signature",
+            underlyingError: StubUnderlyingError()
+        )
+        #expect(error.code == "DEVICE_SIGNER_SIGNING_FAILED")
+        #expect((error.underlyingError as? StubUnderlyingError) != nil)
+    }
+
+    @Test("signingFailed message keeps the operation and the underlying code once")
+    func signingFailedMessageKeepsUnderlyingCode() {
+        let error = DeviceSignerError.signingFailed(
+            operation: "Secure Enclave signature",
+            underlyingError: StubUnderlyingError()
+        )
+        #expect(error.message.contains("Secure Enclave signature"))
+        #expect(occurrences(of: "-25293", in: error.message) == 1)
+    }
+
+    @Test("localizedDescription does not surface the underlying code")
+    func localizedDescriptionStaysClean() {
+        let error = DeviceSignerError.signingFailed(
+            operation: "Secure Enclave signature",
+            underlyingError: StubUnderlyingError()
+        )
+        #expect(!error.localizedDescription.contains("-25293"))
+    }
+
+    @Test("cases without a signing failure have no underlying error")
+    func noUnderlyingForOtherCases() {
+        #expect(DeviceSignerError.keyNotFound.underlyingError == nil)
+    }
+}
+
+private func occurrences(of needle: String, in haystack: String) -> Int {
+    haystack.components(separatedBy: needle).count - 1
+}

--- a/Tests/WalletTests/Model/SignatureErrorTests.swift
+++ b/Tests/WalletTests/Model/SignatureErrorTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import Wallet
+
+private struct StubUnderlyingError: Error, CustomStringConvertible {
+    var description: String { "underlyingCoreCryptoError(error: -25293)" }
+}
+
+@Suite("SignatureError")
+struct SignatureErrorTests {
+
+    @Test("signingFailed exposes the code and forwards the underlying error")
+    func signingFailedForwardsUnderlying() {
+        let error = SignatureError.signingFailed(underlyingError: StubUnderlyingError())
+        #expect(error.code == "SIGNATURE_SIGNING_FAILED")
+        #expect((error.underlyingError as? StubUnderlyingError) != nil)
+    }
+
+    @Test("description carries the underlying code once and message stays clean")
+    func descriptionCarriesCodeOnce() {
+        let error = SignatureError.signingFailed(underlyingError: StubUnderlyingError())
+        #expect(occurrences(of: "-25293", in: error.description) == 1)
+        #expect(!error.message.contains("-25293"))
+    }
+}
+
+private func occurrences(of needle: String, in haystack: String) -> Int {
+    haystack.components(separatedBy: needle).count - 1
+}


### PR DESCRIPTION
When a device signer fails to sign, the SDK only reported `signingFailed`, which hid why the Secure Enclave refused. This threads the underlying CryptoKit/Security error through, so logs can tell a corrupt or missing key apart from a genuine enclave failure.

The enclave surfaces failures as a `CryptoKitError`, usually `underlyingCoreCryptoError` with an OSStatus like `-25293`, and that code now rides along. `localizedDescription` stays clean for users, while `description`, which is what the loggers print, carries the underlying error.

## Changes
- `DeviceSignerError.signingFailed` now carries the operation and the original error (`signingFailed(operation:underlyingError:)`) and exposes it through an `underlyingError` accessor.
- `SecureEnclaveKeyStorage` and `KeychainKeyStorage` pass the caught error into `signingFailed` at each signing site.
- `SignatureError` gained `signingFailed(underlyingError:)`, and `EVMWallet` forwards the error instead of collapsing it into `approvalFailed`.
- `CrossmintError.description` appends the underlying error when present, so every `"\(error)"` log across the SDK includes it.
- Added unit tests covering the device signer and signature error forwarding, and that `localizedDescription` stays clean.
