### PR TITLE
Add a typed SignerLocator

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -164,6 +164,7 @@ let package = Package(
                 .process("Resources/Transaction/RemoveSignerTransactionSuccess.json"),
                 .process("Resources/Signature/CreateSignatureAwaitingApproval.json"),
                 .process("Resources/WalletEVMApiKey.json"),
+                .process("Resources/WalletEVMApiKeyWithDelegatedSigners.json"),
                 .process("Resources/WalletEVMEmail.json"),
                 .process("Resources/WalletSolanaEmail.json"),
                 .process("Resources/WalletSolanaEmailWithStaleDeviceSigner.json"),

--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -377,6 +377,9 @@ public enum LogEvents {
 
     // MARK: - Device Signer Events
 
+    /// Local device signer locator failed to parse
+    public static let walletLocalDeviceSignerLocatorParseError = "wallet.localDeviceSignerLocator.error"
+
     /// Device signer key prepared for new wallet creation
     public static let walletCreateDeviceSignerPrepared = "wallet.create.deviceSigner.prepared"
 

--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -392,9 +392,6 @@ public enum LogEvents {
 
     // MARK: - Device Signer Events
 
-    /// Local device signer locator failed to parse
-    public static let walletLocalDeviceSignerLocatorParseError = "wallet.localDeviceSignerLocator.error"
-
     /// Device signer key prepared for new wallet creation
     public static let walletCreateDeviceSignerPrepared = "wallet.create.deviceSigner.prepared"
 

--- a/Sources/Wallet/Data/CreateWallet/Signers/SignerConfig.swift
+++ b/Sources/Wallet/Data/CreateWallet/Signers/SignerConfig.swift
@@ -21,14 +21,14 @@ public enum SignerConfig: Sendable {
 }
 
 extension SignerConfig {
-    /// The locator string for this signer config, or `nil` for types whose locator
+    /// The locator for this signer config, or `nil` for types whose locator
     /// cannot be determined without async context (`.device`) or server-assigned data (`.passkey`).
-    var locator: String? {
+    var locator: SignerLocator? {
         switch self {
-        case .email(let email): "email:\(email)"
-        case .phone(let phone): "phone:\(phone)"
-        case .externalWallet(let address): "external-wallet:\(address)"
-        case .apiKey: "api-key"
+        case .email(let email): .email(email)
+        case .phone(let phone): .phone(phone)
+        case .externalWallet(let address): .externalWallet(address: address)
+        case .apiKey: .apiKey()
         case .device, .passkey: nil
         }
     }

--- a/Sources/Wallet/DefaultCrossmintWallets.swift
+++ b/Sources/Wallet/DefaultCrossmintWallets.swift
@@ -310,10 +310,11 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
     ) -> String? {
         guard let signers = wallet.config.signers else { return nil }
         for entry in signers {
-            guard let locator = entry.locator, locator.hasPrefix("device:") else { continue }
-            let b64 = String(locator.dropFirst("device:".count))
-            if storage.hasKey(publicKeyBase64: b64) {
-                return b64
+            guard let locatorString = entry.locator,
+                  let locator = try? SignerLocator(from: locatorString),
+                  case .device(let publicKey) = locator else { continue }
+            if storage.hasKey(publicKeyBase64: publicKey) {
+                return publicKey
             }
         }
         return nil
@@ -334,7 +335,7 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
               rawKey.count == 65, rawKey[0] == 0x04 else {
             return false
         }
-        let locator = "device:\(keyBase64)"
+        let locator = SignerLocator.device(publicKey: keyBase64).value
         return wallet.config.signers?.contains(where: { $0.locator == locator }) ?? false
     }
 
@@ -343,6 +344,6 @@ Review if the .crossmintEnvironmentObject modifier is used as expected.
               rawPublicKey.count == 65, rawPublicKey[0] == 0x04 else {
             throw WalletError.walletCreationFailed("Invalid device signer public key")
         }
-        return DelegatedSignerEntry(signer: "device:\(publicKeyBase64)")
+        return DelegatedSignerEntry(signer: SignerLocator.device(publicKey: publicKeyBase64).value)
     }
 }

--- a/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
+++ b/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
@@ -124,11 +124,16 @@ final class DeviceSignerService: Sendable {
         }
     }
 
-    func locator(for storage: any DeviceSignerKeyStorage) async -> String? {
+    func publicKey(for storage: any DeviceSignerKeyStorage) async -> String? {
         guard let publicKeyBase64 = await storage.getKey(address: address),
               let rawKey = Data(base64Encoded: publicKeyBase64),
               rawKey.count == 65, rawKey[0] == 0x04 else { return nil }
-        return "device:\(publicKeyBase64)"
+        return publicKeyBase64
+    }
+
+    func locator(for storage: any DeviceSignerKeyStorage) async -> String? {
+        guard let publicKeyBase64 = await publicKey(for: storage) else { return nil }
+        return SignerLocator.device(publicKey: publicKeyBase64).value
     }
 
     func ensureRegistered(storage: any DeviceSignerKeyStorage, signer: any Signer) async throws(WalletError) {
@@ -162,7 +167,7 @@ final class DeviceSignerService: Sendable {
               rawPublicKey.count == 65, rawPublicKey[0] == 0x04 else {
             throw WalletError.walletGeneric("Invalid device signer public key")
         }
-        return DelegatedSignerEntry(signer: "device:\(publicKeyBase64)")
+        return DelegatedSignerEntry(signer: SignerLocator.device(publicKey: publicKeyBase64).value)
     }
 
 }

--- a/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
+++ b/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
@@ -131,11 +131,6 @@ final class DeviceSignerService: Sendable {
         return publicKeyBase64
     }
 
-    func locator(for storage: any DeviceSignerKeyStorage) async -> String? {
-        guard let publicKeyBase64 = await publicKey(for: storage) else { return nil }
-        return SignerLocator.device(publicKey: publicKeyBase64).value
-    }
-
     func ensureRegistered(storage: any DeviceSignerKeyStorage, signer: any Signer) async throws(WalletError) {
         guard await storage.getKey(address: address) == nil else { return }
         Logger.smartWallet.info(LogEvents.walletAddDelegatedSignerStart, attributes: ["address": address])
@@ -156,7 +151,8 @@ final class DeviceSignerService: Sendable {
         storage: any DeviceSignerKeyStorage
     ) async throws(DeviceSignerError) -> SignRequestApi {
         let (r, s) = try await storage.signMessage(address: address, message: message)
-        let currentLocator = await locator(for: storage) ?? signerLocator
+        let currentPublicKey = await publicKey(for: storage)
+        let currentLocator = currentPublicKey.map { SignerLocator.device(publicKey: $0).value } ?? signerLocator
         return SignRequestApi(approvals: [
             .device(signer: currentLocator, signature: .init(r: r, s: s))
         ])

--- a/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
+++ b/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
@@ -66,7 +66,7 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
                 value: "\(value ?? .zero)",
                 data: data ?? "0x",
                 chain: chain,
-                signer: selectedSignerLocator ?? self.config.recovery.locator
+                signer: selectedSignerLocator?.value ?? self.config.recovery.locator
             )
         ) else {
             throw .transactionGeneric("Unknown error")
@@ -111,7 +111,7 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
                 value: value ?? "0",
                 data: data ?? "0x",
                 chain: chain ?? self.evmChain,
-                signer: selectedSignerLocator ?? self.config.recovery.locator
+                signer: selectedSignerLocator?.value ?? self.config.recovery.locator
             )
         ) else {
             throw .transactionGeneric("Unknown error")

--- a/Sources/Wallet/Model/Wallet/SignerLocator.swift
+++ b/Sources/Wallet/Model/Wallet/SignerLocator.swift
@@ -1,7 +1,14 @@
+//
+//  SignerLocator.swift
+//  CrossmintSDK
+//
+//  Created by Tomas Martins on 27/07/26.
+//
+
 /// Identifies a signer registered on a wallet.
 ///
-/// Signer locators are sent to and received from the API as strings, e.g. `"email:user@example.com"`
-/// or `"device:<publicKey>"`. `SignerLocator` parses that format so callers don't have to match
+/// The API sends and receives signer locators as strings, for example `"email:user@example.com"`
+/// or `"device:<publicKey>"`. `SignerLocator` parses this format. Callers do not have to match
 /// prefixes by hand.
 public enum SignerLocator: Codable, Sendable, Equatable {
     case device(publicKey: String)

--- a/Sources/Wallet/Model/Wallet/SignerLocator.swift
+++ b/Sources/Wallet/Model/Wallet/SignerLocator.swift
@@ -6,10 +6,6 @@
 //
 
 /// Identifies a signer registered on a wallet.
-///
-/// The API sends and receives signer locators as strings, for example `"email:user@example.com"`
-/// or `"device:<publicKey>"`. `SignerLocator` parses this format. Callers do not have to match
-/// prefixes by hand.
 public enum SignerLocator: Codable, Sendable, Equatable {
     case device(publicKey: String)
     case email(String)

--- a/Sources/Wallet/Model/Wallet/SignerLocator.swift
+++ b/Sources/Wallet/Model/Wallet/SignerLocator.swift
@@ -1,0 +1,80 @@
+/// Identifies a signer registered on a wallet.
+///
+/// Signer locators are sent to and received from the API as strings, e.g. `"email:user@example.com"`
+/// or `"device:<publicKey>"`. `SignerLocator` parses that format so callers don't have to match
+/// prefixes by hand.
+public enum SignerLocator: Codable, Sendable, Equatable {
+    case device(publicKey: String)
+    case email(String)
+    case phone(String)
+    case externalWallet(address: String)
+    case passkey(credentialId: String)
+    case apiKey(address: String? = nil)
+    case server(address: String)
+
+    public var value: String {
+        switch self {
+        case let .device(publicKey):
+            "device:\(publicKey)"
+        case let .email(email):
+            "email:\(email)"
+        case let .phone(phone):
+            "phone:\(phone)"
+        case let .externalWallet(address):
+            "external-wallet:\(address)"
+        case let .passkey(credentialId):
+            "passkey:\(credentialId)"
+        case let .apiKey(address):
+            address.map { "api-key:\($0)" } ?? "api-key"
+        case let .server(address):
+            "server:\(address)"
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        do {
+            self = try SignerLocator(from: value)
+        } catch {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid signer locator: \(value)"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+
+    public init(from locator: String) throws(WalletError) {
+        let components = locator.split(separator: ":", maxSplits: 1)
+        guard let prefix = components.first else {
+            throw .signerLocatorError(locator)
+        }
+        let rest = components.count > 1 ? String(components[1]) : nil
+
+        switch (prefix, rest) {
+        case ("device", .some(let publicKey)):
+            self = .device(publicKey: publicKey)
+        case ("email", .some(let email)):
+            self = .email(email)
+        case ("phone", .some(let phone)):
+            self = .phone(phone)
+        case ("external-wallet", .some(let address)):
+            self = .externalWallet(address: address)
+        case ("passkey", .some(let credentialId)):
+            self = .passkey(credentialId: credentialId)
+        case ("api-key", let address):
+            // The client-side literal "api-key" (no address) and the backend's
+            // "api-key:api-key" fallback both mean "no address on this signer".
+            self = .apiKey(address: address == "api-key" ? nil : address)
+        case ("server", .some(let address)):
+            self = .server(address: address)
+        default:
+            throw .signerLocatorError(locator)
+        }
+    }
+}

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -196,7 +196,7 @@ extension Wallet {
 
     private func activateEmailSigner(email: String) async throws(WalletError) {
         let locator = "email:\(email)"
-        guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
+        guard await isLocatorStringRegistered(locator) else { throw .signerNotRegistered(locator) }
         let newSigner: any Signer = await MainActor.run { makeEmailSigner(email: email) }
         selectedSigner = newSigner
         selectedSignerLocator = locator
@@ -204,19 +204,19 @@ extension Wallet {
 
     private func activatePhoneSigner(phone: String) async throws(WalletError) {
         let locator = "phone:\(phone)"
-        guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
+        guard await isLocatorStringRegistered(locator) else { throw .signerNotRegistered(locator) }
         throw .walletGeneric("Phone OTP signing is not yet supported on iOS.")
     }
 
     private func activateExternalWalletSigner(address: String) async throws(WalletError) {
         let locator = "external-wallet:\(address)"
-        guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
+        guard await isLocatorStringRegistered(locator) else { throw .signerNotRegistered(locator) }
         throw .walletGeneric("External wallet signers must approve transactions outside of the SDK.")
     }
 
     private func activateApiKeySigner() async throws(WalletError) {
         let locator = config.recovery.locator
-        guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator) }
+        guard await isLocatorStringRegistered(locator) else { throw .signerNotRegistered(locator) }
         guard let apiKeyData = config.recovery as? ApiKeySignerData else {
             throw .walletGeneric("Recovery signer is not an ApiKeySignerData")
         }

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -222,13 +222,13 @@ extension Wallet {
     }
 
     private func activateApiKeySigner() async throws(WalletError) {
-        let locator = try SignerLocator(from: config.recovery.locator)
-        guard await isLocatorStringRegistered(locator.value) else { throw .signerNotRegistered(locator.value) }
+        let locator = config.recovery.locator
+        guard await isLocatorStringRegistered(locator) else { throw .signerNotRegistered(locator) }
         guard let apiKeyData = config.recovery as? ApiKeySignerData else {
             throw .walletGeneric("Recovery signer is not an ApiKeySignerData")
         }
         selectedSigner = ApiKeySigner(adminSigner: apiKeyData)
-        selectedSignerLocator = locator.value
+        selectedSignerLocator = locator
     }
 
     private func activatePasskeySigner(name: String, host: String) async throws(WalletError) {

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -194,10 +194,10 @@ extension Wallet {
             throw .walletGeneric("No device key found for this wallet on this device. Call recover() first.")
         }
         deviceSignerKeyStorage = storage
-        guard let locator = await deviceSignerService.locator(for: storage) else {
+        guard let publicKey = await deviceSignerService.publicKey(for: storage) else {
             throw .walletGeneric("Failed to compute device signer locator")
         }
-        selectedSignerLocator = locator
+        selectedSignerLocator = SignerLocator.device(publicKey: publicKey).value
         _deviceSignerApproved = true
     }
 

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -228,33 +228,33 @@ extension Wallet {
         guard let publicKey = await deviceSignerService.publicKey(for: storage) else {
             throw .walletGeneric("Failed to compute device signer locator")
         }
-        selectedSignerLocator = SignerLocator.device(publicKey: publicKey).value
+        selectedSignerLocator = .device(publicKey: publicKey)
         _deviceSignerApproved = true
     }
 
     private func activateEmailSigner(email: String) async throws(WalletError) {
         let locator = SignerLocator.email(email)
-        guard await isLocatorStringRegistered(locator.value) else { throw .signerNotRegistered(locator.value) }
+        guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator.value) }
         let newSigner: any Signer = await MainActor.run { makeEmailSigner(email: email) }
         selectedSigner = newSigner
-        selectedSignerLocator = locator.value
+        selectedSignerLocator = locator
     }
 
     private func activatePhoneSigner(phone: String) async throws(WalletError) {
         let locator = SignerLocator.phone(phone)
-        guard await isLocatorStringRegistered(locator.value) else { throw .signerNotRegistered(locator.value) }
+        guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator.value) }
         throw .walletGeneric("Phone OTP signing is not yet supported on iOS.")
     }
 
     private func activateExternalWalletSigner(address: String) async throws(WalletError) {
         let locator = SignerLocator.externalWallet(address: address)
-        guard await isLocatorStringRegistered(locator.value) else { throw .signerNotRegistered(locator.value) }
+        guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator.value) }
         throw .walletGeneric("External wallet signers must approve transactions outside of the SDK.")
     }
 
     private func activateApiKeySigner() async throws(WalletError) {
-        let locator = config.recovery.locator
-        guard await isLocatorStringRegistered(locator) else { throw .signerNotRegistered(locator) }
+        let locator = try SignerLocator(from: config.recovery.locator)
+        guard await signerIsRegistered(locator) else { throw .signerNotRegistered(locator.value) }
         guard let apiKeyData = config.recovery as? ApiKeySignerData else {
             throw .walletGeneric("Recovery signer is not an ApiKeySignerData")
         }
@@ -291,7 +291,7 @@ extension Wallet {
         let passkeySigner = PasskeySigner(name: name, host: host)
         _ = await passkeySigner.updateAdminSigner(passkeyData)
         selectedSigner = passkeySigner
-        selectedSignerLocator = locator.value
+        selectedSignerLocator = locator
     }
 
     @MainActor

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -123,7 +123,7 @@ extension Wallet {
                 deviceSignerKeyStorage = storage
             case .email, .phone, .externalWallet, .apiKey:
                 guard let locator = config.locator else { return }
-                try await registerLocatorSigner(locator, deployImmediately: deployImmediately)
+                try await registerLocatorSigner(locator.value, deployImmediately: deployImmediately)
             case .passkey(let name, let host):
                 try await registerPasskeySigner(name: name, host: host, deployImmediately: deployImmediately)
             }
@@ -165,8 +165,9 @@ extension Wallet {
             // Device signer was configured but none was registered — recovery needed
             _needsRecovery = true
         case 1:
-            guard let locator = initialDelegatedSigners[0].locator,
-                  locator.hasPrefix("device:"),
+            guard let locatorString = initialDelegatedSigners[0].locator,
+                  let locator = try? SignerLocator(from: locatorString),
+                  case .device = locator,
                   let storage = deviceSignerKeyStorage else { return }
             if await storage.getKey(address: address) != nil {
                 _deviceSignerApproved = true
@@ -201,33 +202,33 @@ extension Wallet {
     }
 
     private func activateEmailSigner(email: String) async throws(WalletError) {
-        let locator = "email:\(email)"
-        guard await isLocatorStringRegistered(locator) else { throw .signerNotRegistered(locator) }
+        let locator = SignerLocator.email(email)
+        guard await isLocatorStringRegistered(locator.value) else { throw .signerNotRegistered(locator.value) }
         let newSigner: any Signer = await MainActor.run { makeEmailSigner(email: email) }
         selectedSigner = newSigner
-        selectedSignerLocator = locator
+        selectedSignerLocator = locator.value
     }
 
     private func activatePhoneSigner(phone: String) async throws(WalletError) {
-        let locator = "phone:\(phone)"
-        guard await isLocatorStringRegistered(locator) else { throw .signerNotRegistered(locator) }
+        let locator = SignerLocator.phone(phone)
+        guard await isLocatorStringRegistered(locator.value) else { throw .signerNotRegistered(locator.value) }
         throw .walletGeneric("Phone OTP signing is not yet supported on iOS.")
     }
 
     private func activateExternalWalletSigner(address: String) async throws(WalletError) {
-        let locator = "external-wallet:\(address)"
-        guard await isLocatorStringRegistered(locator) else { throw .signerNotRegistered(locator) }
+        let locator = SignerLocator.externalWallet(address: address)
+        guard await isLocatorStringRegistered(locator.value) else { throw .signerNotRegistered(locator.value) }
         throw .walletGeneric("External wallet signers must approve transactions outside of the SDK.")
     }
 
     private func activateApiKeySigner() async throws(WalletError) {
-        let locator = config.recovery.locator
-        guard await isLocatorStringRegistered(locator) else { throw .signerNotRegistered(locator) }
+        let locator = try SignerLocator(from: config.recovery.locator)
+        guard await isLocatorStringRegistered(locator.value) else { throw .signerNotRegistered(locator.value) }
         guard let apiKeyData = config.recovery as? ApiKeySignerData else {
             throw .walletGeneric("Recovery signer is not an ApiKeySignerData")
         }
         selectedSigner = ApiKeySigner(adminSigner: apiKeyData)
-        selectedSignerLocator = locator
+        selectedSignerLocator = locator.value
     }
 
     private func activatePasskeySigner(name: String, host: String) async throws(WalletError) {
@@ -238,25 +239,28 @@ extension Wallet {
             throw .walletGeneric("Failed to fetch wallet config")
         }
 
-        let passkeyLocator = walletModel.config.signers?
+        let delegatedPasskeyLocator = walletModel.config.signers?
             .compactMap(\.locator)
-            .first(where: { $0.hasPrefix("passkey:") })
+            .compactMap { try? SignerLocator(from: $0) }
+            .first { if case .passkey = $0 { true } else { false } }
 
-        let locator: String
-        if let delegatedLocator = passkeyLocator {
-            locator = delegatedLocator
+        let locator: SignerLocator
+        if let delegatedPasskeyLocator {
+            locator = delegatedPasskeyLocator
         } else if config.recovery is PasskeySignerData {
-            locator = config.recovery.locator
+            locator = try SignerLocator(from: config.recovery.locator)
         } else {
-            throw .signerNotRegistered("passkey:\(name)")
+            throw .signerNotRegistered(SignerLocator.passkey(credentialId: name).value)
         }
 
-        let credentialId = String(locator.dropFirst("passkey:".count))
+        guard case .passkey(let credentialId) = locator else {
+            throw .walletGeneric("Recovery signer is not a passkey")
+        }
         let passkeyData = PasskeySignerData(id: credentialId, name: name, publicKey: .init(x: "0", y: "0"))
         let passkeySigner = PasskeySigner(name: name, host: host)
         _ = await passkeySigner.updateAdminSigner(passkeyData)
         selectedSigner = passkeySigner
-        selectedSignerLocator = locator
+        selectedSignerLocator = locator.value
     }
 
     @MainActor

--- a/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
@@ -53,7 +53,23 @@ extension Wallet {
     /// - Parameter locator: The signer locator string identifying the signer to remove
     ///   (e.g. `"device:ABC123..."`, `"external-wallet:0x456..."`).
     /// - Returns: The completed ``Transaction`` once the signer has been removed on-chain.
+    @available(*, deprecated, message: "Use removeSigner(locator: SignerLocator) instead of raw strings.")
     public func removeSigner(locator: String) async throws(TransactionError) -> Transaction {
+        try await removeSignerByLocatorString(locator)
+    }
+
+    /// Removes an assigned signer from this wallet.
+    ///
+    /// Submits a remove-signer transaction on-chain. If the transaction requires approval,
+    /// the current signer signs it automatically before polling for completion.
+    ///
+    /// - Parameter locator: The locator identifying the signer to remove.
+    /// - Returns: The completed ``Transaction`` once the signer has been removed on-chain.
+    public func removeSigner(locator: SignerLocator) async throws(TransactionError) -> Transaction {
+        try await removeSignerByLocatorString(locator.value)
+    }
+
+    private func removeSignerByLocatorString(_ locator: String) async throws(TransactionError) -> Transaction {
         Logger.smartWallet.info(LogEvents.walletRemoveSignerStart, attributes: [
             "locator": locator
         ])

--- a/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
@@ -322,7 +322,8 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
         if let active = selectedSignerLocator {
             signerLocator = active
         } else if let storage = deviceSignerKeyStorage {
-            signerLocator = await deviceSignerService.locator(for: storage)
+            signerLocator = await deviceSignerService.publicKey(for: storage)
+                .map { SignerLocator.device(publicKey: $0).value }
         } else {
             signerLocator = nil
         }

--- a/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
@@ -47,23 +47,26 @@ extension Wallet {
 
     /// Removes an assigned signer from this wallet.
     ///
-    /// Submits a remove-signer transaction on-chain. If the transaction requires approval,
-    /// the current signer signs it automatically before polling for completion.
+    /// This method submits a remove-signer transaction on-chain. If the transaction needs approval,
+    /// the current signer signs it. The method then polls until the transaction completes.
     ///
-    /// - Parameter locator: The signer locator string identifying the signer to remove
-    ///   (e.g. `"device:ABC123..."`, `"external-wallet:0x456..."`).
+    /// - Parameter locator: The signer locator string that identifies the signer to remove,
+    ///   for example `"device:ABC123..."` or `"external-wallet:0x456..."`.
     /// - Returns: The completed ``Transaction`` once the signer has been removed on-chain.
-    @available(*, deprecated, message: "Use removeSigner(locator: SignerLocator) instead of raw strings.")
+    @available(
+        *, deprecated, renamed: "removeSigner(locator:)",
+        message: "Use the SignerLocator overload instead of raw strings."
+    )
     public func removeSigner(locator: String) async throws(TransactionError) -> Transaction {
         try await removeSignerByLocatorString(locator)
     }
 
     /// Removes an assigned signer from this wallet.
     ///
-    /// Submits a remove-signer transaction on-chain. If the transaction requires approval,
-    /// the current signer signs it automatically before polling for completion.
+    /// This method submits a remove-signer transaction on-chain. If the transaction needs approval,
+    /// the current signer signs it. The method then polls until the transaction completes.
     ///
-    /// - Parameter locator: The locator identifying the signer to remove.
+    /// - Parameter locator: The locator that identifies the signer to remove.
     /// - Returns: The completed ``Transaction`` once the signer has been removed on-chain.
     public func removeSigner(locator: SignerLocator) async throws(TransactionError) -> Transaction {
         try await removeSignerByLocatorString(locator.value)

--- a/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+Transactions.swift
@@ -319,7 +319,7 @@ Transaction ID: \(createdTransaction?.id ?? "unknown")
             }
         }
         let signerLocator: String?
-        if let active = selectedSignerLocator {
+        if let active = selectedSignerLocator?.value {
             signerLocator = active
         } else if let storage = deviceSignerKeyStorage {
             signerLocator = await deviceSignerService.publicKey(for: storage)

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -129,11 +129,11 @@ open class Wallet: @unchecked Sendable {
 
     /// Returns whether the given signer is approved and usable on this wallet's chain.
     ///
-    /// A freshly registered signer can require approval before it can sign — see ``addSigner(_:)``.
-    /// Returns `false` when the signer is not registered on this wallet.
+    /// A freshly registered signer can need approval before it can sign. Call ``addSigner(_:)``
+    /// to register a signer. This method returns `false` when the signer is not registered on this wallet.
     ///
-    /// - Parameter locator: A signer locator string, e.g. `"email:user@example.com"`,
-    ///   `"device:<pubkey>"`, `"api-key"`, `"passkey:<id>"`.
+    /// - Parameter locator: A signer locator string, for example `"email:user@example.com"`,
+    ///   `"device:<pubkey>"`, `"api-key"`, or `"passkey:<id>"`.
     /// - Throws: ``WalletError`` if the request fails.
     public func isSignerApproved(_ locator: String) async throws(WalletError) -> Bool {
         Logger.smartWallet.debug(LogEvents.walletIsSignerApprovedStart)
@@ -160,9 +160,6 @@ open class Wallet: @unchecked Sendable {
         return approved
     }
 
-    /// EVM approval state lives in the per-chain entries; Solana and Stellar approve through
-    /// a transaction. An empty `chains` map means the signer was created together with the
-    /// wallet and needed no approval.
     private func registrationStatus(of response: AddDelegatedSignerResponse) -> SignerStatus? {
         if chain.chainType == .solana || chain.chainType == .stellar {
             return SignerStatus.from(response.transaction?.status ?? "success")

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -25,7 +25,7 @@ open class Wallet: @unchecked Sendable {
     var deviceSignerService: DeviceSignerService
     var signerRegistrationService: SignerRegistrationService
     var selectedSigner: (any Signer)?
-    var selectedSignerLocator: String?
+    var selectedSignerLocator: SignerLocator?
     var _needsRecovery: Bool = false
     var _deviceSignerApproved: Bool = false
     var _deviceSignerUnsupported: Bool = false
@@ -76,7 +76,8 @@ open class Wallet: @unchecked Sendable {
     /// Returns whether the given locator is registered as a signer on this wallet.
     ///
     /// This method makes a fresh API call. It checks the delegated signers first, then the admin signer.
-    /// It returns `false` on any network error.
+    /// It returns `false` on any network error, and when the locator string does not parse
+    /// as a ``SignerLocator``.
     ///
     /// - Parameter locator: A signer locator string, for example `"email:user@example.com"`,
     ///   `"device:<pubkey>"`, `"api-key"`, or `"passkey:<id>"`.
@@ -85,7 +86,8 @@ open class Wallet: @unchecked Sendable {
         message: "Use the SignerLocator overload instead of raw strings."
     )
     public func signerIsRegistered(_ locator: String) async -> Bool {
-        await isLocatorStringRegistered(locator)
+        guard let parsed = try? SignerLocator(from: locator) else { return false }
+        return await signerIsRegistered(parsed)
     }
 
     /// Returns whether the given locator is registered as a signer on this wallet.
@@ -93,10 +95,6 @@ open class Wallet: @unchecked Sendable {
     /// This method makes a fresh API call. It checks the delegated signers first, then the admin signer.
     /// It returns `false` on any network error.
     public func signerIsRegistered(_ locator: SignerLocator) async -> Bool {
-        await isLocatorStringRegistered(locator.value)
-    }
-
-    func isLocatorStringRegistered(_ locator: String) async -> Bool {
         let walletModel: WalletApiModel
         do {
             walletModel = try await smartWalletService.getWallet(GetMeWalletRequest(chainType: chain.chainType))
@@ -104,9 +102,12 @@ open class Wallet: @unchecked Sendable {
             return false
         }
         let delegatedMatch = walletModel.config.signers?
-            .contains(where: { $0.locator == locator }) ?? false
+            .compactMap(\.locator)
+            .compactMap { try? SignerLocator(from: $0) }
+            .contains(locator) ?? false
         if delegatedMatch { return true }
-        return walletModel.config.recovery.toDomain.locator == locator
+        let recovery = try? SignerLocator(from: walletModel.config.recovery.toDomain.locator)
+        return recovery == locator
     }
 
     /// Returns the locator of the device signer whose private key is on this device.

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -74,20 +74,23 @@ open class Wallet: @unchecked Sendable {
 
     /// Returns whether the given locator is registered as a signer on this wallet.
     ///
-    /// Checks both delegated signers (via a fresh API call) and the admin signer.
-    /// Returns `false` on any network error.
+    /// This method makes a fresh API call. It checks the delegated signers first, then the admin signer.
+    /// It returns `false` on any network error.
     ///
-    /// - Parameter locator: A signer locator string, e.g. `"email:user@example.com"`,
-    ///   `"device:<pubkey>"`, `"api-key"`, `"passkey:<id>"`.
-    @available(*, deprecated, message: "Use signerIsRegistered(_ locator: SignerLocator) instead of raw strings.")
+    /// - Parameter locator: A signer locator string, for example `"email:user@example.com"`,
+    ///   `"device:<pubkey>"`, `"api-key"`, or `"passkey:<id>"`.
+    @available(
+        *, deprecated, renamed: "signerIsRegistered(_:)",
+        message: "Use the SignerLocator overload instead of raw strings."
+    )
     public func signerIsRegistered(_ locator: String) async -> Bool {
         await isLocatorStringRegistered(locator)
     }
 
     /// Returns whether the given locator is registered as a signer on this wallet.
     ///
-    /// Checks both delegated signers (via a fresh API call) and the admin signer.
-    /// Returns `false` on any network error.
+    /// This method makes a fresh API call. It checks the delegated signers first, then the admin signer.
+    /// It returns `false` on any network error.
     public func signerIsRegistered(_ locator: SignerLocator) async -> Bool {
         await isLocatorStringRegistered(locator.value)
     }
@@ -105,15 +108,23 @@ open class Wallet: @unchecked Sendable {
         return walletModel.config.recovery.toDomain.locator == locator
     }
 
-    /// Returns the locator of the device signer whose private key lives on this device,
-    /// or `nil` if this wallet has no such signer.
+    /// Returns the locator of the device signer whose private key is on this device.
+    /// Returns `nil` if this wallet has no such signer.
     ///
-    /// A wallet can have `device:` delegated signers registered from other devices; this
-    /// only returns a locator when the matching key is present in local secure storage.
+    /// A wallet can have `device:` delegated signers registered from other devices.
+    /// This method only returns a locator when the matching key is present in local secure storage.
     public func localDeviceSignerLocator() async -> SignerLocator? {
         guard let storage = deviceSignerKeyStorage, !_deviceSignerUnsupported else { return nil }
         guard let locator = await deviceSignerService.locator(for: storage) else { return nil }
-        return try? SignerLocator(from: locator)
+        do {
+            return try SignerLocator(from: locator)
+        } catch {
+            Logger.smartWallet.error(LogEvents.walletLocalDeviceSignerLocatorParseError, attributes: [
+                "locator": locator,
+                "error": "\(error)"
+            ])
+            return nil
+        }
     }
 
     /// Returns a page of NFTs owned by this wallet.

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -115,16 +115,8 @@ open class Wallet: @unchecked Sendable {
     /// This method only returns a locator when the matching key is present in local secure storage.
     public func localDeviceSignerLocator() async -> SignerLocator? {
         guard let storage = deviceSignerKeyStorage, !_deviceSignerUnsupported else { return nil }
-        guard let locator = await deviceSignerService.locator(for: storage) else { return nil }
-        do {
-            return try SignerLocator(from: locator)
-        } catch {
-            Logger.smartWallet.error(LogEvents.walletLocalDeviceSignerLocatorParseError, attributes: [
-                "locator": locator,
-                "error": "\(error)"
-            ])
-            return nil
-        }
+        guard let publicKey = await deviceSignerService.publicKey(for: storage) else { return nil }
+        return .device(publicKey: publicKey)
     }
 
     /// Returns whether the given signer is approved and usable on this wallet's chain.

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -79,7 +79,20 @@ open class Wallet: @unchecked Sendable {
     ///
     /// - Parameter locator: A signer locator string, e.g. `"email:user@example.com"`,
     ///   `"device:<pubkey>"`, `"api-key"`, `"passkey:<id>"`.
+    @available(*, deprecated, message: "Use signerIsRegistered(_ locator: SignerLocator) instead of raw strings.")
     public func signerIsRegistered(_ locator: String) async -> Bool {
+        await isLocatorStringRegistered(locator)
+    }
+
+    /// Returns whether the given locator is registered as a signer on this wallet.
+    ///
+    /// Checks both delegated signers (via a fresh API call) and the admin signer.
+    /// Returns `false` on any network error.
+    public func signerIsRegistered(_ locator: SignerLocator) async -> Bool {
+        await isLocatorStringRegistered(locator.value)
+    }
+
+    func isLocatorStringRegistered(_ locator: String) async -> Bool {
         let walletModel: WalletApiModel
         do {
             walletModel = try await smartWalletService.getWallet(GetMeWalletRequest(chainType: chain.chainType))
@@ -90,6 +103,17 @@ open class Wallet: @unchecked Sendable {
             .contains(where: { $0.locator == locator }) ?? false
         if delegatedMatch { return true }
         return walletModel.config.recovery.toDomain.locator == locator
+    }
+
+    /// Returns the locator of the device signer whose private key lives on this device,
+    /// or `nil` if this wallet has no such signer.
+    ///
+    /// A wallet can have `device:` delegated signers registered from other devices; this
+    /// only returns a locator when the matching key is present in local secure storage.
+    public func localDeviceSignerLocator() async -> SignerLocator? {
+        guard let storage = deviceSignerKeyStorage, !_deviceSignerUnsupported else { return nil }
+        guard let locator = await deviceSignerService.locator(for: storage) else { return nil }
+        return try? SignerLocator(from: locator)
     }
 
     /// Returns a page of NFTs owned by this wallet.

--- a/Sources/Wallet/Model/Wallet/WalletError.swift
+++ b/Sources/Wallet/Model/Wallet/WalletError.swift
@@ -11,6 +11,7 @@ public enum WalletError: CrossmintError {
     case walletGeneric(String)
     case walletInvalidCredentials
     case walletLocatorError(String)
+    case signerLocatorError(String)
     case walletInvalidSignerProvided
     case transactionNotFound
     case invalidChain(chain: Chain)
@@ -32,6 +33,7 @@ public enum WalletError: CrossmintError {
         case .walletGeneric: "WALLET_ERROR"
         case .walletInvalidCredentials: "WALLET_INVALID_CREDENTIALS"
         case .walletLocatorError: "WALLET_LOCATOR_ERROR"
+        case .signerLocatorError: "SIGNER_LOCATOR_ERROR"
         case .walletInvalidSignerProvided: "WALLET_INVALID_SIGNER"
         case .transactionNotFound: "TRANSACTION_NOT_FOUND"
         case .invalidChain: "INVALID_CHAIN"
@@ -53,6 +55,8 @@ public enum WalletError: CrossmintError {
             "The credentials provided are invalid for this wallet."
         case .walletLocatorError(let locator):
             "Invalid wallet locator: \(locator)"
+        case .signerLocatorError(let locator):
+            "Invalid signer locator: \(locator)"
         case .transactionNotFound:
             "Transaction not found"
         case .walletInvalidSignerProvided:
@@ -82,6 +86,8 @@ public enum WalletError: CrossmintError {
             "Check the list of supported chains for this environment."
         case .walletLocatorError:
             "Ensure the wallet locator is in the correct format."
+        case .signerLocatorError:
+            "Ensure the signer locator is in the correct format, e.g. \"email:user@example.com\"."
         case .deviceSignerNotSupported:
             "Use the recovery signer or another registered signer for this wallet."
         default:

--- a/Sources/Wallet/Model/Wallet/WalletError.swift
+++ b/Sources/Wallet/Model/Wallet/WalletError.swift
@@ -87,7 +87,7 @@ public enum WalletError: CrossmintError {
         case .walletLocatorError:
             "Ensure the wallet locator is in the correct format."
         case .signerLocatorError:
-            "Ensure the signer locator is in the correct format, e.g. \"email:user@example.com\"."
+            "Use the correct signer locator format, for example \"email:user@example.com\"."
         case .deviceSignerNotSupported:
             "Use the recovery signer or another registered signer for this wallet."
         default:

--- a/Tests/WalletTests/DefaultCrossmintWalletsTests.swift
+++ b/Tests/WalletTests/DefaultCrossmintWalletsTests.swift
@@ -45,7 +45,8 @@ struct DefaultCrossmintWalletsTests {
         #expect(walletService.createWalletCallCount == 1)
         #expect(await wallet.needsRecovery() == false)
         try await wallet.useSigner(.device)
-        #expect(wallet.selectedSignerLocator?.value.hasPrefix("device:") == true)
+        let publicKeyBase64 = try #require(await keyStorage.getKey(address: wallet.address))
+        #expect(wallet.selectedSignerLocator == .device(publicKey: publicKeyBase64))
     }
 
     @Test

--- a/Tests/WalletTests/Model/SignerLocatorTests.swift
+++ b/Tests/WalletTests/Model/SignerLocatorTests.swift
@@ -42,15 +42,21 @@ struct SignerLocatorTests {
 
     @Test("Throws signerLocatorError for an unknown prefix")
     func throwsForUnknownPrefix() {
-        #expect(throws: WalletError.self) {
+        #expect {
             try SignerLocator(from: "carrier-pigeon:0xabc")
+        } throws: { error in
+            guard case .signerLocatorError("carrier-pigeon:0xabc") = error as? WalletError else { return false }
+            return true
         }
     }
 
     @Test("Throws signerLocatorError when a known prefix has no value")
     func throwsForMissingValue() {
-        #expect(throws: WalletError.self) {
+        #expect {
             try SignerLocator(from: "email")
+        } throws: { error in
+            guard case .signerLocatorError("email") = error as? WalletError else { return false }
+            return true
         }
     }
 

--- a/Tests/WalletTests/Model/SignerLocatorTests.swift
+++ b/Tests/WalletTests/Model/SignerLocatorTests.swift
@@ -1,0 +1,63 @@
+import Testing
+
+@testable import Wallet
+
+@Suite("SignerLocator")
+struct SignerLocatorTests {
+    @Test(
+        "Produces the expected locator string for each case",
+        arguments: [
+            (SignerLocator.device(publicKey: "abc123"), "device:abc123"),
+            (SignerLocator.email("user@example.com"), "email:user@example.com"),
+            (SignerLocator.phone("+15551234567"), "phone:+15551234567"),
+            (SignerLocator.externalWallet(address: "0xabc"), "external-wallet:0xabc"),
+            (SignerLocator.passkey(credentialId: "cred-1"), "passkey:cred-1"),
+            (SignerLocator.apiKey(address: "0xdef"), "api-key:0xdef"),
+            (SignerLocator.apiKey(), "api-key"),
+            (SignerLocator.server(address: "0x999"), "server:0x999")
+        ]
+    )
+    func producesExpectedValue(locatorAndExpected: (SignerLocator, String)) {
+        #expect(locatorAndExpected.0.value == locatorAndExpected.1)
+    }
+
+    @Test(
+        "Parses known locator strings back into the matching case",
+        arguments: [
+            ("device:abc123", SignerLocator.device(publicKey: "abc123")),
+            ("email:user@example.com", SignerLocator.email("user@example.com")),
+            ("phone:+15551234567", SignerLocator.phone("+15551234567")),
+            ("external-wallet:0xabc", SignerLocator.externalWallet(address: "0xabc")),
+            ("passkey:cred-1", SignerLocator.passkey(credentialId: "cred-1")),
+            ("api-key:0xdef", SignerLocator.apiKey(address: "0xdef")),
+            ("api-key", SignerLocator.apiKey()),
+            ("api-key:api-key", SignerLocator.apiKey()),
+            ("server:0x999", SignerLocator.server(address: "0x999"))
+        ]
+    )
+    func parsesKnownLocatorStrings(stringAndExpected: (String, SignerLocator)) throws {
+        let parsed = try SignerLocator(from: stringAndExpected.0)
+        #expect(parsed == stringAndExpected.1)
+    }
+
+    @Test("Throws signerLocatorError for an unknown prefix")
+    func throwsForUnknownPrefix() {
+        #expect(throws: WalletError.self) {
+            try SignerLocator(from: "carrier-pigeon:0xabc")
+        }
+    }
+
+    @Test("Throws signerLocatorError when a known prefix has no value")
+    func throwsForMissingValue() {
+        #expect(throws: WalletError.self) {
+            try SignerLocator(from: "email")
+        }
+    }
+
+    @Test("Round-trips through value and back")
+    func roundTripsThroughValue() throws {
+        let original = SignerLocator.email("round-trip@example.com")
+        let parsed = try SignerLocator(from: original.value)
+        #expect(parsed == original)
+    }
+}

--- a/Tests/WalletTests/Model/WalletErrorTests.swift
+++ b/Tests/WalletTests/Model/WalletErrorTests.swift
@@ -32,6 +32,14 @@ struct WalletErrorTests {
         #expect(error.underlyingError == nil)
     }
 
+    @Test("WalletError.signerLocatorError carries the invalid locator in message")
+    func signerLocatorError() {
+        let error = WalletError.signerLocatorError("carrier-pigeon:0xabc")
+        #expect(error.code == "SIGNER_LOCATOR_ERROR")
+        #expect(error.message.contains("carrier-pigeon:0xabc"))
+        #expect(error.recoverySuggestion != nil)
+    }
+
     @Test("WalletError.serviceError wraps underlying error")
     func serviceError() {
         let inner = CrossmintServiceError.invalidApiKey("bad-key")

--- a/Tests/WalletTests/Model/WalletSignerIsRegisteredTests.swift
+++ b/Tests/WalletTests/Model/WalletSignerIsRegisteredTests.swift
@@ -1,0 +1,56 @@
+import CrossmintCommonTypes
+import Foundation
+import Testing
+import TestsUtils
+
+@testable import Wallet
+
+private func makeWallet(walletService: MockSmartWalletService) throws -> EVMWallet {
+    let baseModel: WalletApiModel = try GetFromFile.getModelFrom(
+        fileName: "WalletEVMApiKeyWithDelegatedSigners",
+        bundle: Bundle.module
+    )
+    walletService.getWalletResult = baseModel
+    return try EVMWallet(
+        smartWalletService: walletService,
+        signer: MockSigner(),
+        baseModel: baseModel,
+        evmChain: .polygon
+    )
+}
+
+@Suite("Wallet signerIsRegistered", .tags(.unit))
+struct WalletSignerIsRegisteredTests {
+
+    @Test func matchesDelegatedEmailSigner() async throws {
+        let wallet = try makeWallet(walletService: MockSmartWalletService())
+
+        #expect(await wallet.signerIsRegistered(.email("user@example.com")))
+    }
+
+    @Test func matchesRecoveryApiKeySigner() async throws {
+        let wallet = try makeWallet(walletService: MockSmartWalletService())
+
+        #expect(await wallet.signerIsRegistered(.apiKey(address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb")))
+    }
+
+    @Test func matchesApiKeySignerStoredInFallbackSpelling() async throws {
+        let wallet = try makeWallet(walletService: MockSmartWalletService())
+
+        #expect(await wallet.signerIsRegistered(.apiKey()))
+    }
+
+    @Test func returnsFalseForUnregisteredSigner() async throws {
+        let wallet = try makeWallet(walletService: MockSmartWalletService())
+
+        #expect(await wallet.signerIsRegistered(.phone("+15551234567")) == false)
+    }
+
+    @Test func returnsFalseOnNetworkError() async throws {
+        let walletService = MockSmartWalletService()
+        let wallet = try makeWallet(walletService: walletService)
+        walletService.getWalletResult = nil
+
+        #expect(await wallet.signerIsRegistered(.email("user@example.com")) == false)
+    }
+}

--- a/Tests/WalletTests/Resources/WalletEVMApiKeyWithDelegatedSigners.json
+++ b/Tests/WalletTests/Resources/WalletEVMApiKeyWithDelegatedSigners.json
@@ -1,0 +1,22 @@
+{
+  "type": "smart",
+  "chainType": "evm",
+  "config": {
+    "adminSigner": {
+      "type": "api-key",
+      "address": "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
+      "locator": "api-key:0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb"
+    },
+    "delegatedSigners": [
+      {
+        "locator": "email:user@example.com"
+      },
+      {
+        "locator": "api-key:api-key"
+      }
+    ]
+  },
+  "address": "0xABCDEF1234567890ABCDEF1234567890ABCDEF12",
+  "linkedUser": "email:admin@example.com",
+  "createdAt": "2025-08-21T10:00:00.000Z"
+}


### PR DESCRIPTION
Signer locators were raw strings, and callers had to string-match prefixes like `"device:"` or `"email:"` to figure out what kind of signer they were looking at. `SignerLocator` replaces that with an enum, so `removeSigner`, `signerIsRegistered`, and the new `localDeviceSignerLocator` all have a typed alternative now.

The string-based overloads still work, they're just marked deprecated. No breaking change, existing callers keep compiling as-is.

## Changes
- `SignerLocator` (public): an enum with a case per signer kind (`device`, `email`, `phone`, `externalWallet`, `passkey`, `apiKey`, `server`), following the same `value`/`init(from:)` shape as `WalletLocator`.
- `WalletError.signerLocatorError` for when a locator string doesn't match any known prefix.
- `Wallet.signerIsRegistered(_:)` and `Wallet.removeSigner(locator:)` now have `SignerLocator` overloads; the `String` versions are `@available(*, deprecated)`.
- `Wallet.localDeviceSignerLocator()`: returns the `SignerLocator` for the device signer whose private key lives on this device, or `nil` if there's none.
- Internal call sites in `Wallet+SignerManagement` moved off the deprecated string overload so the SDK doesn't warn on itself.
- Unit tests covering parsing and round-tripping for every locator kind, plus the new error case.