### PR TITLE
fix: removeSigner approval signature corrupted by lossy hex→UTF-8 decode (WAL-11310)

### DIFF
--- a/Sources/Web/CrossmintTEE.swift
+++ b/Sources/Web/CrossmintTEE.swift
@@ -2,6 +2,7 @@
 import CrossmintAuth
 import Combine
 import Logger
+import Utils
 import WebKit
 
 extension Logger {
@@ -164,7 +165,7 @@ public final class CrossmintTEE: ObservableObject {
                         messageBytes: transaction,
                         keyType: keyType,
                         encoding: encoding)
-                ).stringValue
+                )
             }
         case .error:
             Logger.tee.error(LogEvents.getStatusError, attributes: [
@@ -216,7 +217,7 @@ public final class CrossmintTEE: ObservableObject {
                     messageBytes: transaction,
                     keyType: keyType,
                     encoding: encoding)
-            ).stringValue
+            )
         }
     }
 
@@ -560,9 +561,23 @@ public final class CrossmintTEE: ObservableObject {
                 timeout: 10.0
             )
 
+            guard response.status != .error else {
+                Logger.tee.error(LogEvents.signError, attributes: [
+                    "error": response.errorMessage ?? "Unknown error"
+                ])
+                throw Error.generic(response.errorMessage ?? "Signing failed with an unknown error")
+            }
+
             guard let bytes = response.signature?.bytes, !bytes.isEmpty else {
                 Logger.tee.error(LogEvents.signError, attributes: [
                     "error": "Empty signature returned from frame"
+                ])
+                throw Error.invalidSignature
+            }
+
+            if request.data.data.encoding == "hex", (try? HexUtil.byteArray(fromHex: bytes.noHexPrefix)) == nil {
+                Logger.tee.error(LogEvents.signError, attributes: [
+                    "error": "Frame returned a non-hex signature for a hex-encoded request"
                 ])
                 throw Error.invalidSignature
             }

--- a/Tests/WebTests/CrossmintTEETests.swift
+++ b/Tests/WebTests/CrossmintTEETests.swift
@@ -265,6 +265,68 @@ struct CrossmintTEETests {
                 )
             }
         }
+
+        @Test("Rejects non-hex signature when hex encoding was requested")
+        func testRejectsNonHexSignatureForHexEncoding() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+            try await fixture.setupHandshake()
+
+            fixture.configureReadyDevice()
+            fixture.configureSignResponse(signature: "not-a-hex-ecdsa-signature")
+
+            await #expect(throws: CrossmintTEE.Error.invalidSignature) {
+                _ = try await fixture.tee.signTransaction(
+                    transaction: CrossmintTEETestHelpers.createTestTransaction(),
+                    keyType: "secp256k1",
+                    encoding: "hex"
+                )
+            }
+        }
+
+        @Test("Returns hex signature verbatim even when its bytes decode as UTF-8")
+        func testHexSignatureIsNotDecodedAsUTF8() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+            try await fixture.setupHandshake()
+
+            fixture.configureReadyDevice()
+            // 0x48656c6c6f decodes to the UTF-8 string "Hello"; the signature
+            // must be passed through verbatim, not decoded (regression for WAL-11310).
+            fixture.configureSignResponse(signature: "0x48656c6c6f")
+
+            let signature = try await fixture.tee.signTransaction(
+                transaction: CrossmintTEETestHelpers.createTestTransaction(),
+                keyType: "secp256k1",
+                encoding: "hex"
+            )
+
+            #expect(signature == "0x48656c6c6f")
+        }
+
+        @Test("Throws when the frame reports an error status for the sign request")
+        func testThrowsOnSignErrorStatus() async throws {
+            let fixture = TEETestFixture()
+            await fixture.setupAuthentication()
+            try await fixture.setupHandshake()
+
+            fixture.configureReadyDevice()
+
+            let signResponse = CrossmintTEETestHelpers.createNonCustodialSignResponse(
+                signature: "",
+                status: .error,
+                errorMessage: "Signing failed in frame"
+            )
+            fixture.webProxy.configureResponse(for: NonCustodialSignResponse.self, response: signResponse)
+
+            await #expect(throws: CrossmintTEE.Error.generic("Signing failed in frame")) {
+                _ = try await fixture.tee.signTransaction(
+                    transaction: "test",
+                    keyType: "keyType",
+                    encoding: "encoding"
+                )
+            }
+        }
     }
 
     @Suite("Onboarding")


### PR DESCRIPTION
## Summary

The `removeSigner` approval flow could submit an invalid (non-hex) ECDSA signature to the API. Root cause is three defects in the TEE signing path:

1. **Lossy `.stringValue` transform** — both signature call sites in `Sources/Web/CrossmintTEE.swift` (the `.ready` path, ~line 167, and the `onboardThenSign` path, ~line 219) applied `.stringValue` to the `sign(...)` result. `.stringValue` (`Sources/Utils/Hex/String+Hex.swift:19-26`) hex-decodes the string and, if the bytes happen to be valid UTF-8, silently replaces the hex signature with the decoded text — corrupting the ECDSA signature into garbage (documented behavior: `Tests/UtilsTests/HexUtilTests.swift`, `"48656c6c6f".stringValue == "Hello"`).
2. **No response validation** — `sign(_:)` (~line 555) only checked for non-empty `bytes`; it never checked `response.status`/`response.error` and never verified the bytes were hex when the request declared `encoding: "hex"`.
3. **No request/response correlation** in `waitForMessage` — **intentionally NOT fixed here**; it requires a frame-protocol change and is out of scope for this PR.

## What changed

- `Sources/Web/CrossmintTEE.swift`
  - Removed `.stringValue` at both signature call sites — the signature is now returned verbatim. (`.stringValue` remains intentional on the attestation/message paths, which are untouched.)
  - `sign(_:)` now throws `Error.generic(response.errorMessage)` when the frame responds with `status == .error`, and throws `Error.invalidSignature` when the request declared `encoding: "hex"` but the returned signature does not parse as hex (`HexUtil.byteArray(fromHex:)`) — failing fast client-side instead of submitting garbage to the API.
- `Tests/WebTests/CrossmintTEETests.swift` — 3 new tests in the Signing suite:
  - non-hex signature with `encoding: "hex"` ⇒ `Error.invalidSignature` (no silent passthrough)
  - valid hex signature whose bytes decode as UTF-8 (`0x48656c6c6f` → "Hello") ⇒ returned verbatim (regression test for the `.stringValue` corruption)
  - frame responds `status: error` ⇒ `Error.generic` with the frame's error message

## Test plan

- [x] `xcodebuild test -scheme CrossmintClientSDK -only-testing:WebTests` — 74 tests / 12 suites pass (incl. 3 new)
- [x] `xcodebuild test -scheme CrossmintClientSDK -only-testing:UtilsTests` — 26 tests pass (hex/`.stringValue` behavior unchanged)
- [x] Full `CrossmintClientSDK` test suite on iOS Simulator — all targets pass (336 tests total)

Fixes WAL-11310
https://linear.app/crossmint/issue/WAL-11310
