### PR TITLE
Remove the stale device signer after a successful recovery

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -165,6 +165,7 @@ let package = Package(
                 .process("Resources/WalletEVMApiKey.json"),
                 .process("Resources/WalletEVMEmail.json"),
                 .process("Resources/WalletSolanaEmail.json"),
+                .process("Resources/WalletSolanaEmailWithStaleDeviceSigner.json"),
                 .process("Resources/WalletEVMPhone.json"),
                 .process("Resources/Transfer/ListTransfersResponse.json")
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -161,6 +161,7 @@ let package = Package(
                 .process("Resources/Transaction/CreateStellarTransactionResponse.json"),
                 .process("Resources/Transaction/SolanaSignerRegistrationAwaitingApproval.json"),
                 .process("Resources/Transaction/GetTransactionResponse.json"),
+                .process("Resources/Transaction/RemoveSignerTransactionSuccess.json"),
                 .process("Resources/Signature/CreateSignatureAwaitingApproval.json"),
                 .process("Resources/WalletEVMApiKey.json"),
                 .process("Resources/WalletEVMEmail.json"),

--- a/Sources/Logger/LogEvents.swift
+++ b/Sources/Logger/LogEvents.swift
@@ -437,6 +437,12 @@ public enum LogEvents {
     /// Recover fell back to the recovery signer — the wallet's provider does not support device signers
     public static let walletRecoverDeviceSignerUnsupported = "wallet.recover.deviceSignerUnsupported"
 
+    /// The stale device signer left over from before recovery was removed
+    public static let walletRecoverStaleSignerRemoved = "wallet.recover.staleSignerRemoved"
+
+    /// Removing the stale device signer left over from before recovery failed
+    public static let walletRecoverStaleSignerRemovalFailed = "wallet.recover.staleSignerRemovalFailed"
+
     // MARK: - registerDeviceSigner Events
 
     /// Starting device signer registration

--- a/Sources/Wallet/Data/GetWallet/Response/WalletConfigApiModel.swift
+++ b/Sources/Wallet/Data/GetWallet/Response/WalletConfigApiModel.swift
@@ -1,7 +1,7 @@
 import CrossmintCommonTypes
 import Foundation
 
-public struct WalletDelegatedSignerConfigApiModel: Decodable {
+public struct WalletDelegatedSignerConfigApiModel: Decodable, Sendable {
     public let locator: String?
     public let signer: String?
 }

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -179,15 +179,15 @@ extension Wallet {
         }
     }
 
-    internal func initDefaultSigner() async {
+    internal func initDefaultSigner(delegatedSigners: [WalletDelegatedSignerConfigApiModel]) async {
         guard deviceSignerKeyStorage != nil else { return }
 
-        switch initialDelegatedSigners.count {
+        switch delegatedSigners.count {
         case 0:
             // Device signer was configured but none was registered — recovery needed
             _needsRecovery = true
         case 1:
-            guard let locator = initialDelegatedSigners[0].locator,
+            guard let locator = delegatedSigners[0].locator,
                   locator.hasPrefix("device:"),
                   let storage = deviceSignerKeyStorage else { return }
             if await storage.getKey(address: address) != nil {

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -84,7 +84,7 @@ extension Wallet {
             throw error
         }
 
-        let staleDeviceSignerLocator = findStaleDeviceSignerLocator()
+        let staleDeviceSignerLocator = await findStaleDeviceSignerLocator()
 
         do {
             try await registerDeviceSigner(storage: storage)
@@ -103,8 +103,9 @@ extension Wallet {
         }
     }
 
-    private func findStaleDeviceSignerLocator() -> String? {
-        let deviceLocators = initialDelegatedSigners
+    private func findStaleDeviceSignerLocator() async -> String? {
+        let currentSigners = (try? await signers()) ?? []
+        let deviceLocators = currentSigners
             .compactMap(\.locator)
             .filter { $0.hasPrefix("device:") }
         guard deviceLocators.count == 1 else { return nil }

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -98,7 +98,9 @@ extension Wallet {
             throw error
         }
 
-        await removeStaleDeviceSigner(staleDeviceSignerLocator)
+        if let staleDeviceSignerLocator {
+            await removeStaleDeviceSigner(staleDeviceSignerLocator)
+        }
     }
 
     private func findStaleDeviceSignerLocator() -> String? {
@@ -108,8 +110,7 @@ extension Wallet {
         return locator
     }
 
-    private func removeStaleDeviceSigner(_ locator: String?) async {
-        guard let locator else { return }
+    private func removeStaleDeviceSigner(_ locator: String) async {
         do {
             _ = try await removeSigner(locator: locator)
             Logger.smartWallet.info(LogEvents.walletRecoverStaleSignerRemoved, attributes: ["signerLocator": locator])

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -104,10 +104,11 @@ extension Wallet {
     }
 
     private func findStaleDeviceSignerLocator() -> String? {
-        guard let locator = initialDelegatedSigners.first?.locator, locator.hasPrefix("device:") else {
-            return nil
-        }
-        return locator
+        let deviceLocators = initialDelegatedSigners
+            .compactMap(\.locator)
+            .filter { $0.hasPrefix("device:") }
+        guard deviceLocators.count == 1 else { return nil }
+        return deviceLocators[0]
     }
 
     private func removeStaleDeviceSigner(_ locator: String) async {

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -101,8 +101,6 @@ extension Wallet {
         await removeStaleDeviceSigner(staleDeviceSignerLocator)
     }
 
-    /// The device signer that was registered before recovery started, if any — it's now
-    /// superseded by the freshly-registered one and should be removed from the wallet.
     private func findStaleDeviceSignerLocator() -> String? {
         guard let locator = initialDelegatedSigners.first?.locator, locator.hasPrefix("device:") else {
             return nil

--- a/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet+SignerManagement.swift
@@ -83,6 +83,9 @@ extension Wallet {
             Logger.smartWallet.error(LogEvents.walletRecoverError, attributes: ["error": "\(error)"])
             throw error
         }
+
+        let staleDeviceSignerLocator = findStaleDeviceSignerLocator()
+
         do {
             try await registerDeviceSigner(storage: storage)
             Logger.smartWallet.info(LogEvents.walletRecoverSuccess)
@@ -93,6 +96,30 @@ extension Wallet {
             }
             Logger.smartWallet.error(LogEvents.walletRecoverError, attributes: ["error": "\(error)"])
             throw error
+        }
+
+        await removeStaleDeviceSigner(staleDeviceSignerLocator)
+    }
+
+    /// The device signer that was registered before recovery started, if any — it's now
+    /// superseded by the freshly-registered one and should be removed from the wallet.
+    private func findStaleDeviceSignerLocator() -> String? {
+        guard let locator = initialDelegatedSigners.first?.locator, locator.hasPrefix("device:") else {
+            return nil
+        }
+        return locator
+    }
+
+    private func removeStaleDeviceSigner(_ locator: String?) async {
+        guard let locator else { return }
+        do {
+            _ = try await removeSigner(locator: locator)
+            Logger.smartWallet.info(LogEvents.walletRecoverStaleSignerRemoved, attributes: ["signerLocator": locator])
+        } catch {
+            Logger.smartWallet.warning(LogEvents.walletRecoverStaleSignerRemovalFailed, attributes: [
+                "signerLocator": locator,
+                "error": "\(error)"
+            ])
         }
     }
 

--- a/Sources/Wallet/Model/Wallet/Wallet.swift
+++ b/Sources/Wallet/Model/Wallet/Wallet.swift
@@ -29,7 +29,6 @@ open class Wallet: @unchecked Sendable {
     var _needsRecovery: Bool = false
     var _deviceSignerApproved: Bool = false
     var _deviceSignerUnsupported: Bool = false
-    var initialDelegatedSigners: [WalletDelegatedSignerConfigApiModel] = []
     var signerInitializationTask: Task<Void, Never>?
 
     private let owner: Owner?
@@ -66,9 +65,9 @@ open class Wallet: @unchecked Sendable {
             chainType: chain.chainType,
             chainName: chain.name
         )
-        self.initialDelegatedSigners = baseModel.config.signers ?? []
+        let delegatedSigners = baseModel.config.signers ?? []
         self.signerInitializationTask = Task { [weak self] in
-            await self?.initDefaultSigner()
+            await self?.initDefaultSigner(delegatedSigners: delegatedSigners)
         }
     }
 

--- a/Tests/WalletTests/Mocks/MockSmartWalletService.swift
+++ b/Tests/WalletTests/Mocks/MockSmartWalletService.swift
@@ -107,6 +107,7 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
     // MARK: - removeSigner
 
     var removeSignerResult: (any TransactionApiModel)?
+    var removeSignerError: TransactionError?
     var removeSignerCallCount = 0
     var removeSignerLastLocator: String?
 
@@ -117,17 +118,27 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
     ) async throws(TransactionError) -> any TransactionApiModel {
         removeSignerCallCount += 1
         removeSignerLastLocator = signerLocator
+        if let removeSignerError {
+            throw removeSignerError
+        }
         guard let removeSignerResult else {
             throw TransactionError.transactionGeneric("not implemented")
         }
         return removeSignerResult
     }
 
-    // MARK: - Unused stubs
+    // MARK: - getWallet
+
+    var getWalletResult: WalletApiModel?
 
     func getWallet(_ request: GetMeWalletRequest) async throws(WalletError) -> WalletApiModel {
-        throw WalletError.walletGeneric("not implemented")
+        guard let getWalletResult else {
+            throw WalletError.walletGeneric("not implemented")
+        }
+        return getWalletResult
     }
+
+    // MARK: - Unused stubs
 
     func getBalance(_ params: GetBalanceQueryParams) async throws(WalletError) -> Balances {
         throw WalletError.walletGeneric("not implemented")

--- a/Tests/WalletTests/Mocks/MockSmartWalletService.swift
+++ b/Tests/WalletTests/Mocks/MockSmartWalletService.swift
@@ -145,11 +145,16 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
         throw SignatureError.unknown
     }
 
+    var removeSignerCallCount = 0
+    var lastRemoveSignerLocator: String?
+
     func removeSigner(
         _ signerLocator: String,
         chainType: ChainType,
         chainName: String
     ) async throws(TransactionError) -> any TransactionApiModel {
+        removeSignerCallCount += 1
+        lastRemoveSignerLocator = signerLocator
         throw TransactionError.transactionGeneric("not implemented")
     }
 

--- a/Tests/WalletTests/Mocks/MockSmartWalletService.swift
+++ b/Tests/WalletTests/Mocks/MockSmartWalletService.swift
@@ -104,6 +104,25 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
         return getSignerResult
     }
 
+    // MARK: - removeSigner
+
+    var removeSignerResult: (any TransactionApiModel)?
+    var removeSignerCallCount = 0
+    var removeSignerLastLocator: String?
+
+    func removeSigner(
+        _ signerLocator: String,
+        chainType: ChainType,
+        chainName: String
+    ) async throws(TransactionError) -> any TransactionApiModel {
+        removeSignerCallCount += 1
+        removeSignerLastLocator = signerLocator
+        guard let removeSignerResult else {
+            throw TransactionError.transactionGeneric("not implemented")
+        }
+        return removeSignerResult
+    }
+
     // MARK: - Unused stubs
 
     func getWallet(_ request: GetMeWalletRequest) async throws(WalletError) -> WalletApiModel {
@@ -143,19 +162,6 @@ final class MockSmartWalletService: SmartWalletService, @unchecked Sendable {
         chainType: ChainType
     ) async throws(SignatureError) -> any SignatureApiModel {
         throw SignatureError.unknown
-    }
-
-    var removeSignerCallCount = 0
-    var lastRemoveSignerLocator: String?
-
-    func removeSigner(
-        _ signerLocator: String,
-        chainType: ChainType,
-        chainName: String
-    ) async throws(TransactionError) -> any TransactionApiModel {
-        removeSignerCallCount += 1
-        lastRemoveSignerLocator = signerLocator
-        throw TransactionError.transactionGeneric("not implemented")
     }
 
     func listTransfers(_ params: ListTransfersQueryParams) async throws(WalletError) -> TransferListResult {

--- a/Tests/WalletTests/Model/WalletDeviceSignerRecoveryTests.swift
+++ b/Tests/WalletTests/Model/WalletDeviceSignerRecoveryTests.swift
@@ -40,7 +40,29 @@ struct WalletDeviceSignerRecoveryTests {
     }
 
     @Test
-    func attemptsToRemoveTheStaleDeviceSignerAfterSuccessfulRecovery() async throws {
+    func removesTheStaleDeviceSignerAfterSuccessfulRecovery() async throws {
+        let walletService = MockSmartWalletService()
+        let removedTransaction: SolanaTransactionApiModel = try GetFromFile.getModelFrom(
+            fileName: "RemoveSignerTransactionSuccess",
+            bundle: Bundle.module
+        )
+        walletService.removeSignerResult = removedTransaction
+        let storage = MockDeviceSignerKeyStorage()
+        let wallet = try makeSolanaWallet(
+            walletService: walletService,
+            storage: storage,
+            fileName: "WalletSolanaEmailWithStaleDeviceSigner"
+        )
+
+        try await wallet.recover()
+
+        #expect(await wallet.needsRecovery() == false)
+        #expect(walletService.removeSignerCallCount == 1)
+        #expect(walletService.removeSignerLastLocator == "device:staleKey123")
+    }
+
+    @Test
+    func completesRecoveryWhenStaleSignerRemovalFails() async throws {
         let walletService = MockSmartWalletService()
         let storage = MockDeviceSignerKeyStorage()
         let wallet = try makeSolanaWallet(
@@ -53,11 +75,10 @@ struct WalletDeviceSignerRecoveryTests {
 
         #expect(await wallet.needsRecovery() == false)
         #expect(walletService.removeSignerCallCount == 1)
-        #expect(walletService.lastRemoveSignerLocator == "device:staleKey123")
     }
 
     @Test
-    func doesNotAttemptRemovalWhenNoDeviceSignerWasPreviouslyRegistered() async throws {
+    func skipsRemovalWhenNoDeviceSignerWasPreviouslyRegistered() async throws {
         let walletService = MockSmartWalletService()
         let storage = MockDeviceSignerKeyStorage()
         let wallet = try makeSolanaWallet(walletService: walletService, storage: storage)

--- a/Tests/WalletTests/Model/WalletDeviceSignerRecoveryTests.swift
+++ b/Tests/WalletTests/Model/WalletDeviceSignerRecoveryTests.swift
@@ -7,10 +7,11 @@ import TestsUtils
 
 private func makeSolanaWallet(
     walletService: MockSmartWalletService,
-    storage: MockDeviceSignerKeyStorage
+    storage: MockDeviceSignerKeyStorage,
+    fileName: String = "WalletSolanaEmail"
 ) throws -> SolanaWallet {
     let baseModel: WalletApiModel = try GetFromFile.getModelFrom(
-        fileName: "WalletSolanaEmail",
+        fileName: fileName,
         bundle: Bundle.module
     )
     return try SolanaWallet(
@@ -36,6 +37,34 @@ struct WalletDeviceSignerRecoveryTests {
 
         #expect(await wallet.needsRecovery() == false)
         #expect(await storage.getKey(address: wallet.address) != nil)
+    }
+
+    @Test
+    func attemptsToRemoveTheStaleDeviceSignerAfterSuccessfulRecovery() async throws {
+        let walletService = MockSmartWalletService()
+        let storage = MockDeviceSignerKeyStorage()
+        let wallet = try makeSolanaWallet(
+            walletService: walletService,
+            storage: storage,
+            fileName: "WalletSolanaEmailWithStaleDeviceSigner"
+        )
+
+        try await wallet.recover()
+
+        #expect(await wallet.needsRecovery() == false)
+        #expect(walletService.removeSignerCallCount == 1)
+        #expect(walletService.lastRemoveSignerLocator == "device:staleKey123")
+    }
+
+    @Test
+    func doesNotAttemptRemovalWhenNoDeviceSignerWasPreviouslyRegistered() async throws {
+        let walletService = MockSmartWalletService()
+        let storage = MockDeviceSignerKeyStorage()
+        let wallet = try makeSolanaWallet(walletService: walletService, storage: storage)
+
+        try await wallet.recover()
+
+        #expect(walletService.removeSignerCallCount == 0)
     }
 
     @Test

--- a/Tests/WalletTests/Model/WalletDeviceSignerRecoveryTests.swift
+++ b/Tests/WalletTests/Model/WalletDeviceSignerRecoveryTests.swift
@@ -17,6 +17,7 @@ private func makeSolanaWallet(
         fileName: fileName,
         bundle: Bundle.module
     )
+    walletService.getWalletResult = baseModel
     return try SolanaWallet(
         smartWalletService: walletService,
         signer: MockSigner(),
@@ -67,6 +68,7 @@ struct WalletDeviceSignerRecoveryTests {
     @Test
     func completesRecoveryWhenStaleSignerRemovalFails() async throws {
         let walletService = MockSmartWalletService()
+        walletService.removeSignerError = .transactionGeneric("backend unavailable")
         let storage = MockDeviceSignerKeyStorage()
         let wallet = try makeSolanaWallet(
             walletService: walletService,
@@ -78,6 +80,23 @@ struct WalletDeviceSignerRecoveryTests {
 
         #expect(await wallet.needsRecovery() == false)
         #expect(walletService.removeSignerCallCount == 1)
+    }
+
+    @Test
+    func keepsTheStaleDeviceSignerWhenRegistrationFails() async throws {
+        let walletService = MockSmartWalletService()
+        walletService.addSignerError = .walletGeneric("registration exploded")
+        let storage = MockDeviceSignerKeyStorage()
+        let wallet = try makeSolanaWallet(
+            walletService: walletService,
+            storage: storage,
+            fileName: "WalletSolanaEmailWithStaleDeviceSigner"
+        )
+
+        await #expect(throws: WalletError.self) {
+            try await wallet.recover()
+        }
+        #expect(walletService.removeSignerCallCount == 0)
     }
 
     @Test

--- a/Tests/WalletTests/Model/WalletDeviceSignerRecoveryTests.swift
+++ b/Tests/WalletTests/Model/WalletDeviceSignerRecoveryTests.swift
@@ -5,6 +5,9 @@ import TestsUtils
 
 @testable import Wallet
 
+private let STALE_DEVICE_SIGNER_LOCATOR =
+    "device:BC7k2LhzqCHurW97oXe/9YKI77h80kUwPy8pY2ot+7CWficNoWbwfHddNq4Itg304yMMpDCyHgZPxBJ0KH7Y9qc="
+
 private func makeSolanaWallet(
     walletService: MockSmartWalletService,
     storage: MockDeviceSignerKeyStorage,
@@ -58,7 +61,7 @@ struct WalletDeviceSignerRecoveryTests {
 
         #expect(await wallet.needsRecovery() == false)
         #expect(walletService.removeSignerCallCount == 1)
-        #expect(walletService.removeSignerLastLocator == "device:staleKey123")
+        #expect(walletService.removeSignerLastLocator == STALE_DEVICE_SIGNER_LOCATOR)
     }
 
     @Test

--- a/Tests/WalletTests/Resources/Transaction/RemoveSignerTransactionSuccess.json
+++ b/Tests/WalletTests/Resources/Transaction/RemoveSignerTransactionSuccess.json
@@ -1,0 +1,24 @@
+{
+  "chainType": "solana",
+  "walletType": "smart",
+  "params": {
+    "transaction": "AXGuKpKt4zxavCq2dHNexivchTXKoEQMBmqr6ipcF4QPfTXJRJcBLhsCgcLRjBsfV44G4atgoq9NWffk27AvpPf1",
+    "signer": {
+      "type": "email",
+      "email": "solana.user@example.com",
+      "locator": "email:solana.user@example.com"
+    },
+    "feeConfig": {
+      "feePayer": "crossmint",
+      "amount": "15001"
+    }
+  },
+  "onChain": {
+    "transaction": "ezQaZ2VQ3KixhCSkSoYB6hNNeQtHQe3hKMz7iDPUZjgeYgFug4ZKumULiuH9KSXCyYZH7wjm8v1gjhgoVuG4u2uL",
+    "lastValidBlockHeight": 389278945,
+    "txId": "5EjD1jUfPXWcbmXBoZFqsX6ZmsbEZQ7F9jZK3v4mNAqvJKyfXwvW7cGgUyGvkQZWKRrHtnPBAiTAminx82Xibsov"
+  },
+  "id": "1d9e2f88-4c1b-4b6e-9a3f-6f9d1f2a7c55",
+  "status": "success",
+  "createdAt": "2025-08-21T11:31:00.000Z"
+}

--- a/Tests/WalletTests/Resources/Transaction/RemoveSignerTransactionSuccess.json
+++ b/Tests/WalletTests/Resources/Transaction/RemoveSignerTransactionSuccess.json
@@ -20,5 +20,22 @@
   },
   "id": "1d9e2f88-4c1b-4b6e-9a3f-6f9d1f2a7c55",
   "status": "success",
-  "createdAt": "2025-08-21T11:31:00.000Z"
+  "approvals": {
+    "required": 1,
+    "pending": [],
+    "submitted": [
+      {
+        "signature": "4vC7yGqzXhFxkPjW2mBd8uT5rN3aKse9Jf6QLnUwYpEHRcVSb1oiZgAtD",
+        "submittedAt": "2025-08-21T11:30:58.412Z",
+        "signer": {
+          "type": "email",
+          "email": "solana.user@example.com",
+          "locator": "email:solana.user@example.com"
+        },
+        "message": "3ScRUqvpU4ZEHKD23XBxWargqNCPoxhQagfjCYXefxcTmejFQxhdJYCyns"
+      }
+    ]
+  },
+  "createdAt": "2025-08-21T11:30:55.133Z",
+  "completedAt": "2025-08-21T11:31:00.000Z"
 }

--- a/Tests/WalletTests/Resources/WalletSolanaEmailWithStaleDeviceSigner.json
+++ b/Tests/WalletTests/Resources/WalletSolanaEmailWithStaleDeviceSigner.json
@@ -9,8 +9,13 @@
     },
     "delegatedSigners": [
       {
-        "locator": "device:staleKey123",
-        "signer": "device:staleKey123"
+        "type": "device",
+        "locator": "device:BC7k2LhzqCHurW97oXe/9YKI77h80kUwPy8pY2ot+7CWficNoWbwfHddNq4Itg304yMMpDCyHgZPxBJ0KH7Y9qc=",
+        "publicKey": {
+          "x": "21210727915620898270263577618335726360686289280229254613311030525442693771414",
+          "y": "57060420031112627645685127062353466079773194120131755218185211468686573500071"
+        },
+        "name": "iPhone 17 Pro"
       }
     ]
   },

--- a/Tests/WalletTests/Resources/WalletSolanaEmailWithStaleDeviceSigner.json
+++ b/Tests/WalletTests/Resources/WalletSolanaEmailWithStaleDeviceSigner.json
@@ -1,0 +1,20 @@
+{
+  "type": "smart",
+  "chainType": "solana",
+  "config": {
+    "adminSigner": {
+      "type": "email",
+      "email": "solana.user@example.com",
+      "locator": "email:solana.user@example.com"
+    },
+    "delegatedSigners": [
+      {
+        "locator": "device:staleKey123",
+        "signer": "device:staleKey123"
+      }
+    ]
+  },
+  "address": "7ZN9rAofFVVP1WKqfKozsVWQYcDj2u9juYyRkrKUVR8Y",
+  "linkedUser": "email:solana.user@example.com",
+  "createdAt": "2025-08-21T11:30:00.000Z"
+}


### PR DESCRIPTION
This pull request ports the same stale signer removal mechanism from [crossmint-sdk #2001](https://github.com/Crossmint/crossmint-sdk/pull/2001) to Swift. Recovery registers a replacement device signer but left the old broken one on the wallet indefinitely, so now it gets removed once the replacement is in.

Removal only happens when the wallet has exactly one `device:` signer, so we can be certain which one is stale. It's also best-effort: a failed removal logs a warning and recovery still succeeds.

## Changes

- **`Wallet+SignerManagement`**: `recover()` captures the stale `device:` locator before re-registering and removes it after success, logging a warning instead of throwing when removal fails
- **`LogEvents`**: added `wallet.recover.staleSignerRemoved` and `staleSignerRemovalFailed`, same event names as the TS SDK
- **`MockSmartWalletService`**: `removeSigner` got a configurable result and call tracking
- **`WalletDeviceSignerRecoveryTests`**: covers successful removal, recovery surviving a failed removal, and the no-previous-signer case, with two new fixtures shaped after the wallets API OpenAPI spec