### PR TITLE
Extend device signer recovery to signMessage/signTypedData, fix a stale locator on approval

### DIFF
--- a/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
+++ b/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
@@ -139,8 +139,9 @@ final class DeviceSignerService: Sendable {
         storage: any DeviceSignerKeyStorage
     ) async throws(DeviceSignerError) -> SignRequestApi {
         let rAndS = try await storage.signMessage(address: address, message: message)
+        let currentLocator = await locator(for: storage) ?? signerLocator
         return SignRequestApi(approvals: [
-            .device(signer: signerLocator, signature: .init(r: rAndS.r, s: rAndS.s))
+            .device(signer: currentLocator, signature: .init(r: rAndS.r, s: rAndS.s))
         ])
     }
 

--- a/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
+++ b/Sources/Wallet/Model/Wallet/DeviceSignerService.swift
@@ -138,10 +138,10 @@ final class DeviceSignerService: Sendable {
         message: String,
         storage: any DeviceSignerKeyStorage
     ) async throws(DeviceSignerError) -> SignRequestApi {
-        let rAndS = try await storage.signMessage(address: address, message: message)
+        let (r, s) = try await storage.signMessage(address: address, message: message)
         let currentLocator = await locator(for: storage) ?? signerLocator
         return SignRequestApi(approvals: [
-            .device(signer: currentLocator, signature: .init(r: rAndS.r, s: rAndS.s))
+            .device(signer: currentLocator, signature: .init(r: r, s: s))
         ])
     }
 

--- a/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
+++ b/Sources/Wallet/Model/Wallet/EVM/EVMWallet.swift
@@ -150,6 +150,12 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
     ) async throws(SignatureError) -> String {
         Logger.smartWallet.info(LogEvents.evmSignMessageStart)
 
+        do {
+            try await preAuthIfNeeded()
+        } catch {
+            throw .signingFailed(underlyingError: error)
+        }
+
         let signer = signer ?? self.config.recovery
 
         do {
@@ -207,6 +213,12 @@ open class EVMWallet: Wallet, WalletOnChain, @unchecked Sendable {
         isSmartWalletSignature: Bool = true
     ) async throws(SignatureError) -> String {
         Logger.smartWallet.info(LogEvents.evmSignTypedDataStart)
+
+        do {
+            try await preAuthIfNeeded()
+        } catch {
+            throw .signingFailed(underlyingError: error)
+        }
 
         let signer = signer ?? self.config.recovery
 


### PR DESCRIPTION
`approve()`, `sendTransaction`, and `transferToken` all call `preAuthIfNeeded()` before doing anything else, which recovers a broken or missing device signer automatically before signing happens. EVM's `signMessage`/`signTypedData` never got the same call added, so a broken device signer on those two paths just fails instead of self-healing like everywhere else. Solana and Stellar don't have an equivalent standalone signing method, so this gap is EVM-only.

Separately, when a device signer does recover mid-flow, `buildSignRequest` was still tagging the submitted approval with whatever locator the backend's pending-approval entry named, not the signer that actually produced the signature. After recovering to a new key, that's the old, dead locator. `DeviceSignerService` already has a `locator(for:)` helper that recomputes the current one, `buildSignRequest` just wasn't using it. This path is shared across all chains, so the fix isn't EVM-specific.

## Changes

- **`EVMWallet`**: `signMessage`/`signTypedData` now call `preAuthIfNeeded()` first, same as the other signing entry points
- **`DeviceSignerService`**: `buildSignRequest` now tags the submitted approval with the signer's current locator via `locator(for:)`, instead of whatever locator the caller passed in
