### PR TITLE
Validate Secure Enclave keys are usable on getKey and hasKey

### DIFF
--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -79,7 +79,8 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
     public func getKey(address: String) async -> String? {
         let tag = "\(walletKeyPrefix)\(address)"
         guard let keyData = keychain.load(tag: tag),
-              let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData) else {
+              let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData),
+              isUsable(key) else {
             return nil
         }
         return uncompressedPublicKey(from: key.publicKey.rawRepresentation)
@@ -135,12 +136,24 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
 
     public func hasKey(publicKeyBase64: String) -> Bool {
         keychain.hasMatchingKey(publicKeyBase64: publicKeyBase64) { [self] keyData in
-            guard let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData) else { return nil }
+            guard let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData),
+                  isUsable(key) else { return nil }
             return uncompressedPublicKey(from: key.publicKey.rawRepresentation)
         }
     }
 
     // MARK: - Private helper
+
+    // A key can reconstruct successfully from its stored data (well-formed wrapped blob) while
+    // still being unusable, e.g. after the device was erased and restored from a backup: the
+    // wrapping is tied to the Secure Enclave's state at generation time, so an old blob can parse
+    // fine and still fail the moment the enclave actually tries to use it. Reconstruction alone
+    // can't tell the two apart, so this exercises the same signing path `signMessage` uses.
+    private static let usabilityCheckPayload = Data([0x00])
+
+    private func isUsable(_ key: SecureEnclave.P256.Signing.PrivateKey) -> Bool {
+        (try? key.signature(for: Self.usabilityCheckPayload)) != nil
+    }
 
     private func makeAccessControl() -> SecAccessControl? {
         let flags: SecAccessControlCreateFlags

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -144,11 +144,6 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
 
     // MARK: - Private helper
 
-    // A key can reconstruct successfully from its stored data (well-formed wrapped blob) while
-    // still being unusable, e.g. after the device was erased and restored from a backup: the
-    // wrapping is tied to the Secure Enclave's state at generation time, so an old blob can parse
-    // fine and still fail the moment the enclave actually tries to use it. Reconstruction alone
-    // can't tell the two apart, so this exercises the same signing path `signMessage` uses.
     private func isUsable(_ key: SecureEnclave.P256.Signing.PrivateKey) -> Bool {
         (try? key.signature(for: Data([0x00]))) != nil
     }

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -78,9 +78,7 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
 
     public func getKey(address: String) async -> String? {
         let tag = "\(walletKeyPrefix)\(address)"
-        guard let keyData = keychain.load(tag: tag),
-              let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData),
-              isUsable(key) else {
+        guard let keyData = keychain.load(tag: tag), let key = isUsable(keyData) else {
             return nil
         }
         return uncompressedPublicKey(from: key.publicKey.rawRepresentation)
@@ -136,16 +134,19 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
 
     public func hasKey(publicKeyBase64: String) -> Bool {
         keychain.hasMatchingKey(publicKeyBase64: publicKeyBase64) { [self] keyData in
-            guard let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData),
-                  isUsable(key) else { return nil }
+            guard let key = isUsable(keyData) else { return nil }
             return uncompressedPublicKey(from: key.publicKey.rawRepresentation)
         }
     }
 
     // MARK: - Private helper
 
-    private func isUsable(_ key: SecureEnclave.P256.Signing.PrivateKey) -> Bool {
-        (try? key.signature(for: Data([0x00]))) != nil
+    private func isUsable(_ keyData: Data) -> SecureEnclave.P256.Signing.PrivateKey? {
+        guard let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData),
+              (try? key.signature(for: Data([0x00]))) != nil else {
+            return nil
+        }
+        return key
     }
 
     private func makeAccessControl() -> SecAccessControl? {

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -149,10 +149,8 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
     // wrapping is tied to the Secure Enclave's state at generation time, so an old blob can parse
     // fine and still fail the moment the enclave actually tries to use it. Reconstruction alone
     // can't tell the two apart, so this exercises the same signing path `signMessage` uses.
-    private static let usabilityCheckPayload = Data([0x00])
-
     private func isUsable(_ key: SecureEnclave.P256.Signing.PrivateKey) -> Bool {
-        (try? key.signature(for: Self.usabilityCheckPayload)) != nil
+        (try? key.signature(for: Data([0x00]))) != nil
     }
 
     private func makeAccessControl() -> SecAccessControl? {

--- a/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
+++ b/Sources/DeviceSigner/Storage/SecureEnclaveKeyStorage.swift
@@ -142,11 +142,13 @@ public final class SecureEnclaveKeyStorage: DeviceSignerKeyStorage {
     // MARK: - Private helper
 
     private func isUsable(_ keyData: Data) -> SecureEnclave.P256.Signing.PrivateKey? {
-        guard let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData),
-              (try? key.signature(for: Data([0x00]))) != nil else {
+        do {
+            let key = try SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: keyData)
+            _ = try key.signature(for: Data([0x00]))
+            return key
+        } catch {
             return nil
         }
-        return key
     }
 
     private func makeAccessControl() -> SecAccessControl? {


### PR DESCRIPTION
`getKey`/`hasKey` only checked that a stored key could be read back and parsed. That's not the same as the key actually working, since the key's wrapping is tied to the enclave's internal state at the time it was created, and a stored blob can still parse fine while no longer being usable to sign anything

Since these methods said the key was fine, nothing downstream knew to treat it as broken until a real signing attempt failed later

Now both methods also try a real, throwaway signature after parsing the key, just to confirm the enclave can actually use it. Same thing `signMessage` already does, just with junk input and the result thrown away. A broken key now reports as missing, same as if it were never there. No auto-recovery added here, just the detection fix

## Changes

- **`SecureEnclaveKeyStorage`**: added a new `isUsable` check that parses the key and does a throwaway trial signature to confirm it actually works
- **`SecureEnclaveKeyStorage`**: `getKey`/`hasKey` now use `isUsable` to check the key instead of just parsing it
