### PR TITLE
fix(web): don't buffer messages already consumed by a waiting listener (WAL-11310)

### DIFF
--- a/Sources/Web/WebViewMessageHandler.swift
+++ b/Sources/Web/WebViewMessageHandler.swift
@@ -71,16 +71,24 @@ public class WebViewMessageHandler {
         if let decodedMessage = WebViewMessageRegistry.decode(messageType: messageTypeInfo, data: messageData) {
             Logger.web.debug("Web >> Native: \(String(data: messageData, encoding: .utf8) ?? "Unknown")")
 
-            // Add to message buffer
-            addToMessageBuffer(decodedMessage)
-
+            // Deliver to waiting listeners first; only buffer unclaimed messages.
+            // Buffering a listener-consumed message leaves a stale copy behind,
+            // and the next waitForMessage of the same type returns it instead of
+            // the fresh response (e.g. back-to-back TEE signs reusing the
+            // previous signature — WAL-11310).
+            var consumedByListener = false
             for (id, predicate) in messagePredicates {
                 if predicate(decodedMessage) {
                     if let continuation = messageListeners.removeValue(forKey: id) {
                         messagePredicates.removeValue(forKey: id)
                         continuation.resume(returning: decodedMessage)
+                        consumedByListener = true
                     }
                 }
+            }
+
+            if !consumedByListener {
+                addToMessageBuffer(decodedMessage)
             }
 
             delegate?.handleWebViewMessage(decodedMessage)

--- a/Tests/WebTests/WebViewMessageHandlerTests.swift
+++ b/Tests/WebTests/WebViewMessageHandlerTests.swift
@@ -476,6 +476,44 @@ struct WebViewMessageHandlerTests {
         }
     }
 
+    @Test("Listener-consumed message is not left in buffer for the next wait")
+    func testListenerConsumedMessageNotReusedByNextWait() async throws {
+        let handler = WebViewMessageHandler()
+
+        // First cycle: a listener is already waiting when the response arrives.
+        let firstWait = Task {
+            try await handler.waitForMessage(
+                ofType: HandshakeResponse.self,
+                timeout: 1.0
+            )
+        }
+        try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+        handler.processIncomingMessage(
+            """
+            {"event":"handshakeResponse","data":{"requestVerificationId":"FIRST"}}
+            """
+        )
+        let first = try await firstWait.value
+        #expect(first.data.requestVerificationId == "FIRST")
+
+        // Second cycle: the consumed FIRST response must not be served from the
+        // buffer — the wait must resolve with the fresh SECOND response.
+        let secondWait = Task {
+            try await handler.waitForMessage(
+                ofType: HandshakeResponse.self,
+                timeout: 1.0
+            )
+        }
+        try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+        handler.processIncomingMessage(
+            """
+            {"event":"handshakeResponse","data":{"requestVerificationId":"SECOND"}}
+            """
+        )
+        let second = try await secondWait.value
+        #expect(second.data.requestVerificationId == "SECOND")
+    }
+
     @Test("New pattern: send message then wait")
     func testNewPatternSendThenWait() async throws {
         let handler = WebViewMessageHandler()


### PR DESCRIPTION
## Summary

`WebViewMessageHandler.processIncomingMessage` buffered **every** decoded message (30s TTL) even when a waiting listener consumed it, leaving a stale copy behind. Since `waitForMessage` checks the buffer **first** (default predicate `{ _ in true }`), the next wait of the same type returned the stale message instead of the fresh response.

Concrete failure ([WAL-11310](https://linear.app/crossmint/issue/WAL-11310), defect (3) left out of scope in #139): two back-to-back TEE signs — the add-signer approval followed by the remove-signer approval — made the second `waitForMessage(ofType: NonCustodialSignResponse.self)` return the **first** sign's response. The removal approval was submitted with the previous signature and the API rejected it:

> Signature '0x…' on the approval for signer 'email:…' is invalid. Please ensure you're providing a valid hex-encoded ECDSA signature and the signer is correct.

This is the deterministic failure blocking the `add-external-wallet-signer` remove leg in mobile-e2e-tests PR [#25](https://github.com/Crossmint/crossmint-mobile-e2e-tests/pull/25) (failed 2/2 CI attempts).

## Fix

Deliver incoming messages to matching waiting listeners first, and only add to the buffer when **no** listener claimed the message. Messages arriving with no listener waiting are still buffered, preserving the existing send-then-wait pattern (`testNewPatternSendThenWait`, `testWaitForMessageChecksBufferFirst`, `testMessageRemovedFromBufferWhenConsumed` all still pass).

## Test plan

- [x] New regression test `testListenerConsumedMessageNotReusedByNextWait`: two wait/deliver cycles of the same message type; asserts the second wait resolves with the second response, not the buffered first one. Fails on `main`, passes here.
- [x] All 26 `WebViewMessageHandlerTests` pass (`xcodebuild test -only-testing:WebTests/WebViewMessageHandlerTests`, iPhone 17 Pro sim).
- [x] SwiftLint strict: 0 violations on both changed files.
- [x] Local A/B on the Maestro `add-external-wallet-signer` flow with `SWIFT_REMOVE_SIGNER=true` (iPhone 16e, iOS 26.2): pre-fix build fails at `Assert "Signer removed."` with the invalid-signature alert (same as CI); this branch's build passes the full add → verify → remove → verify-gone leg.