### PR TITLE
Fix signer picker listing device signers from other devices

### DIFF
--- a/Examples/SmartWalletsDemo/SmartWalletsDemo.xcodeproj/project.pbxproj
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo.xcodeproj/project.pbxproj
@@ -491,9 +491,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = SmartWalletsDemo/SmartWalletsDemo.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = T7Q46ZFBCG;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = SmartWalletsDemo/Info.plist;
@@ -528,9 +528,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = SmartWalletsDemo/SmartWalletsDemo.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = T7Q46ZFBCG;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = SmartWalletsDemo/Info.plist;

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo.xcodeproj/project.pbxproj
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		AC0102102DD700000000006 /* AuthHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0102112DD700000000006 /* AuthHeaderView.swift */; };
 		2CC6EA9B9C96B07E039BCA27 /* CopyButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC8F1E1CCA8881A74C85EF1 /* CopyButton.swift */; };
 		30BCF1F16E84DB0995489C62 /* OTPSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F32D4100D0B463E463390BC /* OTPSheet.swift */; };
 		7CAB00000000000000000001 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAF00000000000000000001 /* AppState.swift */; };
@@ -34,9 +33,10 @@
 		AC0101092DC600000000007 /* SplashScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0101082DC600000000007 /* SplashScreen.swift */; };
 		AC0102012DD700000000001 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0102002DD700000000001 /* SignInView.swift */; };
 		AC0102032DD700000000002 /* VerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0102022DD700000000002 /* VerificationView.swift */; };
+		AC0102052DD700000000003 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0102042DD700000000003 /* CustomTextField.swift */; };
 		AC0102062DD700000000004 /* OTPSignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0102072DD700000000004 /* OTPSignInView.swift */; };
 		AC0102082DD700000000005 /* JWTSignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0102092DD700000000005 /* JWTSignInView.swift */; };
-		AC0102052DD700000000003 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0102042DD700000000003 /* CustomTextField.swift */; };
+		AC0102102DD700000000006 /* AuthHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0102112DD700000000006 /* AuthHeaderView.swift */; };
 		E52EB51B2ED54D19004256E2 /* CrossmintAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52EB51A2ED54D15004256E2 /* CrossmintAuthManager.swift */; };
 		EB49FDE22DC35C0D00BAAFEB /* CrossmintClientSDK in Frameworks */ = {isa = PBXBuildFile; productRef = EB49FDE12DC35C0D00BAAFEB /* CrossmintClientSDK */; };
 		EB5D83162E45FA36002F8EF1 /* OTPValidatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB5D83152E45FA36002F8EF1 /* OTPValidatorView.swift */; };
@@ -47,7 +47,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		AC0102112DD700000000006 /* AuthHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthHeaderView.swift; sourceTree = "<group>"; };
 		1FC8F1E1CCA8881A74C85EF1 /* CopyButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CopyButton.swift; sourceTree = "<group>"; };
 		6F32D4100D0B463E463390BC /* OTPSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OTPSheet.swift; sourceTree = "<group>"; };
 		7CAF00000000000000000001 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -75,9 +74,10 @@
 		AC0101082DC600000000007 /* SplashScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreen.swift; sourceTree = "<group>"; };
 		AC0102002DD700000000001 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		AC0102022DD700000000002 /* VerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationView.swift; sourceTree = "<group>"; };
+		AC0102042DD700000000003 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		AC0102072DD700000000004 /* OTPSignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPSignInView.swift; sourceTree = "<group>"; };
 		AC0102092DD700000000005 /* JWTSignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTSignInView.swift; sourceTree = "<group>"; };
-		AC0102042DD700000000003 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
+		AC0102112DD700000000006 /* AuthHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthHeaderView.swift; sourceTree = "<group>"; };
 		E52EB51A2ED54D15004256E2 /* CrossmintAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrossmintAuthManager.swift; sourceTree = "<group>"; };
 		EB1EA11F2DC0F6550018C2C3 /* SmartWalletsDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SmartWalletsDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB5D83152E45FA36002F8EF1 /* OTPValidatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPValidatorView.swift; sourceTree = "<group>"; };
@@ -491,9 +491,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = SmartWalletsDemo/SmartWalletsDemo.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = T7Q46ZFBCG;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = SmartWalletsDemo/Info.plist;
@@ -528,9 +528,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = SmartWalletsDemo/SmartWalletsDemo.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = T7Q46ZFBCG;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = SmartWalletsDemo/Info.plist;

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/AppState.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/AppState.swift
@@ -33,6 +33,7 @@ final class AppState {
     // Signer selection (shared across Transfer/Signing/Signers)
     private(set) var selectedSignerLocator: String?
     private(set) var delegatedSigners: [WalletDelegatedSignerConfigApiModel] = []
+    private(set) var localDeviceLocator: String?
 
     private let sdk: CrossmintSDK = .shared
 
@@ -112,6 +113,7 @@ final class AppState {
 
     func loadSigners() async {
         delegatedSigners = (try? await wallet?.signers()) ?? []
+        localDeviceLocator = await wallet?.localDeviceSignerLocator()
         guard selectedSignerLocator == nil, let locator = firstSelectableLocator() else { return }
         await selectSigner(locator: locator)
     }
@@ -122,6 +124,7 @@ final class AppState {
         selectedChain = chain
         selectedSignerLocator = nil
         delegatedSigners = []
+        localDeviceLocator = nil
         walletErrorMessage = nil
         balance = nil
 

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Signers/SignerPicker.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Signers/SignerPicker.swift
@@ -6,8 +6,6 @@
 import CrossmintClient
 import SwiftUI
 
-/// A form section with a "Sign with" picker.
-/// Renders whenever the wallet has at least one selectable signer.
 struct SignerPicker: View {
     @Environment(AppState.self) private var appState
 
@@ -25,9 +23,9 @@ struct SignerPicker: View {
             result.append(Option(locator: recovery, typeLabel: SignerRow.typeLabel(for: recovery), isRecovery: true))
         }
         for signer in appState.delegatedSigners {
-            if let locator = signer.locator ?? signer.signer, isSelectable(locator) {
-                result.append(Option(locator: locator, typeLabel: SignerRow.typeLabel(for: locator), isRecovery: false))
-            }
+            guard let locator = signer.locator ?? signer.signer, isSelectable(locator) else { continue }
+            if locator.hasPrefix("device:"), locator != appState.localDeviceLocator { continue }
+            result.append(Option(locator: locator, typeLabel: SignerRow.typeLabel(for: locator), isRecovery: false))
         }
         return result
     }
@@ -35,20 +33,16 @@ struct SignerPicker: View {
     var body: some View {
         let opts = options
         if !opts.isEmpty {
-            Section {
-                Picker("Sign with", selection: Binding(
-                    get: { appState.selectedSignerLocator ?? opts.first?.id ?? "" },
-                    set: { new in Task { await appState.selectSigner(locator: new) } }
-                )) {
-                    ForEach(opts) { opt in
-                        Button { } label: {
-                            Text(opt.typeLabel + (opt.isRecovery ? " (Recovery)" : ""))
-                            Text(opt.id)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        .tag(opt.id)
+            Picker("Sign with", selection: Binding(
+                get: { appState.selectedSignerLocator ?? opts.first?.id ?? "" },
+                set: { new in Task { await appState.selectSigner(locator: new) } }
+            )) {
+                ForEach(opts) { opt in
+                    Button { } label: {
+                        Text(opt.typeLabel + (opt.isRecovery ? " (Recovery)" : ""))
+                        Text(opt.id)
                     }
+                    .tag(opt.id)
                 }
             }
         }
@@ -74,7 +68,7 @@ struct SignerPicker: View {
                         ForEach(options, id: \.id) { opt in
                             Button { } label: {
                                 Text(opt.label)
-                                Text(opt.sublabel).font(.caption).foregroundStyle(.secondary)
+                                Text(opt.sublabel)
                             }
                             .tag(opt.id)
                         }

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Signing/SigningView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Signing/SigningView.swift
@@ -50,7 +50,9 @@ struct SigningView: View {
                     }
                 }
 
-                SignerPicker()
+                Section {
+                    SignerPicker()
+                }
 
                 if let sig = signature {
                     Section("Signature") {

--- a/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Transfer/TransferView.swift
+++ b/Examples/SmartWalletsDemo/SmartWalletsDemo/Playground/Transfer/TransferView.swift
@@ -80,7 +80,9 @@ struct TransferView: View {
                     }
                 }
 
-                SignerPicker()
+                Section {
+                    SignerPicker()
+                }
 
                 if let txId = transactionId {
                     Section("Sent") {

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -92,6 +92,16 @@ open class Wallet: @unchecked Sendable {
         return walletModel.config.recovery.toDomain.locator == locator
     }
 
+    /// Returns the locator of the device signer that keeps its private key on this device.
+    /// Returns `nil` if this device has no key, or if the wallet does not support device signers.
+    ///
+    /// This device keeps only one device key for each wallet. Device signing always uses that key.
+    /// Thus this is the only device signer that can sign here.
+    public func localDeviceSignerLocator() async -> String? {
+        guard let storage = deviceSignerKeyStorage, !_deviceSignerUnsupported else { return nil }
+        return await deviceSignerService.locator(for: storage)
+    }
+
     /// Returns a page of NFTs owned by this wallet.
     ///
     /// - Parameters:


### PR DESCRIPTION
The demo signer picker listed every device signer on the wallet, including ones whose private key lives on another device. Picking one of those silently signed with this device's local key, so the selected signer never matched the signer that actually signed.

## Changes
- Add `Wallet.localDeviceSignerLocator()`, which returns the locator of the device signer whose key is on this device, or nil when there is none.
- Filter the demo picker so a device signer appears only when it matches the local device locator.
- Track `localDeviceLocator` in `AppState`, refreshed with the signer list and cleared on chain switch.
- Move the "Sign with" picker into its own Section in the Signing and Transfer views.
